### PR TITLE
ident: Add json unmarshalling to ident types.

### DIFF
--- a/internal/util/ident/ident.go
+++ b/internal/util/ident/ident.go
@@ -108,6 +108,16 @@ func (n Ident) Raw() string {
 // String returns the ident in a manner suitable for constructing a query.
 func (n Ident) String() string { return n.q }
 
+// UnmarshalJSON converts a raw json string into an Ident.
+func (n *Ident) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*n = New(raw)
+	return nil
+}
+
 // A Schema identifier is a two-part ident, consisting of an SQL
 // database and schema. This type is an immutable value
 // type, suitable for use as a map key.
@@ -148,6 +158,20 @@ func (s Schema) String() string {
 	return fmt.Sprintf("%s.%s", s.Database(), s.Schema())
 }
 
+// UnmarshalJSON parses a two-element array.
+func (s *Schema) UnmarshalJSON(data []byte) error {
+	parts := make([]Ident, 0, 2)
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return err
+	}
+	if len(parts) != 2 {
+		return errors.Errorf("expecting 2 parts, had %d", len(parts))
+	}
+	s.db = parts[0]
+	s.schema = parts[1]
+	return nil
+}
+
 // A Table identifier is a three-part ident, consisting of an SQL
 // database, schema, and table ident. This type is an immutable value
 // type, suitable for use as a map key.
@@ -183,4 +207,19 @@ func (t Table) Raw() string {
 // query.
 func (t Table) String() string {
 	return fmt.Sprintf("%s.%s.%s", t.Database(), t.Schema(), t.Table())
+}
+
+// UnmarshalJSON parses a three-element array.
+func (t *Table) UnmarshalJSON(data []byte) error {
+	parts := make([]Ident, 0, 3)
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return err
+	}
+	if len(parts) != 3 {
+		return errors.Errorf("expecting 3 parts, had %d", len(parts))
+	}
+	t.db = parts[0]
+	t.schema = parts[1]
+	t.table = parts[2]
+	return nil
 }

--- a/internal/util/ident/ident_test.go
+++ b/internal/util/ident/ident_test.go
@@ -11,6 +11,7 @@
 package ident
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,31 @@ func TestIdent(t *testing.T) {
 	a.Equal(id, New("table"))
 
 	a.Equal(`"foo!bar"`, New("foo!bar").String())
+}
+
+func TestIdentJson(t *testing.T) {
+	tcs := []struct {
+		raw string
+	}{
+		{""},
+		{"foo"},
+		{`"foo"`},
+		{"null"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.raw, func(t *testing.T) {
+			a := assert.New(t)
+
+			id := New(tc.raw)
+			data, err := json.Marshal(id)
+			a.NoError(err)
+
+			var id2 Ident
+			a.NoError(json.Unmarshal(data, &id2))
+			a.Equal(id, id2)
+		})
+	}
 }
 
 func TestQualified(t *testing.T) {
@@ -105,4 +131,28 @@ func TestRelative(t *testing.T) {
 			a.Equalf(tc.qual, qual, "%s vs %s", tc.qual, qual)
 		})
 	}
+}
+
+func TestSchemaJson(t *testing.T) {
+	a := assert.New(t)
+
+	id := NewSchema(New("db"), New("schema"))
+	data, err := json.Marshal(id)
+	a.NoError(err)
+
+	var id2 Schema
+	a.NoError(json.Unmarshal(data, &id2))
+	a.Equal(id, id2)
+}
+
+func TestTableJson(t *testing.T) {
+	a := assert.New(t)
+
+	id := NewTable(New("db"), New("schema"), New("table"))
+	data, err := json.Marshal(id)
+	a.NoError(err)
+
+	var id2 Table
+	a.NoError(json.Unmarshal(data, &id2))
+	a.Equal(id, id2)
 }


### PR DESCRIPTION
This change adds an UnmarshalJSON method to all of the ident types, as well as
a test to ensure that they round-trip properly. This will support upcoming work
to support JWT-based auth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/82)
<!-- Reviewable:end -->
