### PR TITLE
apply: Implement compare-and-set, deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,77 @@ scrape_configs:
       - targets: [ '127.0.0.1:30004' ]
 ```
 
+## Modes
+
+`cdc-sink` supports a number of optional modes for each changefeed. All of these modes can be
+combined in a single changefeed.
+
+### Immediate
+
+Immediate mode writes incoming mutations to the target schema as soon as they are received, instead
+of waiting for a resolved timestamp. Transaction boundaries from the source database will not be
+preserved, but overall load on the destination database will be reduced.
+
+Immediate mode is enabled by adding the `?immediate=true` query parameter to the changefeed URL.
+
+### Compare-and-set
+
+A compare-and-set (CAS) mode allows `cdc-sink` to discard some updates, based on version- or
+time-like fields.
+
+**The use of CAS mode intentionally discards mutations and may cause data inconsistencies.**
+
+To opt into CAS mode for a feed, add a `?cas=<column_name>` query parameter to the changefeed. The
+named field should be of a type for which SQL defines a comparison operation. Common uses would be a
+`version INT` or an `updated_at TIMESTAMP` column. A mutation from the source database will be
+applied only if the CAS column is strictly greater than the value in the destination database.
+
+Consider a table with a `version INT` column that is used by adding a
+`?cas=version` query parameter to the changefeed URL. If `cdc-sink` receives a message to update
+some row in this table, the update will only be applied if there is no pre-existing row in the
+destination table, or if the update's `version` value is strictly greater than the existing row in
+the destination table. That is, updates are applied only if they would increase the `version` column
+or if they would insert a new row.
+
+Multiple CAS columns can be specified by repeating the query
+parameter: `?cas=version_major&cas=version_minor&cas=version_patch`. When multiple CAS columns are
+present, they are compared as a tuple. That is, the second column is only compared if the first
+column value is equal between the source and destination clusters. In this multi-column case, the
+following psuedo-sql clause is applied to each incoming update:
+
+```sql
+WHERE existing IS NULL OR (
+  (incoming.version_major, incoming.version_minor, incoming.version_patch) >
+  (existing.version_major, existing.version_minor, existing.version_patch)
+)
+```
+
+All tables in the feed must have all named `cas` columns or the changefeed will fail.
+
+Deletes from the source cluster are always applied.
+
+### Deadlines
+
+A deadline mode allows `cdc-sink` to discard some updates, by comparing a time-like field to the
+destination cluster's time. This is useful when a feed's data is advisory only or changefeed
+downtime is expected.
+
+**The use of deadlines intentionally discards mutations and may cause data inconsistencies.**
+
+To opt into deadline mode for a feed, two query parameters must be
+specified: `?dln=<column_name>&dli=<interval>`. The `dln` parameter names a column whose values can
+be coerced to a `TIMESTAMP`. The `dli` parameter specifies some number of seconds, or an interval
+value, such as `1m`.
+
+Given the configuration `?dln=updated_at&dli=1m`, each incoming update would behave as though it
+were filtered with a clause such as `WHERE incoming.updated_at > now() - '1m'::INTERVAL`.
+
+Multiple deadline columns may be specified by repeating pairs of `dln` and `dli` parameters.
+
+All tables in the feed must have all named `dln` columns.
+
+Deletes from the source cluster are always applied.
+
 ## Security Considerations
 
 At a high level, `cdc-sink` accepts network connections to apply arbitrary mutations to the target

--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
@@ -29,10 +30,27 @@ import (
 
 // This file contains code repackaged from main.go
 
-// ImmediateParam is the name of a query parameter that will place a request
-// into "immediate" mode.  In this mode, mutations are written directly
-// to the target table and resolved timestamps are ignored.
-const ImmediateParam = "immediate"
+const (
+	// CASParam is the name of a query parameter that will apply a
+	// compare-and-set behavior to processed records. The value of the
+	// parameter should be a comma-separated list of column names.
+	CASParam = "cas"
+
+	// DeadlineColumnParam is the name of a query parameter that names
+	// a column in the incoming data to use in a deadline calculation.
+	DeadlineColumnParam = "dln"
+
+	// DeadlineIntervalParam is the name of a query parameter that
+	// specifies the deadline time, relative to now() on the target
+	// cluster.
+	DeadlineIntervalParam = "dli"
+
+	// ImmediateParam is the name of a query parameter that will place a
+	// request into "immediate" mode.  In this mode, mutations are
+	// written directly to the target table and resolved timestamps are
+	// ignored.
+	ImmediateParam = "immediate"
+)
 
 // Handler is an http.Handler for processing webhook requests
 // from a CockroachDB changefeed.
@@ -47,11 +65,13 @@ type Handler struct {
 
 // A request is configured by the various parseURL methods in Handler.
 type request struct {
-	body      io.Reader
-	immediate bool
-	leaf      func(ctx context.Context, req *request) error
-	target    ident.Schematic
-	timestamp hlc.Time
+	body       io.Reader
+	casColumns []ident.Ident
+	deadlines  types.Deadlines // Nil if no deadlines set.
+	immediate  bool
+	leaf       func(ctx context.Context, req *request) error
+	target     ident.Schematic
+	timestamp  hlc.Time
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +142,31 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.body = r.Body
-	if found := r.URL.Query().Get(ImmediateParam); found != "" {
+
+	query := r.URL.Query()
+	if query.Has(CASParam) {
+		for _, raw := range query[CASParam] {
+			req.casColumns = append(req.casColumns, ident.New(raw))
+		}
+	}
+	// Pair-wise parsing of dln and dli query params.
+	if cols, ints := query[DeadlineColumnParam], query[DeadlineIntervalParam]; len(cols)+len(ints) > 0 {
+		if len(cols) != len(ints) {
+			sendErr(errors.Errorf("mismatch in %s and %s counts",
+				DeadlineColumnParam, DeadlineIntervalParam))
+			return
+		}
+		req.deadlines = make(types.Deadlines, len(cols))
+		for i, col := range cols {
+			d, err := time.ParseDuration(ints[i])
+			if err != nil {
+				sendErr(err)
+				return
+			}
+			req.deadlines[ident.New(col)] = d
+		}
+	}
+	if found := query.Get(ImmediateParam); found != "" {
 		var err error
 		req.immediate, err = strconv.ParseBool(found)
 		if err != nil {

--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -103,7 +103,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request) error {
 	// The CDC feed guarantees in-order delivery for individual rows.
 	var flush func() error
 	if req.immediate {
-		applier, err := h.Appliers.Get(ctx, target)
+		applier, err := h.Appliers.Get(ctx, target, req.casColumns, req.deadlines)
 		if err != nil {
 			return err
 		}

--- a/internal/source/cdc/resolved.go
+++ b/internal/source/cdc/resolved.go
@@ -129,7 +129,7 @@ func (h *Handler) resolved(ctx context.Context, req *request) error {
 			}
 			stores = append(stores, store)
 
-			applier, err := h.Appliers.Get(ctx, table)
+			applier, err := h.Appliers.Get(ctx, table, req.casColumns, req.deadlines)
 			if err != nil {
 				return err
 			}

--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -115,7 +115,7 @@ func (h *Handler) webhook(ctx context.Context, req *request) error {
 		// Stage or apply the per-target mutations.
 		for target, muts := range toProcess {
 			if req.immediate {
-				applier, err := h.Appliers.Get(ctx, target)
+				applier, err := h.Appliers.Get(ctx, target, req.casColumns, req.deadlines)
 				if err != nil {
 					return err
 				}

--- a/internal/target/apply/factory.go
+++ b/internal/target/apply/factory.go
@@ -12,11 +12,16 @@ package apply
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 )
+
+// cacheKey is used to memoize requests to factory.Get.
+type cacheKey string
 
 // factory vends singleton instance of apply.
 type factory struct {
@@ -24,7 +29,7 @@ type factory struct {
 	mu       struct {
 		sync.RWMutex
 		cleanup   []func()
-		instances map[ident.Table]*apply
+		instances map[cacheKey]*apply
 	}
 }
 
@@ -33,7 +38,7 @@ var _ types.Appliers = (*factory)(nil)
 // NewAppliers returns an instance of types.Appliers.
 func NewAppliers(watchers types.Watchers) (_ types.Appliers, cancel func()) {
 	f := &factory{watchers: watchers}
-	f.mu.instances = make(map[ident.Table]*apply)
+	f.mu.instances = make(map[cacheKey]*apply)
 	return f, func() {
 		f.mu.Lock()
 		defer f.mu.Unlock()
@@ -46,38 +51,58 @@ func NewAppliers(watchers types.Watchers) (_ types.Appliers, cancel func()) {
 }
 
 // Get creates or returns a memoized instance of the table's Applier.
-func (f *factory) Get(ctx context.Context, table ident.Table) (types.Applier, error) {
+func (f *factory) Get(
+	ctx context.Context, table ident.Table, casColumns []ident.Ident, deadlines types.Deadlines,
+) (types.Applier, error) {
+	// All values below are written as quoted strings, so they are
+	// self-delimiting.
+	var sb strings.Builder
+	_, _ = fmt.Fprintf(&sb, "%s", table)
+	for i := range casColumns {
+		_, _ = fmt.Fprintf(&sb, "%s", casColumns[i])
+	}
+	for k, v := range deadlines {
+		_, _ = fmt.Fprintf(&sb, "%s%d", k, v)
+	}
+	key := cacheKey(sb.String())
+
 	// Try read-locked get.
-	if ret := f.getUnlocked(table); ret != nil {
+	if ret := f.getUnlocked(key); ret != nil {
 		return ret, nil
 	}
 	// Fall back to write-locked get-or-create.
-	return f.getOrCreateUnlocked(ctx, table)
+	return f.getOrCreateUnlocked(ctx, key, table, casColumns, deadlines)
 }
 
 // getOrCreateUnlocked takes a write-lock.
-func (f *factory) getOrCreateUnlocked(ctx context.Context, table ident.Table) (*apply, error) {
+func (f *factory) getOrCreateUnlocked(
+	ctx context.Context,
+	key cacheKey,
+	table ident.Table,
+	casColumns []ident.Ident,
+	deadlines types.Deadlines,
+) (*apply, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if ret := f.mu.instances[table]; ret != nil {
+	if ret := f.mu.instances[key]; ret != nil {
 		return ret, nil
 	}
 	watcher, err := f.watchers.Get(ctx, table.Database())
 	if err != nil {
 		return nil, err
 	}
-	ret, cancel, err := newApply(watcher, table)
+	ret, cancel, err := newApply(watcher, table, casColumns, deadlines)
 	if err == nil {
 		f.mu.cleanup = append(f.mu.cleanup, cancel)
-		f.mu.instances[table] = ret
+		f.mu.instances[key] = ret
 	}
 	return ret, err
 }
 
 // getUnlocked takes a read-lock.
-func (f *factory) getUnlocked(table ident.Table) *apply {
+func (f *factory) getUnlocked(key cacheKey) *apply {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
-	return f.mu.instances[table]
+	return f.mu.instances[key]
 }

--- a/internal/target/apply/queries/common.tmpl
+++ b/internal/target/apply/queries/common.tmpl
@@ -1,0 +1,39 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+
+{{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
+{{- define "names" -}}
+    {{- range $idx, $col := . }}
+        {{- if $idx -}},{{- end -}}
+        {{$col.Name}}
+    {{- end -}}
+{{- end -}}
+
+{{- /* params produces a comma-separated list of substitution params: $1, $2, $3, ... */ -}}
+{{- define "params" -}}
+    {{- range $idx, $col := . }}
+        {{- if $idx -}},{{- end -}}
+        ${{- oneBased $idx -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /* exprs produces a comma-separated list of typed substitution params: $1::STRING, $2::INT */ -}}
+{{- define "exprs" -}}
+    {{- range $idx, $col := . -}}
+        {{- if $idx -}},{{- end -}}
+        {{- if eq $col.Type "GEOGRAPHY" -}}
+            st_geogfromgeojson(${{ oneBased $idx }}::JSONB)
+        {{- else if eq $col.Type "GEOMETRY" -}}
+            st_geomfromgeojson(${{ oneBased $idx }}::JSONB)
+        {{- else -}}
+            ${{ oneBased $idx }}::{{ $col.Type }}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /* join creates a comma-separated list of its input: a, b, c, ... */ -}}
+{{- define "join" -}}
+    {{- range $idx, $val := . }}
+        {{- if $idx -}},{{- end -}}
+        {{- $val -}}
+    {{- end -}}
+{{- end -}}

--- a/internal/target/apply/queries/conditional.tmpl
+++ b/internal/target/apply/queries/conditional.tmpl
@@ -1,0 +1,86 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*
+This template implements the conditional update flow (compare-and-set,
+deadlines). For an expanded example, see the templates_test.go file.
+
+The query is structured as a CTE, so we'll update this $dataSource
+variable as different clauses are conditionally introduced.
+*/ -}}
+{{- $dataSource := "data" -}}
+
+{{- /*
+data: the proposed values to insert. We explicitly name the columns to
+aid in joins below.
+
+WITH data( pk0, pk1, val0, val1, ...) AS (VALUES ($1, $2, $3, ...))
+*/ -}}
+WITH data( {{- template "names" .Columns -}} ) AS (
+VALUES ( {{- template "exprs" .Columns -}} ))
+
+
+{{- /*
+deadlined: filters the incoming data by the deadline columns
+
+deadlined AS (SELECT * from data WHERE ts > now() - '1m'::INTERVAL)
+*/ -}}
+{{- if .Deadlines -}}
+, {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
+deadlined AS (SELECT * FROM {{ $dataSource }} WHERE
+{{- $andNeeded := false -}} {{- range $dlc, $dli := .Deadlines -}}
+    {{- if $andNeeded -}} AND {{- end -}}
+    ( {{- $dlc -}} >now()-'{{- $dli -}}'::INTERVAL)
+    {{- $andNeeded = true -}}
+{{- end -}})
+{{- $dataSource = "deadlined" -}}
+{{- end -}}
+
+
+{{- /*
+current: selects the current values of the PK and CAS columns by
+joining the target table to the proposed data by PK
+
+current AS (SELECT pk0, pk1, cas0, cas1 FROM target JOIN data USING (pk0, pk1))
+*/ -}}
+{{- if .Conditions -}}
+, {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
+current AS (
+SELECT {{ template "names" .PK }}, {{ template "join" (qualify .TableName .Conditions) }}
+FROM {{ .TableName }}
+JOIN {{ $dataSource }}
+USING ({{ template "names" .PK }})),
+{{- nl -}}
+
+
+{{- /*
+action: left-joins data to current, by PK, where no current value
+exists or the proposed data has a CAS tuple strictly greater than the
+current data.
+
+action AS (
+  SELECT data.* FROM data
+  LEFT JOIN current
+  USING (pk0, pk1)
+  WHERE current.pk0 IS NULL OR
+  ( data.cas0, data.cas1) > ( current.cas0, current.cas1 )
+*/ -}}
+action AS (
+SELECT {{ $dataSource }}.* FROM {{ $dataSource }}
+LEFT JOIN current
+USING ({{ template "names" .PK }})
+WHERE current.{{ (index .PK 0).Name }}{{/* >= v21.2 lets us say "current IS NULL" */}} IS NULL OR
+( {{- template "join" (qualify $dataSource .Conditions) -}} ) > ( {{- template "join" (qualify "current" .Conditions) -}} ))
+{{- $dataSource = "action" -}}
+{{- end -}}{{- /* .Conditions */ -}}
+
+{{- /*
+The main clause is to then upsert the actionable rows into the
+target table.
+
+UPSERT INTO table (pk0, pk1, ....)
+  SELECT * FROM dataSource
+*/ -}}
+{{- nl -}}
+UPSERT INTO {{ .TableName }} ({{ template "names" .Columns }})
+SELECT * FROM {{ $dataSource }}
+
+{{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/delete.tmpl
+++ b/internal/target/apply/queries/delete.tmpl
@@ -1,14 +1,8 @@
 {{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
 {{- /* DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1") = ($1,$2) */ -}}
 DELETE FROM {{ .TableName }} WHERE (
-{{- range $index, $col :=  .PK -}}
-    {{- if $index -}},{{- end -}}
-    {{- $col.Name -}}
-{{- end -}}
-) = (
-{{- range $index, $col := .PK -}}
-    {{- if $index -}},{{- end -}}
-    ${{- oneBased $index -}}
-{{- end -}}
+    {{- template "names" .PK -}}
+)=(
+    {{- template "params" .PK -}}
 )
 {{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/upsert.tmpl
+++ b/internal/target/apply/queries/upsert.tmpl
@@ -8,21 +8,8 @@ st_geomfromgeojson($2::JSONB),
 st_geogfromgeojson($3::JSONB))
 */ -}}
 UPSERT INTO {{ .TableName }} (
-{{- range $index, $col := .Columns -}}
-    {{- if $index -}},{{- end -}}
-    {{- $col.Name -}}
-{{- end -}}
+{{ template "names" .Columns }}
 ) VALUES (
-{{- range $index, $col := .Columns -}}
-    {{- if $index -}},{{- end -}}
-
-    {{- if eq $col.Type "GEOGRAPHY" -}}
-        st_geogfromgeojson(${{ oneBased $index }}::JSONB)
-    {{- else if eq $col.Type "GEOMETRY" -}}
-        st_geomfromgeojson(${{ oneBased $index }}::JSONB)
-    {{- else -}}
-        ${{ oneBased $index }}::{{ $col.Type }}
-    {{- end -}}
-{{- end -}}
+{{ template "exprs" .Columns }}
 )
 {{- /* Trim whitespace */ -}}

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -12,6 +12,7 @@ package apply
 
 import (
 	"embed"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -25,25 +26,68 @@ var (
 	queries embed.FS
 
 	parsed = template.Must(template.New("").Funcs(template.FuncMap{
+		// nl is a hack to force the inclusion of newlines in the output
+		// since we generally use the whitespace-consuming template
+		// syntax.
+		"nl": func() string { return "\n" },
+
 		"oneBased": func(idx int) int { return idx + 1 },
+
+		// qualify is used with the "join" template to emit a list of
+		// qualified database identifiers. The prefix is prepended to
+		// each column's name using a dot separator.
+		//   {{ range $name := qualify "foo" $.Columns }}
+		// would return values such as
+		//     foo.PK, foo.Val0, foo.Val1, ....
+		"qualify": func(prefix interface{}, cols []types.ColData) ([]string, error) {
+			var id ident.Ident
+			switch t := prefix.(type) {
+			case string:
+				id = ident.New(t)
+			case ident.Ident:
+				id = t
+			case ident.Table:
+				id = t.Table()
+			default:
+				return nil, errors.Errorf("unsupported conversion %T", t)
+			}
+			ret := make([]string, len(cols))
+			for i := range ret {
+				ret[i] = fmt.Sprintf("%s.%s", id, cols[i].Name)
+			}
+			return ret, nil
+		},
 	}).ParseFS(queries, "**/*.tmpl"))
-	deleteTemplate = parsed.Lookup("delete.tmpl")
-	upsertTemplate = parsed.Lookup("upsert.tmpl")
+	conditionalTemplate = parsed.Lookup("conditional.tmpl")
+	deleteTemplate      = parsed.Lookup("delete.tmpl")
+	upsertTemplate      = parsed.Lookup("upsert.tmpl")
 )
 
 type templates struct {
-	Columns   []types.ColData // All non-ignored columns.
-	PK        []types.ColData // All primary-key columns.
-	TableName ident.Table     // The target table.
+	Columns    []types.ColData // All non-ignored columns.
+	Conditions []types.ColData // The version-like fields for CAS ops.
+	Deadlines  types.Deadlines // Allow too-old data to just be dropped.
+	PK         []types.ColData // All primary-key columns.
+	TableName  ident.Table     // The target table.
 }
 
 // newTemplates constructs a new templates instance, performing some
 // pre-computations to identify primary keys and to filter out ignored
 // columns.
-func newTemplates(target ident.Table, colData []types.ColData) *templates {
+func newTemplates(
+	target ident.Table, casNames []ident.Ident, deadlines types.Deadlines, colData []types.ColData,
+) *templates {
+	// Map cas column names to their order in the comparison tuple.
+	casMap := make(map[ident.Ident]int, len(casNames))
+	for idx, name := range casNames {
+		casMap[name] = idx
+	}
+
 	ret := &templates{
-		Columns:   colData,
-		TableName: target,
+		Conditions: make([]types.ColData, len(casNames)),
+		Columns:    append([]types.ColData(nil), colData...),
+		Deadlines:  deadlines,
+		TableName:  target,
 	}
 
 	// Filter out the ignored columns and build the list of PK columns.
@@ -58,6 +102,9 @@ func newTemplates(target ident.Table, colData []types.ColData) *templates {
 		if col.Primary {
 			ret.PK = append(ret.PK, col)
 		}
+		if idx, isCas := casMap[col.Name]; isCas {
+			ret.Conditions[idx] = col
+		}
 	}
 	ret.Columns = ret.Columns[:idx]
 	return ret
@@ -71,6 +118,11 @@ func (t *templates) delete() (string, error) {
 
 func (t *templates) upsert() (string, error) {
 	var buf strings.Builder
-	err := upsertTemplate.Execute(&buf, t)
+	var err error
+	if len(t.Conditions) == 0 && len(t.Deadlines) == 0 {
+		err = upsertTemplate.Execute(&buf, t)
+	} else {
+		err = conditionalTemplate.Execute(&buf, t)
+	}
 	return buf.String(), errors.WithStack(err)
 }

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -11,8 +11,8 @@
 package apply
 
 import (
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -20,75 +20,140 @@ import (
 )
 
 func TestQueryTemplates(t *testing.T) {
-	tmpls := newTemplates(
-		ident.NewTable(
-			ident.New("database"),
-			ident.New("schema"),
-			ident.New("table")),
-		[]types.ColData{
-			{
-				Name:    ident.New("pk0"),
-				Primary: true,
-				Type:    "STRING",
-			},
-			{
-				Name:    ident.New("pk1"),
-				Primary: true,
-				Type:    "INT8",
-			},
-			{
-				Name: ident.New("val0"),
-				Type: "STRING",
-			},
-			{
-				Name: ident.New("val1"),
-				Type: "STRING",
-			},
-			{
-				Ignored: true,
-				Name:    ident.New("ignored_pk"),
-				Primary: true,
-				Type:    "STRING",
-			},
-			{
-				Ignored: true,
-				Name:    ident.New("ignored_val"),
-				Primary: false,
-				Type:    "STRING",
-			},
-			// Field types with special handling
-			{
-				Name: ident.New("geom"),
-				Type: "GEOMETRY",
-			},
-			{
-				Name: ident.New("geog"),
-				Type: "GEOGRAPHY",
-			},
+	cols := []types.ColData{
+		{
+			Name:    ident.New("pk0"),
+			Primary: true,
+			Type:    "STRING",
 		},
-	)
+		{
+			Name:    ident.New("pk1"),
+			Primary: true,
+			Type:    "INT8",
+		},
+		{
+			Name: ident.New("val0"),
+			Type: "STRING",
+		},
+		{
+			Name: ident.New("val1"),
+			Type: "STRING",
+		},
+		{
+			Ignored: true,
+			Name:    ident.New("ignored_pk"),
+			Primary: true,
+			Type:    "STRING",
+		},
+		{
+			Ignored: true,
+			Name:    ident.New("ignored_val"),
+			Primary: false,
+			Type:    "STRING",
+		},
+		// Field types with special handling
+		{
+			Name: ident.New("geom"),
+			Type: "GEOMETRY",
+		},
+		{
+			Name: ident.New("geog"),
+			Type: "GEOGRAPHY",
+		},
+	}
+
+	tableID := ident.NewTable(
+		ident.New("database"),
+		ident.New("schema"),
+		ident.New("table"))
+
 	tcs := []struct {
 		name     string
-		fn       func() (string, error)
-		expected string // Will have newlines stripped out, for readability.
+		cas      []ident.Ident
+		deadline types.Deadlines
+		upsert   string
 	}{
-		{"delete", tmpls.delete,
-			`DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1") = ($1,$2)`},
-		{"upsert", tmpls.upsert,
-			`UPSERT INTO "database"."schema"."table"
- ("pk0","pk1","val0","val1","geom","geog")
- VALUES (
-$1::STRING,$2::INT8,$3::STRING,$4::STRING,
-st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB))`},
+		{
+			name: "base",
+			upsert: `UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog"
+) VALUES (
+$1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB)
+)`,
+		},
+		{
+			name: "cas",
+			cas:  []ident.Ident{ident.New("val1"), ident.New("val0")},
+			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog") AS (
+VALUES ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB))),
+current AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "database"."schema"."table"
+JOIN data
+USING ("pk0","pk1")),
+action AS (
+SELECT data.* FROM data
+LEFT JOIN current
+USING ("pk0","pk1")
+WHERE current."pk0" IS NULL OR
+("data"."val1","data"."val0") > ("current"."val1","current"."val0"))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog")
+SELECT * FROM action`,
+		},
+		{
+			name: "deadline",
+			deadline: types.Deadlines{
+				ident.New("val1"): time.Second,
+				ident.New("val0"): time.Hour,
+			},
+			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog") AS (
+VALUES ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB))),
+deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog")
+SELECT * FROM deadlined`,
+		},
+		{
+			name: "casDeadline",
+			cas:  []ident.Ident{ident.New("val1"), ident.New("val0")},
+			deadline: types.Deadlines{
+				ident.New("val0"): time.Hour,
+				ident.New("val1"): time.Second,
+			},
+			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog") AS (
+VALUES ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB))),
+deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL)),
+current AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "database"."schema"."table"
+JOIN deadlined
+USING ("pk0","pk1")),
+action AS (
+SELECT deadlined.* FROM deadlined
+LEFT JOIN current
+USING ("pk0","pk1")
+WHERE current."pk0" IS NULL OR
+("deadlined"."val1","deadlined"."val0") > ("current"."val1","current"."val0"))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog")
+SELECT * FROM action`,
+		},
 	}
+
+	// The deletion query should never change based on configuration.
+	const expectedDelete = `DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1")=($1,$2)`
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
-			s, err := tc.fn()
-			if a.NoError(err) {
-				a.Equal(strings.ReplaceAll(tc.expected, "\n", ""), s)
-			}
+			tmpls := newTemplates(tableID, tc.cas, tc.deadline, cols)
+
+			s, err := tmpls.delete()
+			a.NoError(err)
+			a.Equal(expectedDelete, s)
+
+			s, err = tmpls.upsert()
+			a.NoError(err)
+			a.Equal(tc.upsert, s)
+
 		})
 
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -33,7 +34,7 @@ type Applier interface {
 
 // Appliers is a factory for Applier instances.
 type Appliers interface {
-	Get(ctx context.Context, target ident.Table) (Applier, error)
+	Get(ctx context.Context, target ident.Table, casColumns []ident.Ident, deadlines Deadlines) (Applier, error)
 }
 
 // An Authenticator determines if an operation on some schema should be
@@ -51,6 +52,9 @@ type Batcher interface {
 	pgxtype.Querier
 	SendBatch(ctx context.Context, batch *pgx.Batch) pgx.BatchResults
 }
+
+// Deadlines associate a column identifier with a duration.
+type Deadlines map[ident.Ident]time.Duration
 
 // A Mutation describes a row to upsert into the target database.  That
 // is, it is a collection of column values to apply to a row in some


### PR DESCRIPTION
Note to reviewers: this PR is based on PR #85 (adding the request type).

This change adds the ability to use certain columns in the target table for
compare-and-set operations. That is, staged mutations will only be applied if
the proposed data has a CAS tuple that is strictly greater than the CAS tuple
of the data currently in the target table.

Additionally, certain columns can be used to impose deadlines on the
application of certain mutations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/86)
<!-- Reviewable:end -->
