### PR TITLE
cdc-sink: Add test for duplicate message delivery

### DIFF
--- a/sink_table_test.go
+++ b/sink_table_test.go
@@ -205,6 +205,11 @@ func TestWriteToSinkTable(t *testing.T) {
 		return
 	}
 
+	// Re-deliver a message to check at-least-once behavior.
+	if err := WriteToSinkTable(ctx, db, sink.sinkTableFullName, lines[:1]); !a.NoError(err) {
+		return
+	}
+
 	// Check to see if there are indeed 100 rows in the table.
 	if rowCount, err := getRowCount(ctx, db, sink.sinkTableFullName); a.NoError(err) {
 		a.Equal(100, rowCount)


### PR DESCRIPTION
There was not a test for the case in which a CDC update is delivered twice.  As
it turns out, the COPY FROM acts as like INSERT, but with no way to ignore
conflicts. This change reverts the insert-message code to the previous
UPSERT-based approach.

An alternative approach, to use a per-cdc-sink, temporary, intermediate table
was considered, but this was less performant that just upserting into a common
table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/51)
<!-- Reviewable:end -->
