### PR TITLE
timekeeper: Improve throughput.

### DIFF
--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -53,10 +53,11 @@ func testHandler(t *testing.T, immediate bool) {
 		return
 	}
 
-	swapper, err := timekeeper.NewTimeKeeper(ctx, dbInfo.Pool(), Resolved)
+	swapper, cancel, err := timekeeper.NewTimeKeeper(ctx, dbInfo.Pool(), Resolved)
 	if !a.NoError(err) {
 		return
 	}
+	defer cancel()
 
 	watchers, cancel := schemawatch.NewWatchers(dbInfo.Pool())
 	defer cancel()

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -175,7 +175,7 @@ func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struc
 		return nil, nil, errors.Wrap(err, "could not connect to CockroachDB")
 	}
 
-	timeKeeper, err := timekeeper.NewTimeKeeper(ctx, targetPool, cdc.Resolved)
+	timeKeeper, cancelTimeKeeper, err := timekeeper.NewTimeKeeper(ctx, targetPool, cdc.Resolved)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -210,6 +210,7 @@ func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struc
 		_ = ret.run(ctx)
 		cancelAppliers()
 		cancelWatchers()
+		cancelTimeKeeper()
 		targetPool.Close()
 		close(stopper)
 	}()

--- a/internal/source/server/server.go
+++ b/internal/source/server/server.go
@@ -105,7 +105,7 @@ func newServer(
 		return nil, nil, errors.Wrap(err, "could not connect to CockroachDB")
 	}
 
-	swapper, err := timekeeper.NewTimeKeeper(ctx, pool, cdc.Resolved)
+	swapper, cancelTimeKeeper, err := timekeeper.NewTimeKeeper(ctx, pool, cdc.Resolved)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -182,6 +182,7 @@ func newServer(
 		cancelAuth()
 		cancelAppliers()
 		cancelWatchers()
+		cancelTimeKeeper()
 		pool.Close()
 		log.Info("server shutdown complete")
 	}()


### PR DESCRIPTION
This change updates the PK structure of the resolved table to include the
timing data. This allows us to always append new values to distinct PK rows, so
we don't need to read though older MVCC data from previous resolved timestamps.

An out-of-band cleanup process is added to retire older resolved timestamps.

The benchmark shows a 10x improvement on my laptop, using an in-memory CRDB
store.