### PR TITLE
pglogical: Add delay between retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Flags:
       --immediate                apply data without waiting for transaction boundaries
       --metricsAddr string       a host:port to serve metrics from at /_/varz
       --publicationName string   the publication within the source database to replicate
+      --retryDelay duration      the amount of time to sleep between replication retries (default 10s)
       --slotName string          the replication slot in the source database (default "cdc_sink")
       --sourceConn string        the source database's connection string
       --targetConn string        the target cluster's connection string

--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -15,6 +15,7 @@ package pglogical
 import (
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -54,6 +55,8 @@ func Command() *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&cfg.Immediate, "immediate", false, "apply data without waiting for transaction boundaries")
 	f.StringVar(&metricsAddr, "metricsAddr", "", "a host:port to serve metrics from at /_/varz")
+	f.DurationVar(&cfg.RetryDelay, "retryDelay", 10*time.Second,
+		"the amount of time to sleep between replication retries")
 	f.StringVar(&cfg.Slot, "slotName", "cdc_sink", "the replication slot in the source database")
 	f.StringVar(&cfg.SourceConn, "sourceConn", "", "the source database's connection string")
 	f.StringVar(&cfg.TargetConn, "targetConn", "", "the target cluster's connection string")

--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -10,7 +10,13 @@
 
 package pglogical
 
-import "github.com/cockroachdb/cdc-sink/internal/util/ident"
+import (
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+const defaultRetryDelay = 10 * time.Second
 
 // Config contains the configuration necessary for creating a
 // replication connection. All field, other than TestControls, are
@@ -25,6 +31,9 @@ type Config struct {
 	Slot string
 	// Connection string for the source db.
 	SourceConn string
+	// The amount of time to sleep between replication-loop retries.
+	// If zero, a default value will be used.
+	RetryDelay time.Duration
 	// Connection string for the target cluster.
 	TargetConn string
 	// The SQL database in the target cluster to write into.

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -93,6 +93,7 @@ func testPGLogical(t *testing.T, immediate bool) {
 	_, stopped, err := NewConn(connCtx, &Config{
 		Immediate:   immediate,
 		Publication: dbName.Raw(),
+		RetryDelay:  time.Nanosecond,
 		Slot:        dbName.Raw(),
 		SourceConn:  *pgConnString + dbName.Raw(),
 		TargetConn:  crdbPool.Config().ConnString(),
@@ -200,6 +201,7 @@ func TestChaos(t *testing.T) {
 		Publication: dbName.Raw(),
 		Slot:        dbName.Raw(),
 		SourceConn:  *pgConnString + dbName.Raw(),
+		RetryDelay:  time.Nanosecond,
 		TargetConn:  crdbPool.Config().ConnString(),
 		TargetDB:    dbName,
 		TestControls: &TestControls{
@@ -370,6 +372,7 @@ func TestDataTypes(t *testing.T) {
 	defer cancelConn()
 	_, stopped, err := NewConn(connCtx, &Config{
 		Publication: dbName.Raw(),
+		RetryDelay:  time.Nanosecond,
 		Slot:        dbName.Raw(),
 		SourceConn:  *pgConnString + dbName.Raw(),
 		TargetConn:  crdbPool.Config().ConnString(),


### PR DESCRIPTION
This changes adds a configurable, ten-second delay between restarting the
replication loop. This prevents excessive logging when, for example, there is a
schema mismatch between the source and target tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/94)
<!-- Reviewable:end -->
