### PR TITLE
cdc-sink: Add --version flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.16 AS builder
 WORKDIR /tmp/compile
 COPY . .
-RUN CGO_ENABLED=0 go build -v -ldflags="-s -w" -o /usr/bin/cdc-sink .
+RUN CGO_ENABLED=0 go build -v -ldflags="-s -w -X main.buildVersion=$(git describe --tags --always --dirty)" -o /usr/bin/cdc-sink .
 
 # Create a single-binary docker image, including a set of core CA
 # certificates so that we can call out to any external APIs.


### PR DESCRIPTION
This change adds a flag to dump the git revision, golang version, and module
sources that were built into the cdc-sink binary.

Sample output:

```
cdc-sink 1bc9305-dirty
go1.16.5 amd64 darwin

github.com/cockroachdb/cdc-sink (devel)
github.com/jackc/chunkreader/v2 v2.0.1
github.com/jackc/pgconn v1.10.0
github.com/jackc/pgio v1.0.0
github.com/jackc/pgpassfile v1.0.0
github.com/jackc/pgproto3/v2 v2.1.1
github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b
github.com/jackc/pgtype v1.8.1
github.com/jackc/pgx/v4 v4.13.0
github.com/jackc/puddle v1.1.3
github.com/pkg/errors v0.9.1
golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
golang.org/x/net v0.0.0-20210716203947-853a461950ff
golang.org/x/text v0.3.6
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/52)
<!-- Reviewable:end -->
