### PR TITLE
cdc-sink: Fix SQL syntax error in composite key deletes

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -135,7 +135,10 @@ func (s *Sink) deleteRows(ctx context.Context, tx pgxtype.Querier, lines []Line)
 				fmt.Fprintf(&statement, ",")
 			}
 			fmt.Fprintf(&statement, "(")
-			for _, key := range line.Key {
+			for i, key := range line.Key {
+				if i > 0 {
+					fmt.Fprintf(&statement, ",")
+				}
 				keys = append(keys, key)
 				fmt.Fprintf(&statement, "$%d", len(keys))
 			}


### PR DESCRIPTION
This change fixes a bug when generating delete statements for tables with
composite key. The generated values did not have a comma separator.

Fixes #36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/42)
<!-- Reviewable:end -->
