### PR TITLE
apply: Add multi-value SQL, benchmark

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,8 +2,13 @@ name: Tests
 permissions: read-all
 on:
   push:
-    branches: [ master ]
   pull_request:
+  workflow_dispatch: # Allow manual runs to kick off benchmarks
+    inputs:
+      run_bench:
+        description: Run benchmarks
+        required: false
+        type: boolean
 
 env:
   GO_VERSION: 1.17
@@ -60,6 +65,12 @@ jobs:
         env:
           COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
         run: go test -v -race -coverpkg=./internal/... -covermode=atomic -coverprofile=${{ env.COVER_OUT }} ./...
+
+      - name: Manual Benchmarks
+        if: ${{ github.event.inputs.run_bench }}
+        env:
+          COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
+        run: go test -v -benchtime 10s -bench . ./...
 
       - name: Stop CockroachDB
         if: ${{ always() }}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.2.0
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgtype v1.9.1
 	github.com/jackc/pgx/v4 v4.14.1

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/metrics"
-	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgtype/pgxtype"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -45,15 +45,9 @@ type apply struct {
 
 	mu struct {
 		sync.RWMutex
-		columns []types.ColData
-		pks     []types.ColData
-
-		sql struct {
-			// DELETE FROM t WHERE ("pk0", "pk1") = ($1::INT8, $2::STRING)
-			delete string
-			// UPSERT INTO t ("pk0", "pk1") VALUES ($1::INT8, $2::STRING)
-			upsert string
-		}
+		columns   []types.ColData
+		pks       []types.ColData
+		templates *templates
 	}
 }
 
@@ -107,7 +101,7 @@ func newApply(
 }
 
 // Apply applies the mutations to the target table.
-func (a *apply) Apply(ctx context.Context, tx types.Batcher, muts []types.Mutation) error {
+func (a *apply) Apply(ctx context.Context, tx pgxtype.Querier, muts []types.Mutation) error {
 	start := time.Now()
 	deletes, r := batches.Mutation()
 	defer r()
@@ -158,12 +152,16 @@ func (a *apply) Apply(ctx context.Context, tx types.Batcher, muts []types.Mutati
 	return nil
 }
 
-func (a *apply) deleteLocked(ctx context.Context, db types.Batcher, muts []types.Mutation) error {
+func (a *apply) deleteLocked(ctx context.Context, db pgxtype.Querier, muts []types.Mutation) error {
 	if len(muts) == 0 {
 		return nil
 	}
+	sql, err := a.mu.templates.delete(len(muts))
+	if err != nil {
+		return err
+	}
 
-	batch := &pgx.Batch{}
+	allArgs := make([]interface{}, 0, len(a.mu.pks)*len(muts))
 
 	for i := range muts {
 		dec := json.NewDecoder(bytes.NewReader(muts[i].Key))
@@ -182,34 +180,33 @@ func (a *apply) deleteLocked(ctx context.Context, db types.Batcher, muts []types
 					"key %s@%s",
 				len(args), len(a.mu.pks), string(muts[i].Key), muts[i].Time)
 		}
-
-		batch.Queue(a.mu.sql.delete, args...)
+		allArgs = append(allArgs, args...)
 	}
 
-	res := db.SendBatch(ctx, batch)
-	defer res.Close()
-
-	// Drain the results from each batched execution to check for errors.
-	for i := batch.Len(); i > 0; i-- {
-		_, err := res.Exec()
-		if err != nil {
-			return errors.Wrap(err, a.mu.sql.delete)
-		}
+	tag, err := db.Exec(ctx, sql, allArgs...)
+	if err != nil {
+		return errors.Wrap(err, sql)
 	}
-	a.deletes.Add(float64(len(muts)))
+
+	a.deletes.Add(float64(tag.RowsAffected()))
 	log.WithFields(log.Fields{
-		"count":  len(muts),
-		"target": a.target,
+		"applied":  tag.RowsAffected(),
+		"proposed": len(muts),
+		"target":   a.target,
 	}).Debug("deleted rows")
 	return nil
 }
 
-func (a *apply) upsertLocked(ctx context.Context, db types.Batcher, muts []types.Mutation) error {
+func (a *apply) upsertLocked(ctx context.Context, db pgxtype.Querier, muts []types.Mutation) error {
 	if len(muts) == 0 {
 		return nil
 	}
+	sql, err := a.mu.templates.upsert(len(muts))
+	if err != nil {
+		return err
+	}
 
-	batch := &pgx.Batch{}
+	allArgs := make([]interface{}, 0, len(a.mu.columns)*len(muts))
 
 	for i := range muts {
 		dec := json.NewDecoder(bytes.NewReader(muts[i].Data))
@@ -257,7 +254,7 @@ func (a *apply) upsertLocked(ctx context.Context, db types.Batcher, muts []types
 			}
 			args = append(args, decoded)
 		}
-		batch.Queue(a.mu.sql.upsert, args...)
+		allArgs = append(allArgs, args...)
 
 		// If new columns have been added in the source table, but not
 		// in the destination, we want to error out.
@@ -277,24 +274,16 @@ func (a *apply) upsertLocked(ctx context.Context, db types.Batcher, muts []types
 		}
 	}
 
-	res := db.SendBatch(ctx, batch)
-	defer res.Close()
-
-	rowsUpserted := int64(0)
-	for i, j := 0, batch.Len(); i < j; i++ {
-		tag, err := res.Exec()
-		if err != nil {
-			return errors.Wrap(err, a.mu.sql.upsert)
-		}
-		rowsUpserted += tag.RowsAffected()
+	tag, err := db.Exec(ctx, sql, allArgs...)
+	if err != nil {
+		return errors.Wrap(err, sql)
 	}
 
-	// Defer metrics update until we're confident that the transaction
-	// will commit.
-	a.upserts.Add(float64(rowsUpserted))
+	a.upserts.Add(float64(tag.RowsAffected()))
 	log.WithFields(log.Fields{
-		"count":  len(muts),
-		"target": a.target,
+		"applied":  tag.RowsAffected(),
+		"proposed": len(muts),
+		"target":   a.target,
 	}).Debug("upserted rows")
 	return nil
 }
@@ -319,19 +308,11 @@ func (a *apply) refreshUnlocked(colData []types.ColData) error {
 	}
 
 	tmpls := newTemplates(a.target, a.casColumns, a.deadlines, colData)
-	del, err := tmpls.delete()
-	if err != nil {
-		return err
-	}
-	upsert, err := tmpls.upsert()
-	if err != nil {
-		return err
-	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.mu.columns = colData
 	a.mu.pks = tmpls.PK
-	a.mu.sql.delete = del
-	a.mu.sql.upsert = upsert
+	a.mu.templates = tmpls
 	return nil
 }

--- a/internal/target/apply/metrics.go
+++ b/internal/target/apply/metrics.go
@@ -30,6 +30,14 @@ var (
 		Name: "apply_errors_total",
 		Help: "the number of times an error was encountered while applying mutations",
 	}, metrics.TableLabels)
+	applyTemplateHits = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "apply_template_hits_total",
+		Help: "the number of times the apply template cache hit",
+	}, []string{"name"})
+	applyTemplateMisses = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "apply_template_misses_total",
+		Help: "the number of times the apply template cache missed",
+	}, []string{"name"})
 	applyUpserts = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "apply_upserts_total",
 		Help: "the number of rows upserted",

