### PR TITLE
Order mutations to satisfy FK constraints

### DIFF
--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/target/apply/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -58,9 +59,10 @@ type Handler struct {
 	Appliers      types.Appliers      // Update tables within TargetDb.
 	Authenticator types.Authenticator // Access checks.
 	Pool          *pgxpool.Pool       // Access to the target cluster.
-	Stores        types.Stagers       // Record incoming json blobs.
-	Swapper       types.TimeKeeper    // Tracks named timestamps.
-	Watchers      types.Watchers      // Schema data.
+	Sequencer     sequencer.Sequencer
+	Stores        types.Stagers    // Record incoming json blobs.
+	Swapper       types.TimeKeeper // Tracks named timestamps.
+	Watchers      types.Watchers   // Schema data.
 }
 
 // A request is configured by the various parseURL methods in Handler.

--- a/internal/source/cdc/resolved.go
+++ b/internal/source/cdc/resolved.go
@@ -19,11 +19,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/target/apply/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // Resolved is the name of table that we track resolved timestamps in.
@@ -117,64 +119,24 @@ func (h *Handler) resolved(ctx context.Context, req *request) error {
 		if err != nil {
 			return err
 		}
-		// Get the tables to process, sorted based on the FK constraints
-		targetTables := watcher.Snapshot().TablesSortedByFK
-		stores := make([]types.Stager, 0, len(targetTables))
-		appliers := make([]types.Applier, 0, len(targetTables))
-		deletes := make([][]types.Mutation, 0, len(targetTables))
-		// Prepare to merge data.
-		for _, table := range targetTables {
-			if table.AsSchema() == target {
-				store, err := h.Stores.Get(ctx, table)
-				if err != nil {
-					return err
-				}
-				stores = append(stores, store)
-				applier, err := h.Appliers.Get(ctx, table, req.casColumns, req.deadlines)
-				if err != nil {
-					return err
-				}
-				appliers = append(appliers, applier)
+
+		allTables := watcher.Snapshot().TablesSortedByFK
+		targetTables := make([]ident.Table, 0, len(allTables))
+		for _, tbl := range allTables {
+			if tbl.AsSchema() == target {
+				targetTables = append(targetTables, tbl)
 			}
 		}
-
-		prev, err := h.Swapper.Put(ctx, tx, target, req.timestamp)
+		target := sequencer.Target{
+			Tables:         targetTables,
+			CasColumns:     nil,
+			Deadlines:      types.Deadlines{},
+			CheckTimestamp: true,
+		}
+		err = h.Sequencer.Apply(ctx, tx, target, req.timestamp)
 		if err != nil {
+			log.Error(err)
 			return err
-		}
-
-		if hlc.Compare(req.timestamp, prev) < 0 {
-			return errors.Errorf(
-				"resolved timestamp went backwards: received %s had %s",
-				req.timestamp, prev)
-		}
-		// To support FK constraints in the target, process upserts first,
-		// and accumulate deletes.
-		for i := range stores {
-			muts, err := stores[i].Drain(ctx, tx, prev, req.timestamp)
-			if err != nil {
-				return err
-			}
-			dmuts := make([]types.Mutation, 0, len(muts))
-			umuts := make([]types.Mutation, 0, len(muts))
-			for _, m := range muts {
-				if m.IsDelete() {
-					dmuts = append(dmuts, m)
-				} else {
-					umuts = append(umuts, m)
-				}
-			}
-			deletes = append(deletes, dmuts)
-			if err := appliers[i].Apply(ctx, tx, umuts); err != nil {
-				return err
-			}
-		}
-		// Delete must be processed in the opposite order
-		for i := len(deletes) - 1; i >= 0; i-- {
-			dmuts := deletes[i]
-			if err := appliers[i].Apply(ctx, tx, dmuts); err != nil {
-				return err
-			}
 		}
 		return tx.Commit(ctx)
 	})

--- a/internal/target/apply/sequencer/sequencer.go
+++ b/internal/target/apply/sequencer/sequencer.go
@@ -1,0 +1,118 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package sequencer applies mutation sequentially, in a transactional consistent order.
+package sequencer
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/jackc/pgtype/pgxtype"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// A Sequencer uses the given stagers and appliers to drain mutations from the
+// staging area and apply them to the target tables.
+// It keeps track of timestamps, on a schema basis, to insure that mutations
+// are applied to satisty a transactional consistent order.
+type Sequencer struct {
+	appliers   types.Appliers
+	stagers    types.Stagers
+	timeKeeper types.TimeKeeper
+}
+
+// Target specifies the tables destinations of the mutations, as well as
+// additional settings for Compare and Set or Deadline operation modes.
+type Target struct {
+	Tables         []ident.Table
+	CasColumns     []ident.Ident
+	Deadlines      types.Deadlines
+	CheckTimestamp bool
+}
+
+// New creates a new Sequencer.
+func New(a types.Appliers, s types.Stagers, t types.TimeKeeper) Sequencer {
+	return Sequencer{
+		appliers:   a,
+		stagers:    s,
+		timeKeeper: t,
+	}
+}
+
+// Apply applies the mutations associated with the target.
+// Upserts are applied first, in the order specified in the Target array.
+// Deletes are applied in reverse order.
+func (s *Sequencer) Apply(
+	ctx context.Context, tx pgxtype.Querier, target Target, txTime hlc.Time,
+) error {
+
+	schemaStartTimes := make(map[ident.Schema]hlc.Time, len(target.Tables))
+	for _, tbl := range target.Tables {
+		schema := tbl.AsSchema()
+		if _, found := schemaStartTimes[schema]; found {
+			continue
+		}
+		prev, err := s.timeKeeper.Put(ctx, tx, tbl.AsSchema(), txTime)
+		if err != nil {
+			return err
+		}
+		if target.CheckTimestamp && hlc.Compare(txTime, prev) < 0 {
+			return errors.Errorf(
+				"resolved timestamp went backwards: received %s had %s",
+				txTime, prev)
+		}
+		schemaStartTimes[schema] = prev
+		log.Tracef("committing %s %s -> %s", schema, prev, txTime)
+	}
+	deletes := make([][]types.Mutation, 0, len(target.Tables))
+	appliers := make([]types.Applier, 0, len(target.Tables))
+	for _, tbl := range target.Tables {
+		prev := schemaStartTimes[tbl.AsSchema()]
+		stage, err := s.stagers.Get(ctx, tbl)
+		if err != nil {
+			return err
+		}
+		muts, err := stage.Drain(ctx, tx, prev, txTime)
+		if err != nil {
+			return err
+		}
+		dmuts := make([]types.Mutation, 0, len(muts))
+		umuts := make([]types.Mutation, 0, len(muts))
+
+		for _, m := range muts {
+			if m.IsDelete() {
+				dmuts = append(dmuts, m)
+			} else {
+				umuts = append(umuts, m)
+			}
+		}
+
+		app, err := s.appliers.Get(ctx, tbl, target.CasColumns, target.Deadlines)
+		deletes = append(deletes, dmuts)
+		appliers = append(appliers, app)
+		if err != nil {
+			return err
+		}
+		if err := app.Apply(ctx, tx, umuts); err != nil {
+			return err
+		}
+	}
+	for i := len(deletes) - 1; i >= 0; i-- {
+		dmuts := deletes[i]
+		if err := appliers[i].Apply(ctx, tx, dmuts); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -100,16 +100,30 @@ func TestWatch(t *testing.T) {
 	a.Error(err)
 }
 
-func createTableStatement(refs ...sinktest.TableInfo) string {
+func createTableSimplePKStatement(refs ...sinktest.TableInfo) string {
 	stm := "CREATE TABLE %s (pk INT PRIMARY KEY "
 	for i, ref := range refs {
 		stm += ", fk_" + strconv.Itoa(i) + " INT REFERENCES " + ref.Name().String() + " (pk) "
 	}
 	stm += ")"
-	fmt.Println(stm)
 	return stm
 }
-func TestWatchFK(t *testing.T) {
+
+func createTableComposityPKStatement(refs ...sinktest.TableInfo) string {
+	stm := "CREATE TABLE %s (pk1 INT, pk2 INT,  CONSTRAINT pk PRIMARY KEY (pk1, pk2) "
+	for i := range refs {
+		stm += ", fk1_" + strconv.Itoa(i) + " INT "
+		stm += ", fk2_" + strconv.Itoa(i) + " INT "
+	}
+	for i, ref := range refs {
+		stm += ", CONSTRAINT fk_ref_" + strconv.Itoa(i) +
+			" FOREIGN KEY (" + " fk1_" + strconv.Itoa(i) + ", fk2_" + strconv.Itoa(i) + ")" +
+			" REFERENCES " + ref.Name().String() + " (pk1, pk2) "
+	}
+	stm += ")"
+	return stm
+}
+func TestWatchSimpleFK(t *testing.T) {
 	a := assert.New(t)
 	*RefreshDelay = time.Second
 	defer func() { *RefreshDelay = time.Minute }()
@@ -129,31 +143,30 @@ func TestWatchFK(t *testing.T) {
 	// Level 2. T3 -> T1,T2
 	// Level 3. T4 -> T1,T2,T3 ; T5 -> T1, T3
 	// Level 4. T6 -> T5
-	tbl1, err := sinktest.CreateTable(ctx, dbName, createTableStatement())
+	tbl1, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement())
 	if !a.NoError(err) {
 		return
 	}
 
-	tbl2, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1))
+	tbl2, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1))
 	if !a.NoError(err) {
 		return
 	}
 
-	tbl3, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1, tbl2))
+	tbl3, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1, tbl2))
 	if !a.NoError(err) {
 		return
 	}
 
