### PR TITLE
schemawatch: Improved PK query.

### DIFF
--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -52,6 +52,11 @@ func TestGetColumns(t *testing.T) {
 			nil,
 		},
 		{
+			"a INT, b INT",
+			[]string{"rowid"},
+			[]string{"a", "b"},
+		},
+		{
 			"a INT, b INT, PRIMARY KEY (a,b)",
 			[]string{"a", "b"},
 			nil,
@@ -83,6 +88,36 @@ func TestGetColumns(t *testing.T) {
 				"PRIMARY KEY (a,b)",
 			primaryKeys: []string{"a", "b"},
 			dataCols:    []string{"ignored_c"},
+		},
+		// Ensure that the PK constraint may have an arbitrary name.
+		{
+			"a INT, b INT, CONSTRAINT foobar_pk PRIMARY KEY (a,b)",
+			[]string{"a", "b"},
+			nil,
+		},
+		// Check non-interference from secondary index.
+		{
+			"a INT, b INT, q INT, c INT, r INT, PRIMARY KEY (b,a,c), INDEX (c,a,b)",
+			[]string{"b", "a", "c"},
+			[]string{"q", "r"},
+		},
+		// Check non-interference from unique secondary index.
+		{
+			"a INT, b INT, q INT, c INT, r INT, PRIMARY KEY (b,a,c), UNIQUE INDEX (c,a,b)",
+			[]string{"b", "a", "c"},
+			[]string{"q", "r"},
+		},
+		// Check no-PK, but with a secondary index.
+		{
+			"a INT, b INT, q INT, c INT, r INT, INDEX (c,a,b)",
+			[]string{"rowid"},
+			[]string{"a", "b", "c", "q", "r"},
+		},
+		// Check no-PK, but with a unique secondary index.
+		{
+			"a INT, b INT, q INT, c INT, r INT, UNIQUE INDEX (c,a,b)",
+			[]string{"rowid"},
+			[]string{"a", "b", "c", "q", "r"},
 		},
 	}
 


### PR DESCRIPTION
This change makes the schema query work properly in cases where the primary key
constraint isn't named "primary". It also adds some additional test cases to
ensure that the revised query works correctly when there are secondary indexes
on the table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/103)
<!-- Reviewable:end -->
