### PR TITLE
cdc-sink: Add workflow to push to DockerHub.

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -1,0 +1,54 @@
+# This workflow is based off of the example at
+# https://github.com/docker/metadata-action
+#
+# Multi-platform configuration from
+# https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md
+#
+# Caching from
+# https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md
+name: Releases
+permissions:
+  contents: read
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*' ]
+  # PR's will trigger an image build, but the push action is disabled.
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: cockroachdb/cdc-sink
+          labels: |
+            org.opencontainers.image.title=CDC Sink
+            org.opencontainers.image.vendor=Cockroach Labs Inc.
+            org.opencontainers.image.descripton=Prototype, not officially supported
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This change adds a new workflow to build and push a Docker image whenever the
master branch or a semver tag is pushed. The image will be built, but not
pushed, for PR's to the master branch.

Closes #72

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/74)
<!-- Reviewable:end -->