-	tbl4, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1, tbl2, tbl3))
+	tbl4, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1, tbl2, tbl3))
 	if !a.NoError(err) {
 		return
 	}
-
-	tbl5, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1, tbl3))
+	tbl5, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1, tbl3))
 	if !a.NoError(err) {
 		return
 	}
-	tbl6, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl5))
+	tbl6, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl5))
 	if !a.NoError(err) {
 		return
 	}
@@ -167,14 +180,138 @@ func TestWatchFK(t *testing.T) {
 
 	snapshot := w.Snapshot()
 	tables := snapshot.TablesSortedByFK
-	// Expected T1, T2, T3,  T4 or T5, T5 or T4 , T6
+	var level3T1, level3T2 sinktest.TableInfo
+	if tbl4.String() < tbl5.String() {
+		level3T1, level3T2 = tbl4, tbl5
+	} else {
+		level3T1, level3T2 = tbl5, tbl4
+	}
 	a.Equal(6, len(tables))
-	tbl4Otbl5 := []string{tbl4.String(), tbl5.String()}
 	a.Equal(tbl1.String(), tables[0].String())
 	a.Equal(tbl2.String(), tables[1].String())
 	a.Equal(tbl3.String(), tables[2].String())
-	a.Contains(tbl4Otbl5, tables[3].String())
-	a.Contains(tbl4Otbl5, tables[4].String())
+	a.Equal(level3T1.String(), tables[3].String())
+	a.Equal(level3T2.String(), tables[4].String())
 	a.Equal(tbl6.String(), tables[5].String())
+}
+func TestWatchCompositeFK(t *testing.T) {
+	a := assert.New(t)
+	*RefreshDelay = time.Second
+	defer func() { *RefreshDelay = time.Minute }()
+
+	ctx, dbInfo, cancel := sinktest.Context()
+	defer cancel()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Tables
+	// Level 0. T1
+	// Level 1. T2 -> T1
+	// Level 2. T3 -> T1,T2
+	// Level 3. T4 -> T1,T2,T3 ; T5 -> T1, T3
+	// Level 4. T6 -> T5
+	tbl1, err := sinktest.CreateTable(ctx, dbName, createTableComposityPKStatement())
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl2, err := sinktest.CreateTable(ctx, dbName, createTableComposityPKStatement(tbl1))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl3, err := sinktest.CreateTable(ctx, dbName, createTableComposityPKStatement(tbl1, tbl2))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl4, err := sinktest.CreateTable(ctx, dbName, createTableComposityPKStatement(tbl1, tbl2, tbl3))
+	if !a.NoError(err) {
+		return
+	}
+	tbl5, err := sinktest.CreateTable(ctx, dbName, createTableComposityPKStatement(tbl1, tbl3))
+	if !a.NoError(err) {
+		return
+	}
+	tbl6, err := sinktest.CreateTable(ctx, dbName, createTableComposityPKStatement(tbl5))
+	if !a.NoError(err) {
+		return
+	}
+
+	w, cancel, err := newWatcher(ctx, dbInfo.Pool(), dbName)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+	a.Equal(time.Second, w.delay)
+
+	snapshot := w.Snapshot()
+	tables := snapshot.TablesSortedByFK
+	var level3T1, level3T2 sinktest.TableInfo
+	if tbl4.String() < tbl5.String() {
+		level3T1, level3T2 = tbl4, tbl5
+	} else {
+		level3T1, level3T2 = tbl5, tbl4
+	}
+	a.Equal(6, len(tables))
+	a.Equal(tbl1.String(), tables[0].String())
+	a.Equal(tbl2.String(), tables[1].String())
+	a.Equal(tbl3.String(), tables[2].String())
+	a.Equal(level3T1.String(), tables[3].String())
+	a.Equal(level3T2.String(), tables[4].String())
+	a.Equal(tbl6.String(), tables[5].String())
+}
+
+func TestWatchFKLoop(t *testing.T) {
+	a := assert.New(t)
+	*RefreshDelay = time.Second
+	defer func() { *RefreshDelay = time.Minute }()
+
+	ctx, dbInfo, cancel := sinktest.Context()
+	defer cancel()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Tables
+	// Level 0. T1 -> T4
+	// Level 1. T2 -> T1
+	// Level 2. T3 -> T1,T2
+	// Level 3. T4 -> T1,T2,T3
+	tbl1, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement())
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl2, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl3, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1, tbl2))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl4, err := sinktest.CreateTable(ctx, dbName, createTableSimplePKStatement(tbl1, tbl2, tbl3))
+	if !a.NoError(err) {
+		return
+	}
+
+	err = tbl1.Exec(ctx, "ALTER TABLE %s ADD COLUMN fk INT REFERENCES "+tbl4.String()+"(pk)")
+	if !a.NoError(err) {
+		return
+	}
+
+	_, _, err = newWatcher(ctx, dbInfo.Pool(), dbName)
+
+	a.EqualError(err, "detected cycle in FK references")
 
 }

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -12,6 +12,7 @@ package schemawatch
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -97,4 +98,83 @@ func TestWatch(t *testing.T) {
 	a.Nil(ch)
 	a.Nil(cancel)
 	a.Error(err)
+}
+
+func createTableStatement(refs ...sinktest.TableInfo) string {
+	stm := "CREATE TABLE %s (pk INT PRIMARY KEY "
+	for i, ref := range refs {
+		stm += ", fk_" + strconv.Itoa(i) + " INT REFERENCES " + ref.Name().String() + " (pk) "
+	}
+	stm += ")"
+	fmt.Println(stm)
+	return stm
+}
+func TestWatchFK(t *testing.T) {
+	a := assert.New(t)
+	*RefreshDelay = time.Second
+	defer func() { *RefreshDelay = time.Minute }()
+
+	ctx, dbInfo, cancel := sinktest.Context()
+	defer cancel()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Tables
+	// Level 0. T1
+	// Level 1. T2 -> T1
+	// Level 2. T3 -> T1,T2
+	// Level 3. T4 -> T1,T2,T3 ; T5 -> T1, T3
+	// Level 4. T6 -> T5
+	tbl1, err := sinktest.CreateTable(ctx, dbName, createTableStatement())
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl2, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl3, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1, tbl2))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl4, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1, tbl2, tbl3))
+	if !a.NoError(err) {
+		return
+	}
+
+	tbl5, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl1, tbl3))
+	if !a.NoError(err) {
+		return
+	}
+	tbl6, err := sinktest.CreateTable(ctx, dbName, createTableStatement(tbl5))
+	if !a.NoError(err) {
+		return
+	}
+
+	w, cancel, err := newWatcher(ctx, dbInfo.Pool(), dbName)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+	a.Equal(time.Second, w.delay)
+
+	snapshot := w.Snapshot()
+	tables := snapshot.TablesSortedByFK
+	// Expected T1, T2, T3,  T4 or T5, T5 or T4 , T6
+	a.Equal(6, len(tables))
+	tbl4Otbl5 := []string{tbl4.String(), tbl5.String()}
+	a.Equal(tbl1.String(), tables[0].String())
+	a.Equal(tbl2.String(), tables[1].String())
+	a.Equal(tbl3.String(), tables[2].String())
+	a.Contains(tbl4Otbl5, tables[3].String())
+	a.Contains(tbl4Otbl5, tables[4].String())
+	a.Equal(tbl6.String(), tables[5].String())
+
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -100,9 +100,9 @@ type TableSchema struct {
 }
 
 // DatabaseTables maintains the tables in a database.