--- a/internal/target/apply/queries/common.tmpl
+++ b/internal/target/apply/queries/common.tmpl
@@ -8,25 +8,42 @@
     {{- end -}}
 {{- end -}}
 
-{{- /* params produces a comma-separated list of substitution params: $1, $2, $3, ... */ -}}
+{{- /*
+params produces a comma-separated list of substitution params tuples:
+($1, $2, $3), ($4, $5, $6), ...
+*/ -}}
 {{- define "params" -}}
-    {{- range $idx, $col := . }}
-        {{- if $idx -}},{{- end -}}
-        ${{- oneBased $idx -}}
+    {{- range $groupIdx, $pairs := $.Vars -}}
+        {{- if $groupIdx -}},{{- end -}}
+        (
+        {{- range $pairIdx, $pair := $pairs -}}
+            {{- if $pairIdx -}},{{- end -}}
+            ${{- $pair.Index -}}
+        {{- end -}}
+        )
     {{- end -}}
 {{- end -}}
 
-{{- /* exprs produces a comma-separated list of typed substitution params: $1::STRING, $2::INT */ -}}
+{{- /*
+exprs is similar to the param templates, save that it adds explicit
+typecasts to each variable produces a comma-separated list of typed
+substitution params: ($1::STRING, $2::INT), (...), (...), ...
+*/ -}}
 {{- define "exprs" -}}
-    {{- range $idx, $col := . -}}
-        {{- if $idx -}},{{- end -}}
-        {{- if eq $col.Type "GEOGRAPHY" -}}
-            st_geogfromgeojson(${{ oneBased $idx }}::JSONB)
-        {{- else if eq $col.Type "GEOMETRY" -}}
-            st_geomfromgeojson(${{ oneBased $idx }}::JSONB)
-        {{- else -}}
-            ${{ oneBased $idx }}::{{ $col.Type }}
+    {{- range $groupIdx, $pairs := $.Vars -}}
+        {{- if $groupIdx -}},{{- nl -}}{{- end -}}
+        (
+        {{- range $pairIdx, $pair := $pairs -}}
+            {{- if $pairIdx -}},{{- end -}}
+            {{- if eq $pair.Column.Type "GEOGRAPHY" -}}
+                st_geogfromgeojson(${{ $pair.Index }}::JSONB)
+            {{- else if eq $pair.Column.Type "GEOMETRY" -}}
+                st_geomfromgeojson(${{ $pair.Index }}::JSONB)
+            {{- else -}}
+                ${{ $pair.Index }}::{{ $pair.Column.Type }}
+            {{- end -}}
         {{- end -}}
+        )
     {{- end -}}
 {{- end -}}
 

