### PR TITLE
cdc-sink: Initial add of pglogical replication

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -16,3 +16,23 @@ services:
     image: cockroachdb/cockroach:latest-v21.2
     network_mode: host
     command: start-single-node --insecure
+  postgresql-v13:
+    image: postgres:13
+    environment:
+      POSTGRES_PASSWORD: SoupOrSecret
+    ports:
+      - "5432:5432"
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+  postgresql-v14:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: SoupOrSecret
+    ports:
+      - "5432:5432"
+    command:
+      - postgres
+      - -c
+      - wal_level=logical

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,24 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Determine paths to cache
+        id: cache
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache.outputs.go-build }}
+          key: ${{ runner.os }}-quality-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache.outputs.go-mod }}
+          key: ${{ runner.os }}-quality-mod-${{ hashFiles('**/go.sum') }}
+
       - name: crlfmt returns no deltas
         if: ${{ always() }}
         run: |
@@ -41,11 +59,12 @@ jobs:
         run: go run honnef.co/go/tools/cmd/staticcheck -checks all ./...
 
   integration:
-    name: Integration Tests ${{ matrix.cockroachdb }}
+    name: Integration Tests crdb-${{ matrix.cockroachdb }} pg-${{ matrix.postgresql }}
     strategy:
       fail-fast: false
       matrix:
         cockroachdb: [ v20.2, v21.1, v21.2 ]
+        postgresql: [ v13, v14 ]
     runs-on: ubuntu-latest
     env:
       COVER_OUT: coverage-${{ matrix.coverage }}.out
@@ -57,9 +76,31 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Determine paths to cache
+        id: cache
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache.outputs.go-build }}
+          key: ${{ runner.os }}-integration-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache.outputs.go-mod }}
+          key: ${{ runner.os }}-integration-mod-${{ hashFiles('**/go.sum') }}
+
       - name: Start CockroachDB
         working-directory: .github
         run: docker-compose up -d cockroachdb-${{ matrix.cockroachdb }}
+
+      - name: Start PostgreSQL
+        working-directory: .github
+        run: docker-compose up -d postgresql-${{ matrix.postgresql }}
 
       - name: Go Tests
         env:
@@ -72,7 +113,7 @@ jobs:
           COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
         run: go test -v -benchtime 10s -bench . ./...
 
-      - name: Stop CockroachDB
+      - name: Stop databases
         if: ${{ always() }}
         working-directory: .github
         run: docker-compose down

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,10 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/google/uuid v1.1.2
 	github.com/jackc/pgconn v1.10.1
+	github.com/jackc/pglogrepl v0.0.0-20211030141007-2b9e46709343
+	github.com/jackc/pgproto3/v2 v2.2.0
 	github.com/jackc/pgtype v1.9.1
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/joonix/log v0.0.0-20200409080653-9c1d2ceb5f1d
@@ -18,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/tools v0.1.8
 	honnef.co/go/tools v0.2.2
 )
@@ -34,7 +38,6 @@ require (
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/puddle v1.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -259,6 +260,7 @@ github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgO
 github.com/jackc/pgconn v0.0.0-20190420214824-7e0022ef6ba3/go.mod h1:jkELnwuX+w9qN5YIfX0fl88Ehu4XC3keFuOJJk9pcnA=
 github.com/jackc/pgconn v0.0.0-20190824142844-760dd75542eb/go.mod h1:lLjNuW/+OfW9/pnVKPazfWOgNfH2aPem8YQ7ilXGvJE=
 github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsUgOEh9hBm+xYTstcNHg7UPMVJqRfQxq4s=
+github.com/jackc/pgconn v1.6.5-0.20200823013804-5db484908cf7/go.mod h1:gm9GeeZiC+Ja7JV4fB/MNDeaOqsCrzFiZlLVhAompxk=
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgconn v1.9.0/go.mod h1:YctiPyvzfU11JFxoXokUOOKQXQmDMoJL9vJzHH8/2JY=
 github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
@@ -266,6 +268,8 @@ github.com/jackc/pgconn v1.10.1 h1:DzdIHIjG1AxGwoEEqS+mGsURyjt4enSmqzACXvVzOT8=
 github.com/jackc/pgconn v1.10.1/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
+github.com/jackc/pglogrepl v0.0.0-20211030141007-2b9e46709343 h1:ICoXVKAvJEE6pKhghLFFKaArqOqAj7IqhP/8ifh2FA8=
+github.com/jackc/pglogrepl v0.0.0-20211030141007-2b9e46709343/go.mod h1:DmTlVuDAzLCpHDCtr+UJOGjN09Lh/7AvCULTvbRt674=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgmock v0.0.0-20201204152224-4fe30f7445fd/go.mod h1:hrBW0Enj2AZTNpt/7Y5rr2xe/9Mn757Wtb2xeBzPv2c=
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5Wi/+Zz7xoE5ALHsRQlOctkOiHc=
@@ -278,6 +282,7 @@ github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod 
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
 github.com/jackc/pgproto3/v2 v2.0.0-rc3/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
+github.com/jackc/pgproto3/v2 v2.0.4/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.1.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.2.0 h1:r7JypeP2D3onoQTCxWdTpCtJ4D+qpKr0TxvoyMhZ5ns=
@@ -599,6 +604,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -1,0 +1,94 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package pglogical contains a command to perform logical replication
+// from a PostgreSQL source server.
+package pglogical
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// Command returns the pglogical subcommand.
+func Command() *cobra.Command {
+	cfg := &pglogical.Config{}
+	var metricsAddr, targetDB string
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Short: "start a pg logical replication feed",
+		Use:   "pglogical",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if metricsAddr != "" {
+				if err := metricsServer(metricsAddr); err != nil {
+					return err
+				}
+			}
+			cfg.TargetDB = ident.New(targetDB)
+
+			_, stopped, err := pglogical.NewConn(cmd.Context(), cfg)
+			if err != nil {
+				return err
+			}
+			<-stopped
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.BoolVar(&cfg.Immediate, "immediate", false, "apply data without waiting for transaction boundaries")
+	f.StringVar(&metricsAddr, "metricsAddr", "", "a host:port to serve metrics from at /_/varz")
+	f.StringVar(&cfg.Slot, "slotName", "cdc_sink", "the replication slot in the source database")
+	f.StringVar(&cfg.SourceConn, "sourceConn", "", "the source database's connection string")
+	f.StringVar(&cfg.TargetConn, "targetConn", "", "the target cluster's connection string")
+	f.StringVar(&targetDB, "targetDB", "", "the SQL database in the target cluster to update")
+	f.StringVar(&cfg.Publication, "publicationName", "",
+		"the publication within the source database to replicate")
+	return cmd
+}
+
+// metricsServer starts a trivial prometheus endpoint server which runs
+// until the context is canceled.
+func metricsServer(bindAddr string) error {
+	mux := &http.ServeMux{}
+	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+	mux.Handle("/_/varz", promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer,
+		promhttp.HandlerFor(
+			prometheus.DefaultGatherer,
+			promhttp.HandlerOpts{
+				EnableOpenMetrics: true,
+				ErrorLog:          log.StandardLogger().WithField("promhttp", "true"),
+			})))
+	mux.Handle("/", http.NotFoundHandler())
+
+	l, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	srv := &http.Server{
+		Handler: h2c.NewHandler(mux, &http2.Server{}),
+	}
+	log.Infof("metrics server bound to %s", l.Addr())
+	go srv.Serve(l)
+	return nil
+}