-// The TablesSortedByFK field holds the tables in an order that satisfies FK constraints.
 type DatabaseTables struct {
-	Tables           map[ident.Table]TableSchema
+	Tables map[ident.Table]TableSchema
+	// The TablesSortedByFK field holds the tables in an order that satisfies FK constraints.
 	TablesSortedByFK []ident.Table
 }
 
@@ -118,8 +118,7 @@ type Watcher interface {
 	Refresh(context.Context, pgxtype.Querier) error
 	// Snapshot returns the tables known to be part of a database.
 	Snapshot() DatabaseTables
-	// Watch returns a channel that emits updated column data for the
-	// given table.  The channel will be closed if there
+	// Snapshot returns the tables known to be part of a database.
 	Watch(table ident.Table) (_ <-chan []ColData, cancel func(), _ error)
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -94,6 +94,18 @@ type ColData struct {
 	Type    string
 }
 
+// TableSchema maintains the columns in a table.
+type TableSchema struct {
+	Columns []ColData
+}
+
+// DatabaseTables maintains the tables in a database.
+// The TablesSortedByFK field holds the tables in an order that satisfies FK constraints.
+type DatabaseTables struct {
+	Tables           map[ident.Table]TableSchema
+	TablesSortedByFK []ident.Table
+}
+
 // Watcher allows table metadata to be observed.
 //
 // The methods in this type return column data such that primary key
@@ -104,9 +116,8 @@ type Watcher interface {
 	// for updated schema information. This is intended for testing and
 	// does not need to be called in the general case.
 	Refresh(context.Context, pgxtype.Querier) error
-	// Snapshot returns the tables known to be part of the given
-	// user-defined schema.
-	Snapshot(in ident.Schema) map[ident.Table][]ColData
+	// Snapshot returns the tables known to be part of a database.
+	Snapshot() DatabaseTables
 	// Watch returns a channel that emits updated column data for the
 	// given table.  The channel will be closed if there
 	Watch(table ident.Table) (_ <-chan []ColData, cancel func(), _ error)


### PR DESCRIPTION
To allow users to specify FK constraints in the target database,  when using stage-and-apply method, we order the mutations based on FK constraints.  

Summary of changes:

- types:   adding DatabaseTables, TableSchema; 
changed Watcher.Snapshot() to return all the tables in a database.

- watcher: getting tables and sorting them based on FK constraints.
 level 0 tables don't have any dependencies.
 level n+1 tables depends on tables in level n (at least one table in this level) or lower.

- pglogical, cdc (stage and apply)
upserts are done first, in level order;
deletes are done last, in reverse level order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/109)
<!-- Reviewable:end -->
