### PR TITLE
apply: Extract query generation to templates

### DIFF
--- a/internal/target/apply/queries/delete.tmpl
+++ b/internal/target/apply/queries/delete.tmpl
@@ -1,0 +1,12 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+DELETE FROM {{ .TableName }} WHERE (
+{{- range $index, $col :=  .PK -}}
+    {{- if $index -}},{{- end -}}
+    {{- $col.Name -}}
+{{- end -}}
+) = (
+{{- range $index, $col := .PK -}}
+    {{- if $index -}},{{- end -}}
+    ${{- oneBased $index -}}
+{{- end -}}
+)

--- a/internal/target/apply/queries/upsert.tmpl
+++ b/internal/target/apply/queries/upsert.tmpl
@@ -1,0 +1,19 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+UPSERT INTO {{ .TableName }} (
+{{- range $index, $col := .Columns -}}
+    {{- if $index -}},{{- end -}}
+    {{- $col.Name -}}
+{{- end -}}
+) VALUES (
+{{- range $index, $col := .Columns -}}
+    {{- if $index -}},{{- end -}}
+
+    {{- if eq $col.Type "GEOGRAPHY" -}}
+        st_geogfromgeojson(${{ oneBased $index }}::JSONB)
+    {{- else if eq $col.Type "GEOMETRY" -}}
+        st_geomfromgeojson(${{ oneBased $index }}::JSONB)
+    {{- else -}}
+        ${{ oneBased $index }}::{{ $col.Type }}
+    {{- end -}}
+{{- end -}}
+)

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package apply
+
+import (
+	"embed"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+var (
+	//go:embed queries/*.tmpl
+	queries embed.FS
+
+	parsed = template.Must(template.New("").Funcs(template.FuncMap{
+		"oneBased": func(idx int) int { return idx + 1 },
+	}).ParseFS(queries, "**/*.tmpl"))
+	deleteTemplate = parsed.Lookup("delete.tmpl")
+	upsertTemplate = parsed.Lookup("upsert.tmpl")
+)
+
+type templates struct {
+	Columns   []types.ColData // All non-ignored columns.
+	PK        []types.ColData // All primary-key columns.
+	TableName ident.Table     // The target table.
+}
+
+func templatesFor(target ident.Table, colData []types.ColData) *templates {
+	ret := &templates{
+		Columns:   colData,
+		TableName: target,
+	}
+
+	// Filter out the ignored columns and build the list of PK columns.
+	// https://github.com/golang/go/wiki/SliceTricks#filter-in-place
+	idx := 0
+	for _, col := range ret.Columns {
+		if col.Ignored {
+			continue
+		}
+		ret.Columns[idx] = col
+		idx++
+		if col.Primary {
+			ret.PK = append(ret.PK, col)
+		}
+	}
+	ret.Columns = ret.Columns[:idx]
+	return ret
+}
+
+func (t *templates) delete() (string, error) {
+	var buf strings.Builder
+	err := deleteTemplate.Execute(&buf, t)
+	return buf.String(), errors.WithStack(err)
+}
+
+func (t *templates) upsert() (string, error) {
+	var buf strings.Builder
+	err := upsertTemplate.Execute(&buf, t)
+	return buf.String(), errors.WithStack(err)
+}

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -1,0 +1,99 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package apply
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryTemplates(t *testing.T) {
+	tmpls := testTemplates()
+	tcs := []struct {
+		name     string
+		fn       func() (string, error)
+		expected string // Will have newlines stripped out, for readability.
+	}{
+		{"delete", tmpls.delete,
+			`DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1") = ($1,$2)`},
+		{"upsert", tmpls.upsert,
+			`UPSERT INTO "database"."schema"."table"
+ ("pk0","pk1","val0","val1","geom","geog")
+ VALUES (
+$1::STRING,$2::INT8,$3::STRING,$4::STRING,
+st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB))`},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			s, err := tc.fn()
+			if a.NoError(err) {
+				a.Equal(strings.ReplaceAll(tc.expected, "\n", ""), s)
+			}
+		})
+
+	}
+}
+
+func testTemplates() *templates {
+	return templatesFor(
+		ident.NewTable(
+			ident.New("database"),
+			ident.New("schema"),
+			ident.New("table")),
+		[]types.ColData{
+			{
+				Name:    ident.New("pk0"),
+				Primary: true,
+				Type:    "STRING",
+			},
+			{
+				Name:    ident.New("pk1"),
+				Primary: true,
+				Type:    "INT8",
+			},
+			{
+				Name: ident.New("val0"),
+				Type: "STRING",
+			},
+			{
+				Name: ident.New("val1"),
+				Type: "STRING",
+			},
+			{
+				Ignored: true,
+				Name:    ident.New("ignored_pk"),
+				Primary: true,
+				Type:    "STRING",
+			},
+			{
+				Ignored: true,
+				Name:    ident.New("ignored_val"),
+				Primary: false,
+				Type:    "STRING",
+			},
+			// Field types with special handling
+			{
+				Name: ident.New("geom"),
+				Type: "GEOMETRY",
+			},
+			{
+				Name: ident.New("geog"),
+				Type: "GEOGRAPHY",
+			},
+		},
+	)
+}


### PR DESCRIPTION
This change moves the schema-driven query generation into Golang templates. The
templates are packaged into the binary via use of go:embed.  Golden-output
tests are added to ensure that all conditional logic in the templates is
exercised.