--- a/internal/target/apply/queries/conditional.tmpl
+++ b/internal/target/apply/queries/conditional.tmpl
@@ -15,7 +15,9 @@ aid in joins below.
 WITH data( pk0, pk1, val0, val1, ...) AS (VALUES ($1, $2, $3, ...))
 */ -}}
 WITH data( {{- template "names" .Columns -}} ) AS (
-VALUES ( {{- template "exprs" .Columns -}} ))
+VALUES{{- nl -}}
+{{- template "exprs" . -}}
+)
 
 
 {{- /*

--- a/internal/target/apply/queries/delete.tmpl
+++ b/internal/target/apply/queries/delete.tmpl
@@ -1,8 +1,11 @@
 {{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
-{{- /* DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1") = ($1,$2) */ -}}
+{{- /*
+DELETE FROM "database"."schema"."table"
+WHERE ("pk0","pk1") IN (($1,$2), (...), ...)
+*/ -}}
 DELETE FROM {{ .TableName }} WHERE (
     {{- template "names" .PK -}}
-)=(
-    {{- template "params" .PK -}}
+)IN(
+    {{- template "params" . -}}
 )
 {{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/upsert.tmpl
+++ b/internal/target/apply/queries/upsert.tmpl
@@ -9,7 +9,7 @@ st_geogfromgeojson($3::JSONB))
 */ -}}
 UPSERT INTO {{ .TableName }} (
 {{ template "names" .Columns }}
-) VALUES (
-{{ template "exprs" .Columns }}
-)
+) VALUES
+{{ template "exprs" . }}
+
 {{- /* Trim whitespace */ -}}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -29,7 +29,7 @@ import (
 // An Applier accepts some number of Mutations and applies them to
 // a target table.
 type Applier interface {
-	Apply(context.Context, Batcher, []Mutation) error
+	Apply(context.Context, pgxtype.Querier, []Mutation) error
 }
 
 // Appliers is a factory for Applier instances.

--- a/internal/util/batches/batches.go
+++ b/internal/util/batches/batches.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 )
 
-const defaultSize = 1000
+const defaultSize = 100
 
 var batchSize = flag.Int("batchSize", defaultSize, "default size for batched operations")
 


### PR DESCRIPTION
Note to reviewers, this depends on PR #86.

This change improves the throughput of the apply package by changing the SQL to
use multi-valued VALUE clauses.

The append benchmark is updated to demonstrate the performance curve of the
Apply method at varying batch sizes.

The default batch size is adjusted to 100 to be more conservative with total
size of generated SQL.

The testing GitHub workflow is updated to run on all branches and to add
another build step for this and future benchmarks.

Benchmark results on my laptop:

```
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/cdc-sink/internal/target/apply
BenchmarkApply/size=1/base-10    	          199155	     60065 ns/op	268569.38 MB/s
BenchmarkApply/size=1/cas-10     	           76429	    161671 ns/op	38292.18 MB/s
BenchmarkApply/size=1/deadline-10         	  181066	     61327 ns/op	239148.64 MB/s
BenchmarkApply/size=1/cas+deadline-10     	   64364	    160838 ns/op	32414.52 MB/s
BenchmarkApply/size=10/base-10            	  130818	     99337 ns/op	1070802.78 MB/s
BenchmarkApply/size=10/cas-10             	   33937	    299548 ns/op	91768.23 MB/s
BenchmarkApply/size=10/deadline-10        	  124788	    106038 ns/op	956503.64 MB/s
BenchmarkApply/size=10/cas+deadline-10    	   43885	    299746 ns/op	118589.99 MB/s
BenchmarkApply/size=100/base-10           	   28309	    526175 ns/op	439461.58 MB/s
BenchmarkApply/size=100/cas-10            	    8474	   1447730 ns/op	47411.74 MB/s
BenchmarkApply/size=100/deadline-10       	   25753	    547519 ns/op	384049.86 MB/s
BenchmarkApply/size=100/cas+deadline-10   	    8410	   1443147 ns/op	47203.09 MB/s
BenchmarkApply/size=1000/base-10          	    2198	   5105932 ns/op	35123.07 MB/s
BenchmarkApply/size=1000/cas-10           	     854	  13761511 ns/op	5026.63 MB/s
BenchmarkApply/size=1000/deadline-10      	    2390	   5281912 ns/op	36933.60 MB/s
BenchmarkApply/size=1000/cas+deadline-10  	     853	  14189589 ns/op	4869.27 MB/s
BenchmarkApply/size=10000/base-10         	     234	  50549005 ns/op	3778.12 MB/s
BenchmarkApply/size=10000/cas-10          	      81	 144095278 ns/op	 455.32 MB/s
BenchmarkApply/size=10000/deadline-10     	     234	  51832442 ns/op	3684.56 MB/s
BenchmarkApply/size=10000/cas+deadline-10 	      85	 147260294 ns/op	 467.54 MB/s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/87)
<!-- Reviewable:end -->
