### PR TITLE
workflow: Run tests on all PR base branches

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -15,7 +15,6 @@ on:
     tags: [ 'v*' ]
   # PR's will trigger an image build, but the push action is disabled.
   pull_request:
-    branches: [ master ]
 
 jobs:
   docker:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   GO_VERSION: 1.17


### PR DESCRIPTION
This tweaks the workflow filtering for tests to allow them to run on all PRs,
regardless of the base branch. The rationale for this change is to make it
easier to build up a sequence of "stacked PRs" that depend on one another, but
that only present a single or a limited number of commits to the reviewer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/80)
<!-- Reviewable:end -->
