### PR TITLE
apply: Log target table in delete drift message

### DIFF
--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -174,11 +174,13 @@ func (a *apply) deleteLocked(ctx context.Context, db pgxtype.Querier, muts []typ
 
 		if len(args) != len(a.mu.pks) {
 			return errors.Errorf(
-				"schema drift detected: "+
-					"inconsistent number of key colums: "+
+				"schema drift detected in %s: "+
+					"inconsistent number of key columns: "+
 					"received %d expect %d: "+
 					"key %s@%s",
-				len(args), len(a.mu.pks), string(muts[i].Key), muts[i].Time)
+				a.target,
+				len(args), len(a.mu.pks),
+				string(muts[i].Key), muts[i].Time)
 		}
 		allArgs = append(allArgs, args...)
 	}


### PR DESCRIPTION
The log message when a delete message cannot be applied due to schema drift
does not include the target table. This commit remedies that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/98)
<!-- Reviewable:end -->