--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pglogical
+
+import "github.com/cockroachdb/cdc-sink/internal/util/ident"
+
+// Config contains the configuration necessary for creating a
+// replication connection. All field, other than TestControls, are
+// mandatory.
+type Config struct {
+	// Place the configuration into immediate mode, where mutations are
+	// applied without waiting for transaction boundaries.
+	Immediate bool
+	// The name of the publication to attach to.
+	Publication string
+	// The replication slot to attach to.
+	Slot string
+	// Connection string for the source db.
+	SourceConn string
+	// Connection string for the target cluster.
+	TargetConn string
+	// The SQL database in the target cluster to write into.
+	TargetDB ident.Ident
+	// Additional controls for testing.
+	TestControls *TestControls
+}
+
+// TestControls define a collection of testing hook points for injecting
+// behavior in a testing scenario. The function callbacks in this type
+// must be prepared to be called from arbitrary goroutines. All fields
+// in this type are optional.
+type TestControls struct {
+	BreakOnDataTuple     func() bool
+	BreakReplicationFeed func() bool
+	BreakSinkFlush       func() bool
+}

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -1,0 +1,708 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package pglogical contains support for reading a PostgreSQL logical
+// replication feed.
+package pglogical
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
+	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/target/stage"
+	"github.com/cockroachdb/cdc-sink/internal/target/timekeeper"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/batches"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/retry"
+	"github.com/google/uuid"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// A Conn encapsulates all wire-connection behavior. It is
+// responsible for receiving replication messages and replying with
+// status updates.
+type Conn struct {
+	// Apply mutations to the backing store.
+	appliers types.Appliers
+	// Columns, as ordered by the source database.
+	columns map[ident.Table][]types.ColData
+	// Tables that need to be drained.
+	dirty     map[ident.Table]struct{}
+	immediate bool
+	// Batches of mutations to stage.
+	pending map[ident.Table][]types.Mutation
+	// Callbacks to release the slices in pending.
+	pendingReleases []func()
+	// The pg publication name to subscribe to.
+	publicationName string
+	// Map source ids to target tables.
+	relations map[uint32]ident.Table
+	// Stage mutations in the backing store.
+	stagers types.Stagers
+	// The name of the slot within the publication.
+	slotName string
+	// The configuration for opening replication connections.
+	sourceConfig *pgconn.Config
+	// The SQL database we're going to be writing into.
+	targetDB ident.Ident
+	// Connection string for the target database.
+	targetPool *pgxpool.Pool
+	// Likely nil.
+	testControls *TestControls
+	// Drain.
+	timeKeeper types.TimeKeeper
+	// The (eventual) commit time of the transaction being processed.
+	txTime hlc.Time
+
+	mu struct {
+		sync.Mutex
+
+		// This is the position in the transaction log that we'll
+		// occasionally report back to the server. It is updated when we
+		// successfully commit an entire transaction's worth of data.
+		clientXLogPos pglogrepl.LSN
+	}
+}
+
+// NewConn constructs a new pglogical replication feed.
+//
+// The feed will terminate when the context is canceled and the stopped
+// channel will be closed once shutdown is complete.
+func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struct{}, _ error) {
+	// Some pre-flight checks.
+	if config.Publication == "" {
+		return nil, nil, errors.New("no publication name was configured")
+	}
+	if config.Slot == "" {
+		return nil, nil, errors.New("no replication slot name was configured")
+	}
+	if config.SourceConn == "" {
+		return nil, nil, errors.New("no source connection was configured")
+	}
+	if config.TargetConn == "" {
+		return nil, nil, errors.New("no target connection was configured")
+	}
+	if config.TargetDB.IsEmpty() {
+		return nil, nil, errors.New("no target db was configured")
+	}
+
+	// Verify that the publication and replication slots were configured
+	// by the user. We could create the replication slot ourselves, but
+	// we want to coordinate the timing of the backup, restore, and
+	// streaming operations.
+	source, err := pgx.Connect(ctx, config.SourceConn)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "could not connect to source database")
+	}
+	defer source.Close(context.Background())
+
+	// Ensure that the requested publication exists.
+	var count int
+	if err := source.QueryRow(ctx,
+		"SELECT count(*) FROM pg_publication WHERE pubname = $1",
+		config.Publication,
+	).Scan(&count); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	if count != 1 {
+		return nil, nil, errors.Errorf(
+			`run CREATE PUBLICATION %s FOR ALL TABLES; in source database`,
+			config.Publication)
+	}
+	log.Tracef("validated that publication %q exists", config.Publication)
+
+	// Verify that the consumer slot exists.
+	if err := source.QueryRow(ctx,
+		"SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1",
+		config.Slot,
+	).Scan(&count); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	if count != 1 {
+		return nil, nil, errors.Errorf(
+			"run SELECT pg_create_logical_replication_slot('%s', 'pgoutput'); in source database, "+
+				"then perform bulk data copy",
+			config.Slot)
+	}
+	log.Tracef("validated that replication slot %q exists", config.Slot)
+
+	// Copy the configuration and tweak it for replication behavior.
+	sourceConfig := source.Config().Config.Copy()
+	sourceConfig.RuntimeParams["replication"] = "database"
+
+	// Bring up connection to target database.
+	targetCfg, err := pgxpool.ParseConfig(config.TargetConn)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "could not parse %q", config.TargetConn)
+	}
+	// Identify traffic.
+	targetCfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET application_name=$1", "cdc-sink")
+		return err
+	}
+	// Ensure connection diversity through long-lived loadbalancers.
+	targetCfg.MaxConnLifetime = 10 * time.Minute
+	// Keep one spare connection.
+	targetCfg.MinConns = 1
+
+	targetPool, err := pgxpool.ConnectConfig(ctx, targetCfg)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "could not connect to CockroachDB")
+	}
+
+	timeKeeper, err := timekeeper.NewTimeKeeper(ctx, targetPool, cdc.Resolved)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	watchers, cancelWatchers := schemawatch.NewWatchers(targetPool)
+	appliers, cancelAppliers := apply.NewAppliers(watchers)
+	stagers := stage.NewStagers(targetPool, ident.StagingDB)
+
+	ret := &Conn{
+		appliers:        appliers,
+		columns:         make(map[ident.Table][]types.ColData),
+		dirty:           make(map[ident.Table]struct{}),
+		immediate:       config.Immediate,
+		pending:         make(map[ident.Table][]types.Mutation),
+		publicationName: config.Publication,
+		relations:       make(map[uint32]ident.Table),
+		slotName:        config.Slot,
+		sourceConfig:    sourceConfig,
+		stagers:         stagers,
+		targetDB:        config.TargetDB,
+		targetPool:      targetPool,
+		testControls:    config.TestControls,
+		timeKeeper:      timeKeeper,
+	}
+
+	stopper := make(chan struct{})
+	go func() {
+		_ = ret.run(ctx)
+		cancelAppliers()
+		cancelWatchers()
+		targetPool.Close()
+		close(stopper)
+	}()
+
+	return ret, stopper, nil
+}
+
+// run blocks while the connection is processing messages.
+func (c *Conn) run(ctx context.Context) error {
+	for ctx.Err() == nil {
+		group, ctx := errgroup.WithContext(ctx)
+
+		// Start a background goroutine to maintain the replication
+		// connection. This source goroutine is set up to be robust; if
+		// there's an error talking to the source database, we send a
+		// rollback message to the consumer and retry the connection.
+		ch := make(chan pglogrepl.Message, 16)
+		group.Go(func() error {
+			defer close(ch)
+			for ctx.Err() == nil {
+				if err := c.readReplicationData(ctx, ch); err != nil {
+					log.WithError(err).Error("error from replication channel; continuing")
+				}
+				select {
+				case ch <- &rollbackMessage{}:
+				case <-ctx.Done():
+					return nil
+				}
+			}
+			return nil
+		})
+
+		// This goroutine applies the incoming mutations to the target
+		// database. It is fragile, when it errors, we need to also
+		// restart the source goroutine.
+		group.Go(func() error {
+			err := c.processMessages(ctx, ch)
+			if err != nil {
+				log.WithError(err).Error("error while applying replication messages; stopping")
+			}
+			return err
+		})
+
+		if err := group.Wait(); err != nil {
+			log.WithError(err).Error("error in replication loop; restarting")
+		}
+	}
+	log.Info("shut down replication loop")
+	return nil
+}
+
+func (c *Conn) getLogPos() pglogrepl.LSN {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.clientXLogPos
+}
+
+func (c *Conn) setLogPos(pos pglogrepl.LSN) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.clientXLogPos = pos
+	log.WithField("LSN", pos).Trace("updated LSN")
+	lsnOffset.Set(float64(pos))
+}
+
+// decodeMutation converts the incoming tuple data into a Mutation.
+func (c *Conn) decodeMutation(
+	tbl ident.Table, data *pglogrepl.TupleData, isDelete bool,
+) (types.Mutation, error) {
+	mut := types.Mutation{Time: c.txTime}
+	var key []string
+	enc := make(map[string]interface{})
+	targetCols, ok := c.columns[tbl]
+	if !ok {
+		return mut, errors.Errorf("no column data for %s", tbl)
+	}
+	if len(targetCols) != len(data.Columns) {
+		return mut, errors.Errorf("column count mismatch is %s: %d vs %d",
+			tbl, len(targetCols), len(data.Columns))
+	}
+	for idx, sourceCol := range data.Columns {
+		targetCol := targetCols[idx]
+		switch sourceCol.DataType {
+		case pglogrepl.TupleDataTypeNull:
+			enc[targetCol.Name.Raw()] = nil
+		case pglogrepl.TupleDataTypeText:
+			// The incoming data is in a textual format.
+			enc[targetCol.Name.Raw()] = string(sourceCol.Data)
+			if targetCol.Primary {
+				key = append(key, string(sourceCol.Data))
+			}
+		case pglogrepl.TupleDataTypeToast:
+			return mut, errors.Errorf(
+				"TOASTed columns are not supported in %s.%s", tbl, targetCol.Name)
+		default:
+			return mut, errors.Errorf(
+				"unimplemented tuple data type %q", string(sourceCol.DataType))
+		}
+	}
+
+	// In the pathological case where a table has no primary key, we'll
+	// generate a random uuid value to use as the staging key. This is
+	// fine, because the underlying data has no particular identity to
+	// update. In fact, it's not possible to issue an UPDATE to Postgres
+	// when a row has no replication identity.
+	if len(key) == 0 {
+		key = []string{uuid.New().String()}
+	}
+
+	var err error
+	mut.Key, err = json.Marshal(key)
+	if err != nil {
+		return mut, errors.WithStack(err)
+	}
+	// We don't need the actual column data for delete operations.
+	if !isDelete {
+		mut.Data, err = json.Marshal(enc)
+		if err != nil {
+			return mut, errors.WithStack(err)
+		}
+	}
+	return mut, errors.WithStack(err)
+}
+
+// flush commits all pending mutations to their respective stages or
+// applies them in immediate-mode. It will also zero-out the length of
+// the associated pending slice.
+func (c *Conn) flush(ctx context.Context, tbl ident.Table) error {
+	if ctrl := c.testControls; ctrl != nil {
+		if fn := c.testControls.BreakSinkFlush; fn != nil {
+			if fn() {
+				return errors.New("breaking sink flush for test")
+			}
+		}
+	}
+
+	found := c.pending[tbl]
+	if len(found) == 0 {
+		return nil
+	}
+
+	if c.immediate {
+		// TODO(bob): Eventually we'll have data-driven configuration.
+		app, err := c.appliers.Get(ctx, tbl, nil /* cas */, types.Deadlines{})
+		if err != nil {
+			return err
+		}
+		if err := app.Apply(ctx, c.targetPool, found); err != nil {
+			return err
+		}
+	} else {
+		stager, err := c.stagers.Get(ctx, tbl)
+		if err != nil {
+			return err
+		}
+		if err := stager.Store(ctx, c.targetPool, found); err != nil {
+			return err
+		}
+	}
+	c.pending[tbl] = found[:0]
+	return nil
+}
+
+// learn updates the source database namespace mappings.
+func (c *Conn) learn(msg *pglogrepl.RelationMessage) {
+	// The replication protocol says that we'll see these
+	// descriptors before any use of the relation id in the
+	// stream. We'll map the int value to our table identifiers.
+	tbl := ident.NewTable(
+		c.targetDB,
+		ident.New(msg.Namespace),
+		ident.New(msg.RelationName))
+	c.relations[msg.RelationID] = tbl
+
+	colNames := make([]types.ColData, len(msg.Columns))
+	for idx, col := range msg.Columns {
+		colNames[idx] = types.ColData{
+			Name:    ident.New(col.Name),
+			Primary: col.Flags == 1,
+			// This could be made textual if we used the
+			// ConnInfo metadata methods.
+			Type: fmt.Sprintf("%d", col.DataType),
+		}
+	}
+	c.columns[tbl] = colNames
+
+	log.WithFields(log.Fields{
+		"Columns":    colNames,
+		"RelationID": msg.RelationID,
+		"Table":      tbl,
+	}).Trace("learned relation")
+}
+
+// onCommit ensure that all in-memory data has been committed to the
+// target cluster. It will also update the WAL position that we report
+// back to the source database.
+func (c *Conn) onCommit(ctx context.Context, msg *pglogrepl.CommitMessage) error {
+	// Flush in-memory data to the staging tables.
+	for tbl := range c.pending {
+		if err := c.flush(ctx, tbl); err != nil {
+			return err
+		}
+	}
+
+	// In immediate mode, the call(s) to flush() above will have
+	// committed to the target tables. Otherwise, apply the transaction
+	// data, through the usual drain-and-apply mechanism.
+	if !c.immediate {
+		if err := retry.Retry(ctx, func(ctx context.Context) error {
+			tx, err := c.targetPool.Begin(ctx)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			defer tx.Rollback(ctx)
+
+			for tbl := range c.dirty {
+				prev, err := c.timeKeeper.Put(ctx, tx, tbl.AsSchema(), c.txTime)
+				if err != nil {
+					return err
+				}
+
+				stage, err := c.stagers.Get(ctx, tbl)
+				if err != nil {
+					return err
+				}
+
+				muts, err := stage.Drain(ctx, tx, prev, c.txTime)
+				if err != nil {
+					return err
+				}
+
+				app, err := c.appliers.Get(ctx, tbl, nil /* casColumns */, types.Deadlines{})
+				if err != nil {
+					return err
+				}
+
+				if err := app.Apply(ctx, tx, muts); err != nil {
+					return err
+				}
+			}
+			return tx.Commit(ctx)
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Advance our high-water mark within the source's WAL,
+	// which will be reported by the keepalive loop.
+	c.setLogPos(msg.TransactionEndLSN)
+	c.reset()
+	commitCount.Inc()
+	commitTime.Set(float64(msg.CommitTime.Unix()))
+	return nil
+}
+
+// onDataTuple will add an incoming row tuple to the in-memory slice,
+// possibly flushing it when the batch size limit is reached.
+func (c *Conn) onDataTuple(
+	ctx context.Context, relation uint32, tuple *pglogrepl.TupleData, isDelete bool,
+) error {
+	if ctrl := c.testControls; ctrl != nil {
+		if fn := c.testControls.BreakOnDataTuple; fn != nil {
+			if fn() {
+				return errors.New("breaking onDataTuple for test")
+			}
+		}
+	}
+
+	traceTuple(tuple)
+	tbl, ok := c.relations[relation]
+	if !ok {
+		return errors.Errorf("unknown relation id %d", relation)
+	}
+	mut, err := c.decodeMutation(tbl, tuple, isDelete)
+	if err != nil {
+		return err
+	}
+
+	found := c.pending[tbl]
+	if found == nil {
+		next, fn := batches.Mutation()
+		c.pendingReleases = append(c.pendingReleases, fn)
+		found = next
+	}
+	found = append(found, mut)
+	c.dirty[tbl] = struct{}{}
+	c.pending[tbl] = found
+	if len(found) == cap(found) {
+		return c.flush(ctx, tbl)
+	}
+	return nil
+}
+
+// processMessages receives a sequence of logical replication messages,
+// or possibly a rollbackMessage. If this loop fails out, we'll need to
+// stop and restart the underlying replication network connection.
+func (c *Conn) processMessages(ctx context.Context, ch <-chan pglogrepl.Message) error {
+	for msg := range ch {
+		log.Tracef("message %T", msg)
+		var err error
+		switch msg := msg.(type) {
+		case *rollbackMessage:
+			// This is a custom message that we'll insert to indicate
+			// that the upstream message provider is going to restart
+			// the feed.
+			c.reset()
+
+		case *pglogrepl.RelationMessage:
+			// The replication protocol says that we'll see these
+			// descriptors before any use of the relation id in the
+			// stream. We'll map the int value to our table identifiers.
+			c.learn(msg)
+
+		case *pglogrepl.BeginMessage:
+			// Starting a new transaction. We're going to accept the
+			// transaction time as reported by the server as our
+			// HLC timestamp for staging purposes.
+			c.txTime = hlc.From(msg.CommitTime)
+
+		case *pglogrepl.CommitMessage:
+			err = c.onCommit(ctx, msg)
+
+		case *pglogrepl.DeleteMessage:
+			err = c.onDataTuple(ctx, msg.RelationID, msg.OldTuple, true /* isDelete */)
+
+		case *pglogrepl.InsertMessage:
+			err = c.onDataTuple(ctx, msg.RelationID, msg.Tuple, false /* isDelete */)
+
+		case *pglogrepl.UpdateMessage:
+			err = c.onDataTuple(ctx, msg.RelationID, msg.NewTuple, false /* isDelete */)
+
+		case *pglogrepl.TruncateMessage:
+			err = errors.Errorf("the TRUNCATE operation cannot be supported on table %d", msg.RelationNum)
+
+		default:
+			err = errors.Errorf("unimplemented logical replication message %T", msg)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readReplicationData opens a replication connection and writes parsed
+// messages into the provided channel. This method also manages the
+// keepalive protocol. The consuming code should call Conn.setLogPos
+// in order to advance the server-side high-water mark.
+func (c *Conn) readReplicationData(ctx context.Context, ch chan<- pglogrepl.Message) error {
+	replConn, err := pgconn.ConnectConfig(ctx, c.sourceConfig)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer replConn.Close(context.Background())
+
+	if err := pglogrepl.StartReplication(ctx,
+		replConn, c.slotName, c.getLogPos(),
+		pglogrepl.StartReplicationOptions{
+			PluginArgs: []string{
+				"proto_version '1'",
+				fmt.Sprintf("publication_names '%s'", c.publicationName)},
+		},
+	); err != nil {
+		dialFailureCount.Inc()
+		return errors.WithStack(err)
+	}
+	dialSuccessCount.Inc()
+
+	standbyTimeout := time.Second * 10
+	standbyDeadline := time.Now().Add(standbyTimeout)
+
+	for ctx.Err() == nil {
+		if ctrl := c.testControls; ctrl != nil {
+			if fn := c.testControls.BreakReplicationFeed; fn != nil {
+				if fn() {
+					log.Debug("closing replication connection for test")
+					_ = replConn.Close(ctx)
+				}
+			}
+		}
+
+		if time.Now().After(standbyDeadline) {
+			err = pglogrepl.SendStandbyStatusUpdate(ctx, replConn, pglogrepl.StandbyStatusUpdate{
+				WALWritePosition: c.getLogPos(),
+			})
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			log.Trace("Sent Standby status message")
+			standbyDeadline = time.Now().Add(standbyTimeout)
+		}
+
+		// Receive one message, with a timeout. In a low-traffic
+		// situation, we want to ensure that we're sending heartbeats
+		// back to the source server.
+		receiveCtx, cancel := context.WithDeadline(ctx, standbyDeadline)
+		msg, err := replConn.ReceiveMessage(receiveCtx)
+		cancel()
+		if err != nil {
+			if pgconn.Timeout(err) {
+				continue
+			}
+			return errors.WithStack(err)
+		}
+		log.Tracef("received %T", msg)
+
+		switch msg := msg.(type) {
+		case *pgproto3.CopyData:
+			switch msg.Data[0] {
+			case pglogrepl.PrimaryKeepaliveMessageByteID:
+				// The server is sending us a keepalive message. This is
+				// informational, except in the case where an immediate
+				// acknowledgement is requested.  In that case, we'll
+				// reset the standby deadline to zero, so we kick back a
+				// message at the top of the loop.
+				pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(msg.Data[1:])
+				if err != nil {
+					return errors.WithStack(err)
+				}
+				log.WithFields(log.Fields{
+					"ServerWALEnd":   pkm.ServerWALEnd,
+					"ServerTime":     pkm.ServerTime,
+					"ReplyRequested": pkm.ReplyRequested,
+				}).Debug("primary keepalive received")
+
+				if pkm.ReplyRequested {
+					standbyDeadline = time.Time{}
+				}
+
+			case pglogrepl.XLogDataByteID:
+				// This is where things get interesting. We have actual
+				// transaction log data to parse into messages. These
+				// messages get handed off to the consumer via the
+				// channel passed in.
+				xld, err := pglogrepl.ParseXLogData(msg.Data[1:])
+				if err != nil {
+					return errors.WithStack(err)
+				}
+				log.WithFields(log.Fields{
+					"ByteCount":    len(xld.WALData),
+					"ServerWALEnd": xld.ServerWALEnd,
+					"ServerTime":   xld.ServerTime,
+					"WALStart":     xld.WALStart,
+				}).Debug("xlog data")
+
+				logicalMsg, err := pglogrepl.Parse(xld.WALData)
+				if err != nil {
+					return errors.WithStack(err)
+				}
+				select {
+				case ch <- logicalMsg:
+				case <-ctx.Done():
+					return errors.WithStack(ctx.Err())
+				}
+			}
+		case *pgproto3.NotificationResponse:
+			log.Debugf("notification from server: %s", msg.Payload)
+		default:
+			log.Debugf("unexpected payload message: %T", msg)
+		}
+	}
+	return nil
+}
+
+// reset abandons any in-flight data that we've accumulated.
+func (c *Conn) reset() {
+	c.dirty = make(map[ident.Table]struct{})
+	for tbl, muts := range c.pending {
+		c.pending[tbl] = muts[:0]
+	}
+	c.txTime = hlc.Zero()
+}
+
+// traceTuple
+func traceTuple(t *pglogrepl.TupleData) {
+	if !log.IsLevelEnabled(log.TraceLevel) {
+		return
+	}
+	if t == nil {
+		log.Trace("NIL TUPLE")
+		return
+	}
+	s := make([]string, len(t.Columns))
+	for idx, data := range t.Columns {
+		if data.DataType == pglogrepl.TupleDataTypeText {
+			s[idx] = string(data.Data)
+		}
+	}
+	log.WithField("data", s).Trace("values")
+}
+
+// A rollbackMessage is inserted into the message channel to indicate
+// that some error occurred and the receiver should unwind to a safe
+// state.
+type rollbackMessage struct{}
+
+var _ pglogrepl.Message = &rollbackMessage{}
+
+// Type implements pglogrepl.Message and returns a value which is
+// not used by any real message type.
+func (r rollbackMessage) Type() pglogrepl.MessageType {
+	return '!'
+}

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -1,0 +1,465 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pglogical
+
+// The tests in this package rely on the Docker Compose configurations
+// in the .github directory.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/target/sinktest"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4/pgxpool"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	pgConnString = flag.String(
+		"pgConn",
+		"postgres://postgres:SoupOrSecret@127.0.0.1/",
+		"connection string for PostgreSQL instance")
+)
+
+// This is a general smoke-test of the logical replication feed.
+func TestPGLogical(t *testing.T) {
+	t.Run("consistent", func(t *testing.T) { testPGLogical(t, false) })
+	t.Run("immediate", func(t *testing.T) { testPGLogical(t, true) })
+}
+
+func testPGLogical(t *testing.T, immediate bool) {
+	a := assert.New(t)
+
+	ctx, info, cancel := sinktest.Context()
+	defer cancel()
+	crdbPool := info.Pool()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	pgPool, cancel, err := setupPGPool(dbName)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Create the schema in both locations.
+	tgt := ident.NewTable(dbName, ident.Public, ident.New("t"))
+	var schema = fmt.Sprintf(`CREATE TABLE %s (k INT PRIMARY KEY, v TEXT)`, tgt)
+	if _, err := pgPool.Exec(ctx, schema); !a.NoError(err) {
+		return
+	}
+	if _, err := crdbPool.Exec(ctx, schema); !a.NoError(err) {
+		return
+	}
+
+	const rowCount = 1024
+	keys := make([]int, rowCount)
+	vals := make([]string, rowCount)
+	for i := range keys {
+		keys[i] = i
+		vals[i] = fmt.Sprintf("v=%d", i)
+	}
+
+	if _, err := pgPool.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s VALUES (unnest($1::int[]), unnest($2::text[]))", tgt),
+		keys, vals,
+	); !a.NoError(err) {
+		return
+	}
+
+	// Start the connection, to demonstrate that we can backfill pending mutations.
+	connCtx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn()
+	_, stopped, err := NewConn(connCtx, &Config{
+		Immediate:   immediate,
+		Publication: dbName.Raw(),
+		Slot:        dbName.Raw(),
+		SourceConn:  *pgConnString + dbName.Raw(),
+		TargetConn:  crdbPool.Config().ConnString(),
+		TargetDB:    dbName,
+	})
+	if !a.NoError(err) {
+		return
+	}
+
+	// Wait for backfill.
+	for {
+		var count int
+		if err := crdbPool.QueryRow(ctx, fmt.Sprintf("SELECT count(*) FROM %s", tgt)).Scan(&count); !a.NoError(err) {
+			return
+		}
+		log.Trace("backfill count", count)
+		if count == rowCount {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Let's perform an update.
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("UPDATE %s SET v = 'updated'", tgt)); !a.NoError(err) {
+		return
+	}
+
+	// Wait for the update to propagate.
+	for {
+		var count int
+		if err := crdbPool.QueryRow(ctx,
+			fmt.Sprintf("SELECT count(*) FROM %s WHERE v = 'updated'", tgt)).Scan(&count); !a.NoError(err) {
+			return
+		}
+		log.Trace("update count", count)
+		if count == rowCount {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Delete some rows.
+	if _, err := pgPool.Exec(ctx, fmt.Sprintf("DELETE FROM %s WHERE k < 50", tgt)); !a.NoError(err) {
+		return
+	}
+
+	// Wait for the delete to propagate.
+	for {
+		var count int
+		if err := crdbPool.QueryRow(ctx,
+			fmt.Sprintf("SELECT count(*) FROM %s WHERE v = 'updated'", tgt)).Scan(&count); !a.NoError(err) {
+			return
+		}
+		log.Trace("delete count", count)
+		if count == rowCount-50 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	cancelConn()
+	select {
+	case <-ctx.Done():
+		a.Fail("cancelConn timed out")
+	case <-stopped:
+		// OK
+	}
+}
+
+// This test creates a connection and sets various flags to ensure
+// that we have covered certain failure cases.
+func TestChaos(t *testing.T) {
+	a := assert.New(t)
+
+	ctx, info, cancel := sinktest.Context()
+	defer cancel()
+	crdbPool := info.Pool()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	pgPool, cancel, err := setupPGPool(dbName)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Create the schema in both locations.
+	tgt := ident.NewTable(dbName, ident.Public, ident.New("t"))
+	var schema = fmt.Sprintf(`CREATE TABLE %s (k INT PRIMARY KEY, v TEXT)`, tgt)
+	if _, err := pgPool.Exec(ctx, schema); !a.NoError(err) {
+		return
+	}
+	if _, err := crdbPool.Exec(ctx, schema); !a.NoError(err) {
+		return
+	}
+
+	// Start the connection.
+	connCtx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn()
+	_, stopped, err := NewConn(connCtx, &Config{
+		Publication: dbName.Raw(),
+		Slot:        dbName.Raw(),
+		SourceConn:  *pgConnString + dbName.Raw(),
+		TargetConn:  crdbPool.Config().ConnString(),
+		TargetDB:    dbName,
+		TestControls: &TestControls{
+			BreakReplicationFeed: func() bool {
+				// We see multiple messages per row, so we don't need
+				// to fail as often.
+				return rand.Intn(100) == 0
+			},
+			BreakSinkFlush: func() bool {
+				return rand.Intn(10) == 0
+			},
+			BreakOnDataTuple: func() bool {
+				return rand.Intn(10) == 0
+			},
+		},
+	})
+	if !a.NoError(err) {
+		return
+	}
+
+	// We're going to insert as a number of transactions, to ensure
+	// that we cycle through all of the different error cases.
+	const rowCount = 100
+	for i := 0; i < rowCount; i++ {
+		if _, err := pgPool.Exec(ctx,
+			fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tgt),
+			i, fmt.Sprintf("v=%d", i),
+		); !a.NoError(err) {
+			return
+		}
+	}
+
+	// Wait for everything to happen.
+	for {
+		var count int
+		if err := crdbPool.QueryRow(ctx, fmt.Sprintf("SELECT count(*) FROM %s", tgt)).Scan(&count); !a.NoError(err) {
+			return
+		}
+		if count == rowCount {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	cancelConn()
+	select {
+	case <-ctx.Done():
+		a.Fail("cancelConn timed out")
+	case <-stopped:
+		// OK
+	}
+}
+
+// https://www.postgresql.org/docs/current/datatype.html
+func TestDataTypes(t *testing.T) {
+	a := assert.New(t)
+
+	// Build a long value for string and byte types.
+	var sb strings.Builder
+	for sb.Len() < 1<<16 {
+		sb.WriteString("0123456789ABCDEF")
+	}
+	longString := sb.String()
+
+	tcs := []struct {
+		name   string
+		values []interface{} // We automatically test for NULL below.
+	}{
+		{`bigint`, []interface{}{0, -1, 112358}},
+		// bigserial doesn't exist as a reifiable type in pg?
+		{`bit`, []interface{}{"10010101"}},
+		{`bit varying`, []interface{}{"10010101"}},
+		{`boolean`, []interface{}{true, false}},
+		// box
+		{`bytea`, []interface{}{"", "HELLO WORLD!", []byte(longString)}},
+		{`character`, []interface{}{"", "HELLO WORLD!", longString}},
+		{`character varying`, []interface{}{"", "HELLO WORLD!", longString}},
+		// cidr not implemented: https://github.com/cockroachdb/cockroach/issues/18846
+		// circle
+		{`date`, []interface{}{"2020/02/02", time.Date(2022, 02, 22, 0, 0, 0, 0, time.UTC)}},
+		{`double precision`, []interface{}{0.0, -1.1, 1.1}},
+		{`inet`, []interface{}{"127.0.0.1"}},
+		{`integer`, []interface{}{-1, 0, 112358}},
+		{`interval`, []interface{}{time.Duration(0), time.Hour}},
+		{`json`, []interface{}{"null", `{"hello":"world"}`, fmt.Sprintf(`{"long":%q}`, longString)}},
+		{`jsonb`, []interface{}{"null", `{"hello":"world"}`, fmt.Sprintf(`{"long":%q}`, longString)}},
+		// line
+		// lseg
+		// macaddr not implemented: https://github.com/cockroachdb/cockroach/issues/45813
+		// money not implemented: https://github.com/cockroachdb/cockroach/issues/41578
+		{`numeric`, []interface{}{"0", 55, 5.56}},
+		// path
+		// pg_lsn
+		// pg_snapshot
+		// point
+		// polygon
+		{`real`, []interface{}{0.0, -1.1, 1.1}},
+		{`smallint`, []interface{}{0.0, -1, 1}},
+		{`text`, []interface{}{``, `Hello World!`, longString}},
+		{`time`, []interface{}{"16:20"}},
+		{`time with time zone`, []interface{}{"16:20"}},
+		// tsquery
+		// tsvector
+		// txid_snapshot
+		{`uuid`, []interface{}{uuid.New()}},
+		// xml
+	}
+
+	ctx, info, cancel := sinktest.Context()
+	defer cancel()
+	crdbPool := info.Pool()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	pgPool, cancel, err := setupPGPool(dbName)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Create a dummy table for each type
+	tgts := make([]ident.Table, len(tcs))
+	for idx, tc := range tcs {
+		tgt := ident.NewTable(dbName, ident.Public, ident.New(fmt.Sprintf("tgt_%s_%d", tc.name, idx)))
+		tgts[idx] = tgt
+
+		// Create the schema in both locations.
+		var schema = fmt.Sprintf("CREATE TABLE %s (k INT PRIMARY KEY, v %s)",
+			tgt, tc.name)
+		if _, err := pgPool.Exec(ctx, schema); !a.NoErrorf(err, "PG %s", tc.name) {
+			return
+		}
+		if _, err := crdbPool.Exec(ctx, schema); !a.NoErrorf(err, "CRDB %s", tc.name) {
+			return
+		}
+
+		// Insert dummy data into the source in a single transaction.
+		tx, err := pgPool.Begin(ctx)
+		if !a.NoError(err) {
+			return
+		}
+
+		for valIdx, value := range tc.values {
+			if _, err := tx.Exec(ctx,
+				fmt.Sprintf(`INSERT INTO %s VALUES ($1, $2::%s)`, tgt, tc.name), valIdx, value,
+			); !a.NoErrorf(err, "%s %d %s", tc.name, valIdx, value) {
+				return
+			}
+		}
+
+		// Also insert a null value.
+		if _, err := tx.Exec(ctx,
+			fmt.Sprintf(`INSERT INTO %s VALUES ($1, NULL::%s)`, tgt, tc.name), -1,
+		); !a.NoError(err) {
+			return
+		}
+
+		a.NoError(tx.Commit(ctx))
+	}
+	log.Info(tgts)
+
+	// Start the connection, to demonstrate that we can backfill pending mutations.
+	connCtx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn()
+	_, stopped, err := NewConn(connCtx, &Config{
+		Publication: dbName.Raw(),
+		Slot:        dbName.Raw(),
+		SourceConn:  *pgConnString + dbName.Raw(),
+		TargetConn:  crdbPool.Config().ConnString(),
+		TargetDB:    dbName,
+	})
+	if !a.NoError(err) {
+		return
+	}
+
+	// Wait for rows to show up.
+	for idx, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			var count int
+			for count == 0 {
+				if err := crdbPool.QueryRow(ctx,
+					fmt.Sprintf("SELECT count(*) FROM %s", tgts[idx])).Scan(&count); !a.NoError(err) {
+					return
+				}
+				if count == 0 {
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+			// Expect the test data and a row with a NULL value.
+			a.Equalf(len(tc.values)+1, count, "mismatch in %s", tgts[idx])
+		})
+	}
+
+	cancelConn()
+	select {
+	case <-stopped:
+	case <-ctx.Done():
+	}
+}
+
+func setupPGPool(database ident.Ident) (*pgxpool.Pool, func(), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	baseConn, err := pgxpool.Connect(ctx, *pgConnString)
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	if _, err := baseConn.Exec(ctx,
+		fmt.Sprintf("CREATE DATABASE %s", database),
+	); err != nil {
+		return nil, func() {}, err
+	}
+
+	// Open the pool, using the newly-created database.
+	next := baseConn.Config().Copy()
+	next.ConnConfig.Database = database.Raw()
+	retConn, err := pgxpool.ConnectConfig(ctx, next)
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	if _, err := retConn.Exec(ctx,
+		fmt.Sprintf("CREATE PUBLICATION %s FOR ALL TABLES", database),
+	); err != nil {
+		return nil, func() {}, err
+	}
+
+	if _, err := retConn.Exec(ctx,
+		"SELECT pg_create_logical_replication_slot($1, 'pgoutput')",
+		database.Raw(),
+	); err != nil {
+		return nil, func() {}, err
+	}
+
+	return retConn, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, err := retConn.Exec(ctx, "SELECT pg_drop_replication_slot($1)", database.Raw())
+		if err != nil {
+			log.WithError(err).Error("could not drop database")
+		}
+		_, err = retConn.Exec(ctx, fmt.Sprintf("DROP PUBLICATION %s", database))
+		if err != nil {
+			log.WithError(err).Error("could not drop publication")
+		}
+		retConn.Close()
+
+		// Can't drop the default database from its own connection.
+		_, err = baseConn.Exec(ctx, fmt.Sprintf("DROP DATABASE %s", database))
+		if err != nil {
+			log.WithError(err).Error("could not drop database")
+		}
+		baseConn.Close()
+		log.Trace("finished pg pool cleanup")
+	}, nil
+}

--- a/internal/source/pglogical/metrics.go
+++ b/internal/source/pglogical/metrics.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pglogical
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	commitCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_commit_total",
+		Help: "the number transactions from the source database that were applied",
+	})
+	commitTime = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pglogical_last_commit_seconds",
+		Help: "the original time of the most recently applied commit from the source database",
+	})
+	dialFailureCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_dial_failure_total",
+		Help: "the number of times we failed to create a replication connection",
+	})
+	dialSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_dial_success_total",
+		Help: "the number of times we successfully dialed a replication connection",
+	})
+	lsnOffset = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pglogical_lsn_offset_bytes",
+		Help: "the LSN offset that we are reporting to the source database",
+	})
+)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/cmd/mkjwt"
+	"github.com/cockroachdb/cdc-sink/internal/cmd/pglogical"
 	"github.com/cockroachdb/cdc-sink/internal/cmd/start"
 	"github.com/cockroachdb/cdc-sink/internal/cmd/version"
 	joonix "github.com/joonix/log"
@@ -86,6 +87,7 @@ func main() {
 
 	root.AddCommand(
 		mkjwt.Command(),
+		pglogical.Command(),
 		start.Command(),
 		version.Command(),
 	)


### PR DESCRIPTION
This change adds support for consuming a postgres logical replication feed. The
general approach is to convert the feed messages into the canonical
types.Mutation message and reuse the stage-and-apply approach to keep
transaction sizes bounded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/91)
<!-- Reviewable:end -->
