### PR TITLE
cdc-sink: Correct regex parsing

### DIFF
--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNdjsonURL(t *testing.T) {
+	a := assert.New(t)
+	const u = "/endpoint/2020-04-02/202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-test_table-1f.ndjson"
+
+	p, err := parseNdjsonURL(u)
+	if a.NoError(err) {
+		a.Equal("endpoint", p.endpoint)
+		a.Equal("test_table", p.topic)
+	}
+}


### PR DESCRIPTION
This change limits the parser to only hexadecimal characters in the uniquer
part, and allows all hex characters in the schema_id part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/49)
<!-- Reviewable:end -->
