### PR TITLE
cdc-sink: Eliminate a sql round-trip by DELETE RETURNING

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -227,7 +227,7 @@ func (s *Sink) upsertRows(ctx context.Context, tx pgxtype.Querier, lines []Line)
 // UpdateRows updates all changed rows.
 func (s *Sink) UpdateRows(ctx context.Context, tx pgxtype.Querier, prev ResolvedLine, next ResolvedLine) error {
 	// First, gather all the rows to update.
-	lines, err := FindAllRowsToUpdate(ctx, tx, s.sinkTableFullName, prev, next)
+	lines, err := DrainAllRowsToUpdate(ctx, tx, s.sinkTableFullName, prev, next)
 	if err != nil {
 		return err
 	}
@@ -293,10 +293,5 @@ func (s *Sink) UpdateRows(ctx context.Context, tx pgxtype.Querier, prev Resolved
 	}
 
 	// Upsert all rows
-	if err := s.upsertRows(ctx, tx, upserts); err != nil {
-		return err
-	}
-
-	// Delete the rows in the sink table.
-	return DeleteSinkTableLines(ctx, tx, s.sinkTableFullName, prev, next)
+	return s.upsertRows(ctx, tx, upserts)
 }

--- a/sink_table_test.go
+++ b/sink_table_test.go
@@ -32,7 +32,12 @@ func findAllRowsToUpdateDB(
 
 	if err := Retry(ctx, func(ctx context.Context) error {
 		var err error
-		lines, err = FindAllRowsToUpdate(ctx, db, sinkTableFullName, prev, next)
+		tx, err := db.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback(ctx)
+		lines, err = DrainAllRowsToUpdate(ctx, tx, sinkTableFullName, prev, next)
 		return err
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
This change uses a DELETE RETURNING in conjunction with the enclosing
transaction to eliminate the need to run the DELETE at the end of the UPSERT
process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/50)
<!-- Reviewable:end -->
