### PR TITLE
workflows: Add go mod download to builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,14 +34,10 @@ jobs:
       - name: Go Build Cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.cache.outputs.go-build }}
-          key: ${{ runner.os }}-quality-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.cache.outputs.go-mod }}
-          key: ${{ runner.os }}-quality-mod-${{ hashFiles('**/go.sum') }}
+          path: |
+            ${{ steps.cache.outputs.go-build }}
+            ${{ steps.cache.outputs.go-mod }}
+          key: ${{ runner.os }}-quality-${{ hashFiles('**/go.sum') }}
 
       # This action should, in general, be a no-op, given the cache above.
       - name: Download all deps
@@ -89,14 +85,10 @@ jobs:
       - name: Go Build Cache
         uses: actions/cache@v2
         with:
-          path: ${{ steps.cache.outputs.go-build }}
-          key: ${{ runner.os }}-integration-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.cache.outputs.go-mod }}
-          key: ${{ runner.os }}-integration-mod-${{ hashFiles('**/go.sum') }}
+          path: |
+            ${{ steps.cache.outputs.go-build }}
+            ${{ steps.cache.outputs.go-mod }}
+          key: ${{ runner.os }}-integration-${{ hashFiles('**/go.sum') }}
 
       # This action should, in general, be a no-op, given the cache above.
       - name: Download all deps

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,10 @@ jobs:
           path: ${{ steps.cache.outputs.go-mod }}
           key: ${{ runner.os }}-quality-mod-${{ hashFiles('**/go.sum') }}
 
+      # This action should, in general, be a no-op, given the cache above.
+      - name: Download all deps
+        run: go mod download
+
       - name: crlfmt returns no deltas
         if: ${{ always() }}
         run: |
@@ -93,6 +97,10 @@ jobs:
         with:
           path: ${{ steps.cache.outputs.go-mod }}
           key: ${{ runner.os }}-integration-mod-${{ hashFiles('**/go.sum') }}
+
+      # This action should, in general, be a no-op, given the cache above.
+      - name: Download all deps
+        run: go mod download
 
       - name: Start CockroachDB
         working-directory: .github


### PR DESCRIPTION
This build step will ensure that all referenced go modules will be downloaded
as part of the build. This ensures that when we send the go caches to the
GitHub workflows cache, they're complete, at least with respect to modules
used.  The GitHub cache key is based on the contents of the go.sum file and the
cache contents are only ever sent to the cache server once; you can't update an
existing cache key. This can create an opportunity for unnecessary re-downloads
if the build rules change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/96)
<!-- Reviewable:end -->
