### PR TITLE
pglogical: Improve throughput via concurrency.

### DIFF
--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -22,7 +22,7 @@ const defaultRetryDelay = 10 * time.Second
 // replication connection. All field, other than TestControls, are
 // mandatory.
 type Config struct {
-	// Place the configuration into immediate mode, where mutations are
+	// Place the configuration into fan mode, where mutations are
 	// applied without waiting for transaction boundaries.
 	Immediate bool
 	// The name of the publication to attach to.

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -21,18 +21,19 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/apply/fan"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
-	"github.com/cockroachdb/cdc-sink/internal/target/stage"
 	"github.com/cockroachdb/cdc-sink/internal/target/timekeeper"
 	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/cockroachdb/cdc-sink/internal/util/retry"
+	"github.com/cockroachdb/cdc-sink/internal/util/serial"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
 	"github.com/google/uuid"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgproto3/v2"
+	"github.com/jackc/pgtype/pgxtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -40,21 +41,25 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// lsnStamp adapts the LSN offset type to a comparable Stamp value.
+type lsnStamp pglogrepl.LSN
+
+func (s lsnStamp) Less(other stamp.Stamp) bool {
+	o := other.(lsnStamp)
+	return s < o
+}
+
 // A Conn encapsulates all wire-connection behavior. It is
 // responsible for receiving replication messages and replying with
 // status updates.
 type Conn struct {
-	// Apply mutations to the backing store.
-	appliers types.Appliers
 	// Columns, as ordered by the source database.
 	columns map[ident.Table][]types.ColData
-	// Tables that need to be drained.
-	dirty     map[ident.Table]struct{}
-	immediate bool
-	// Batches of mutations to stage.
-	pending map[ident.Table][]types.Mutation
-	// Callbacks to release the slices in pending.
-	pendingReleases []func()
+	// The fan manages the fan-out of applying mutations across multiple
+	// SQL connections.
+	fan *fan.Fan
+	// Locked on mu.
+	logPosUpdated *sync.Cond
 	// The pg publication name to subscribe to.
 	publicationName string
 	// Map source ids to target tables.
@@ -62,20 +67,22 @@ type Conn struct {
 	// The amount of time to sleep between retries of the replication
 	// loop.
 	retryDelay time.Duration
-	// Stage mutations in the backing store.
-	stagers types.Stagers
+	// Allows us to force the concurrent applier logic to concentrate
+	// its work into a single underlying database transaction. This will
+	// be nil when running in the default, concurrent, mode.
+	serializer *serial.Pool
 	// The name of the slot within the publication.
 	slotName string
 	// The configuration for opening replication connections.
 	sourceConfig *pgconn.Config
 	// The SQL database we're going to be writing into.
 	targetDB ident.Ident
-	// Connection string for the target database.
-	targetPool *pgxpool.Pool
 	// Likely nil.
 	testControls *TestControls
 	// Drain.
 	timeKeeper types.TimeKeeper
+	// The log offset of the transaction being processed.
+	txLSN pglogrepl.LSN
 	// The (eventual) commit time of the transaction being processed.
 	txTime hlc.Time
 
@@ -182,32 +189,48 @@ func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struc
 
 	watchers, cancelWatchers := schemawatch.NewWatchers(targetPool)
 	appliers, cancelAppliers := apply.NewAppliers(watchers)
-	stagers := stage.NewStagers(targetPool, ident.StagingDB)
 
 	ret := &Conn{
-		appliers:        appliers,
 		columns:         make(map[ident.Table][]types.ColData),
-		dirty:           make(map[ident.Table]struct{}),
-		immediate:       config.Immediate,
-		pending:         make(map[ident.Table][]types.Mutation),
 		publicationName: config.Publication,
 		relations:       make(map[uint32]ident.Table),
 		retryDelay:      config.RetryDelay,
 		slotName:        config.Slot,
 		sourceConfig:    sourceConfig,
-		stagers:         stagers,
 		targetDB:        config.TargetDB,
-		targetPool:      targetPool,
 		testControls:    config.TestControls,
 		timeKeeper:      timeKeeper,
 	}
+	ret.logPosUpdated = sync.NewCond(&ret.mu)
 	if ret.retryDelay == 0 {
 		ret.retryDelay = defaultRetryDelay
+	}
+
+	// If the user wants to preserve transaction boundaries, we inject a
+	// helper which forces all database operations to be applied within
+	// a single transaction.
+	var applyQuerier pgxtype.Querier = targetPool
+	applyShards := 16
+	if !config.Immediate {
+		ret.serializer = &serial.Pool{Pool: targetPool}
+		applyQuerier = ret.serializer
+		applyShards = 1
+	}
+	var cancelFan func()
+	ret.fan, cancelFan, err = fan.New(
+		appliers,
+		applyQuerier,
+		func(stamp stamp.Stamp) { ret.setLogPos(pglogrepl.LSN(stamp.(lsnStamp))) },
+		applyShards,
+	)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	stopper := make(chan struct{})
 	go func() {
 		_ = ret.run(ctx)
+		cancelFan()
 		cancelAppliers()
 		cancelWatchers()
 		cancelTimeKeeper()
@@ -218,9 +241,23 @@ func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struc
 	return ret, stopper, nil
 }
 
+// reset the connection's internal status to an idle state. This
+// will be called any time there is an error applying mutations.
+func (c *Conn) reset() {
+	c.fan.Reset()
+	c.txLSN = 0
+	c.txTime = hlc.Zero()
+	if s := c.serializer; s != nil {
+		// Don't really care about the transaction state.
+		_ = s.Rollback(context.Background())
+	}
+}
+
 // run blocks while the connection is processing messages.
 func (c *Conn) run(ctx context.Context) error {
 	for ctx.Err() == nil {
+		// Ensure that we're in a clear state when recovering.
+		c.reset()
 		group, ctx := errgroup.WithContext(ctx)
 
 		// Start a background goroutine to maintain the replication
@@ -278,6 +315,7 @@ func (c *Conn) setLogPos(pos pglogrepl.LSN) {
 	c.mu.clientXLogPos = pos
 	log.WithField("LSN", pos).Trace("updated LSN")
 	lsnOffset.Set(float64(pos))
+	c.logPosUpdated.Broadcast()
 }
 
 // decodeMutation converts the incoming tuple data into a Mutation.
@@ -339,45 +377,6 @@ func (c *Conn) decodeMutation(
 	return mut, errors.WithStack(err)
 }
 
-// flush commits all pending mutations to their respective stages or
-// applies them in immediate-mode. It will also zero-out the length of
-// the associated pending slice.
-func (c *Conn) flush(ctx context.Context, tbl ident.Table) error {
-	if ctrl := c.testControls; ctrl != nil {
-		if fn := c.testControls.BreakSinkFlush; fn != nil {
-			if fn() {
-				return errors.New("breaking sink flush for test")
-			}
-		}
-	}
-
-	found := c.pending[tbl]
-	if len(found) == 0 {
-		return nil
-	}
-
-	if c.immediate {
-		// TODO(bob): Eventually we'll have data-driven configuration.
-		app, err := c.appliers.Get(ctx, tbl, nil /* cas */, types.Deadlines{})
-		if err != nil {
-			return err
-		}
-		if err := app.Apply(ctx, c.targetPool, found); err != nil {
-			return err
-		}
-	} else {
-		stager, err := c.stagers.Get(ctx, tbl)
-		if err != nil {
-			return err
-		}
-		if err := stager.Store(ctx, c.targetPool, found); err != nil {
-			return err
-		}
-	}
-	c.pending[tbl] = found[:0]
-	return nil
-}
-
 // learn updates the source database namespace mappings.
 func (c *Conn) learn(msg *pglogrepl.RelationMessage) {
 	// The replication protocol says that we'll see these
@@ -412,75 +411,27 @@ func (c *Conn) learn(msg *pglogrepl.RelationMessage) {
 // target cluster. It will also update the WAL position that we report
 // back to the source database.
 func (c *Conn) onCommit(ctx context.Context, msg *pglogrepl.CommitMessage) error {
-	// Flush in-memory data to the staging tables.
-	for tbl := range c.pending {
-		if err := c.flush(ctx, tbl); err != nil {
-			return err
-		}
-	}
-
-	// In immediate mode, the call(s) to flush() above will have
-	// committed to the target tables. Otherwise, apply the transaction
-	// data, through the usual drain-and-apply mechanism.
-	if !c.immediate {
-		if err := retry.Retry(ctx, func(ctx context.Context) error {
-			tx, err := c.targetPool.Begin(ctx)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-			defer tx.Rollback(ctx)
-
-			// Calculate the windows of mutations to be flushed. This is
-			// tracked on a per-target-schema basis, so we probably only
-			// wind up calling TimeKeeper.Put once.
-			schemaStartTimes := make(map[ident.Schema]hlc.Time, len(c.dirty))
-			for tbl := range c.dirty {
-				schema := tbl.AsSchema()
-				if _, found := schemaStartTimes[schema]; found {
-					continue
-				}
-				prev, err := c.timeKeeper.Put(ctx, tx, tbl.AsSchema(), c.txTime)
-				if err != nil {
-					return err
-				}
-				schemaStartTimes[schema] = prev
-				log.Tracef("committing %s %s -> %s", schema, prev, c.txTime)
-			}
-
-			for tbl := range c.dirty {
-				stage, err := c.stagers.Get(ctx, tbl)
-				if err != nil {
-					return err
-				}
-
-				prev := schemaStartTimes[tbl.AsSchema()]
-				muts, err := stage.Drain(ctx, tx, prev, c.txTime)
-				if err != nil {
-					return err
-				}
-
-				app, err := c.appliers.Get(ctx, tbl, nil /* casColumns */, types.Deadlines{})
-				if err != nil {
-					return err
-				}
-
-				if err := app.Apply(ctx, tx, muts); err != nil {
-					return err
-				}
-			}
-			return tx.Commit(ctx)
-		}); err != nil {
-			return err
-		}
-	}
-
-	// Advance our high-water mark within the source's WAL,
-	// which will be reported by the keepalive loop.
-	c.setLogPos(msg.TransactionEndLSN)
-	c.reset()
 	commitCount.Inc()
 	commitTime.Set(float64(msg.CommitTime.Unix()))
-	return nil
+
+	mark := lsnStamp(msg.CommitLSN)
+	if err := c.fan.Mark(mark); err != nil {
+		return err
+	}
+
+	// If we're running in serial (as opposed to concurrent) mode, we
+	// want to wait for the pending mutations to be flushed to the
+	// single transaction, and then we'll commit it.
+	if c.serializer == nil {
+		return nil
+	}
+
+	c.mu.Lock()
+	for c.mu.clientXLogPos < msg.CommitLSN {
+		c.logPosUpdated.Wait()
+	}
+	c.mu.Unlock()
+	return c.serializer.Commit(ctx)
 }
 
 // onDataTuple will add an incoming row tuple to the in-memory slice,
@@ -506,19 +457,7 @@ func (c *Conn) onDataTuple(
 		return err
 	}
 
-	found := c.pending[tbl]
-	if found == nil {
-		next, fn := batches.Mutation()
-		c.pendingReleases = append(c.pendingReleases, fn)
-		found = next
-	}
-	found = append(found, mut)
-	c.dirty[tbl] = struct{}{}
-	c.pending[tbl] = found
-	if len(found) == cap(found) {
-		return c.flush(ctx, tbl)
-	}
-	return nil
+	return c.fan.Enqueue(ctx, lsnStamp(c.txLSN), tbl, []types.Mutation{mut})
 }
 
 // processMessages receives a sequence of logical replication messages,
@@ -532,7 +471,8 @@ func (c *Conn) processMessages(ctx context.Context, ch <-chan pglogrepl.Message)
 		case *rollbackMessage:
 			// This is a custom message that we'll insert to indicate
 			// that the upstream message provider is going to restart
-			// the feed.
+			// the feed. We want to abandon any in-memory mutations,
+			// since the restart will wind up replaying them.
 			c.reset()
 
 		case *pglogrepl.RelationMessage:
@@ -545,7 +485,11 @@ func (c *Conn) processMessages(ctx context.Context, ch <-chan pglogrepl.Message)
 			// Starting a new transaction. We're going to accept the
 			// transaction time as reported by the server as our
 			// HLC timestamp for staging purposes.
+			c.txLSN = msg.FinalLSN
 			c.txTime = hlc.From(msg.CommitTime)
+			if s := c.serializer; s != nil {
+				err = s.Begin(ctx)
+			}
 
 		case *pglogrepl.CommitMessage:
 			err = c.onCommit(ctx, msg)
@@ -690,15 +634,6 @@ func (c *Conn) readReplicationData(ctx context.Context, ch chan<- pglogrepl.Mess
 		}
 	}
 	return nil
-}
-
-// reset abandons any in-flight data that we've accumulated.
-func (c *Conn) reset() {
-	c.dirty = make(map[ident.Table]struct{})
-	for tbl, muts := range c.pending {
-		c.pending[tbl] = muts[:0]
-	}
-	c.txTime = hlc.Zero()
 }
 
 // traceTuple

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -78,7 +78,7 @@ func testPGLogical(t *testing.T, immediate bool) {
 		}
 	}
 
-	const rowCount = 1024
+	const rowCount = 10_000
 	keys := make([]int, rowCount)
 	vals := make([]string, rowCount)
 	for i := range keys {

--- a/internal/target/apply/fan/bucket.go
+++ b/internal/target/apply/fan/bucket.go
@@ -1,0 +1,181 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fan
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/jackc/pgtype/pgxtype"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// A bucket manages mutations to be applied to a single table.
+type bucket struct {
+	applier types.Applier
+	// A callback to notify that the bucket's consistent point has changed.
+	onConsistent func(*bucket, stamp.Stamp)
+	pool         pgxtype.Querier
+	// stopped is closed when the bucket has shut down. This channel
+	// is provided to external callers, so it is independent of the
+	// internal wakeup channel below.
+	stopped chan struct{}
+	// Send a message to kick the flush loop; close to stop it.
+	wakeup chan struct{}
+
+	mu struct {
+		sync.Mutex
+		stopFlag bool // Set when the stopped channel is closed.
+		work     stamp.Queue
+	}
+}
+
+// newBucket starts a per-bucket goroutine. Callers must call the Stop
+// method to terminate it.
+func newBucket(
+	applier types.Applier, pool pgxtype.Querier, onConsistent func(*bucket, stamp.Stamp),
+) *bucket {
+	ret := &bucket{
+		applier:      applier,
+		pool:         pool,
+		onConsistent: onConsistent,
+		stopped:      make(chan struct{}),
+		wakeup:       make(chan struct{}, 1),
+	}
+
+	go ret.flushLoop()
+
+	return ret
+}
+
+// Consistent returns the consistent point for the bucket.
+func (b *bucket) Consistent() stamp.Stamp {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.mu.work.Consistent()
+}
+
+// Enqueue adds mutations to be processed and their associated stamp.
+func (b *bucket) Enqueue(stamp stamp.Stamp, muts []types.Mutation) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.mu.stopFlag {
+		return errors.New("the bucket has been stopped")
+	}
+	return b.mu.work.Enqueue(newBatch(stamp, muts))
+}
+
+// Flush requests the bucket to flush any in-memory data it has. Results
+// will be visible via the onConsistent callback.
+func (b *bucket) Flush() {
+	// Perform a non-blocking send to the wakeup channel. It has a size-1
+	// buffer, so if there's already a pending flush, we don't need
+	// to add another.
+	select {
+	case b.wakeup <- struct{}{}:
+	default:
+	}
+}
+
+// Mark indicates that the stamp may become a consistent point in the
+// future.
+func (b *bucket) Mark(stamp stamp.Stamp) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.mu.work.Mark(stamp)
+}
+
+// Stop will cleanly halt the flush loop.
+func (b *bucket) Stop() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.mu.stopFlag {
+		return
+	}
+	b.mu.stopFlag = true
+	close(b.stopped)
+}
+
+// Stopped returns a channel which is closed once the bucket's flush
+// goroutine has been stopped.
+func (b *bucket) Stopped() <-chan struct{} {
+	return b.stopped
+}
+
+// flushLoop is executed from a per-bucket goroutine.
+func (b *bucket) flushLoop() {
+	defer close(b.stopped)
+	var consistent stamp.Stamp
+outer:
+	for {
+		_, open := <-b.wakeup
+
+		// Once woken up, drain everything that we have to send.
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			more, err := b.flushOneBatch(ctx)
+			cancel()
+			if err != nil {
+				log.WithError(err).Warn("error while flushing mutations; will retry")
+				continue outer
+			}
+			if !more {
+				break
+			}
+		}
+
+		// If the consistent point advanced, send a callback.
+		if fn := b.onConsistent; fn != nil {
+			nextConsistent := b.Consistent()
+			if stamp.Compare(nextConsistent, consistent) > 0 {
+				fn(b, nextConsistent)
+			}
+		}
+
+		if !open {
+			log.Trace("bucket.flushLoop exiting")
+			return
+		}
+	}
+}
+
+func (b *bucket) flushOneBatch(ctx context.Context) (more bool, _ error) {
+	// Peek at the queued value. We don't want to dequeue it here if the
+	// mutations cannot be applied due to a transient error.
+	b.mu.Lock()
+	peeked := b.mu.work.PeekQueued()
+	b.mu.Unlock()
+
+	if peeked == nil {
+		return false, nil
+	}
+
+	toApply := peeked.(*stampedBatch)
+
+	if err := b.applier.Apply(ctx, b.pool, toApply.Pick()); err != nil {
+		return false, err
+	}
+
+	// Now, we can drain the element that we peeked at above.
+	b.mu.Lock()
+	drained := b.mu.work.Drain()
+	b.mu.Unlock()
+
+	// Sanity-check that we drained the correct element.
+	if toApply != drained.(*stampedBatch) {
+		return false, errors.New("did not drain expected element")
+	}
+	return true, nil
+}

--- a/internal/target/apply/fan/fan.go
+++ b/internal/target/apply/fan/fan.go
@@ -1,0 +1,234 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package fan provides a parallel-commit process for applying mutations
+// across a sharded row-space.
+package fan
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/jackc/pgtype/pgxtype"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// A ConsistentCallback is passed to New
+type ConsistentCallback func(stamp.Stamp)
+
+// Fan allows a serial stream of mutations to be applied across
+// concurrent SQL connections to the target cluster.
+type Fan struct {
+	appliers     types.Appliers
+	onConsistent ConsistentCallback
+	pool         pgxtype.Querier
+	shardCount   int           // Number of per-table buckets.
+	stopped      chan struct{} // Closed to stop the flush loop.
+
+	mu struct {
+		sync.RWMutex
+
+		buckets  map[bucketKey]*bucket
+		minMap   *stamp.MinMap // Keys are *bucket.
+		stopFlag bool          // Set when canceled.
+	}
+}
+
+// New constructs a Fan instance and returns a cancellation
+// function which will perform a graceful shutdown.
+func New(
+	a types.Appliers, pool pgxtype.Querier, onConsistent ConsistentCallback, shardCount int,
+) (_ *Fan, cancel func(), _ error) {
+	ret := &Fan{
+		appliers:     a,
+		onConsistent: onConsistent,
+		pool:         pool,
+		shardCount:   shardCount,
+		stopped:      make(chan struct{}),
+	}
+	if ret.onConsistent == nil {
+		ret.onConsistent = func(s stamp.Stamp) {}
+	}
+	// Initialize other data members.
+	ret.Reset()
+
+	go ret.flushLoop()
+
+	return ret, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := ret.stop(ctx); err != nil {
+			log.WithError(err).Warn("fan helper did not shut down cleanly")
+		}
+	}, nil
+}
+
+// Enqueue mutations with the given stamp.
+//
+// The value provided to stamp must be monotonic.
+func (f *Fan) Enqueue(
+	ctx context.Context, stamp stamp.Stamp, table ident.Table, muts []types.Mutation,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.mu.stopFlag {
+		return errors.New("already stopped")
+	}
+
+	for _, mut := range muts {
+		bucket, err := f.bucketForLocked(ctx, table, mut)
+		if err != nil {
+			return err
+		}
+		// The bucket will coalesce tail values.
+		if err := bucket.Enqueue(stamp, muts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Mark is given a stamp which is guaranteed to be strictly less than
+// any future stamp provided to Enqueue. Marked stamps are used to
+// provide consistent points for transactional consistency.
+func (f *Fan) Mark(s stamp.Stamp) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// If there are no active buckets, we treat the mark as being
+	// consistent.
+	if len(f.mu.buckets) == 0 {
+		f.onConsistent(s)
+		return nil
+	}
+
+	for _, bucket := range f.mu.buckets {
+		if err := bucket.Mark(s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Reset abandons all in-memory mutations.
+func (f *Fan) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.mu.buckets = make(map[bucketKey]*bucket)
+	f.mu.minMap = stamp.NewMinMap()
+}
+
+// bucketForLocked finds or creates a new shard bucket for applying
+// mutations to the given table.
+func (f *Fan) bucketForLocked(
+	ctx context.Context, table ident.Table, mut types.Mutation,
+) (*bucket, error) {
+	key := keyFor(table, f.shardCount, mut)
+	if found, ok := f.mu.buckets[key]; ok {
+		return found, nil
+	}
+
+	// TODO(bob): Make this configurable?
+	app, err := f.appliers.Get(ctx, table, nil /* cas */, types.Deadlines{})
+	if err != nil {
+		return nil, err
+	}
+	ret := newBucket(app, f.pool, f.onBucketConsistent)
+	f.mu.buckets[key] = ret
+
+	// Insert the bucket into the minmap here, so that we don't get
+	// spurious changed notifications later on.
+	f.mu.minMap.Put(ret, nil)
+
+	return ret, nil
+}
+
+// flushLoop is executed from a dedicated goroutine.
+func (f *Fan) flushLoop() {
+	var stopped bool
+	for {
+		select {
+		case <-f.stopped:
+			log.Trace("fan flushLoop exiting")
+			stopped = true
+		case <-time.After(time.Second):
+		}
+		f.mu.Lock()
+		for _, bucket := range f.mu.buckets {
+			bucket.Flush()
+			if stopped {
+				bucket.Stop()
+			}
+		}
+		f.mu.Unlock()
+		if stopped {
+			log.Debug("fan instance quiesced")
+			return
+		}
+	}
+}
+
+// Handle notifications from each shard's bucket. When all shards have
+// agreed on a new consistent value, we can report that back to the
+// owner.
+func (f *Fan) onBucketConsistent(b *bucket, stamp stamp.Stamp) {
+	f.mu.Lock()
+	min, changed := f.mu.minMap.Put(b, stamp)
+	f.mu.Unlock()
+
+	if changed {
+		f.onConsistent(min)
+	}
+}
+
+// stop will shut down the flush loop. This method blocks until all
+// managed buckets have finished stopping. The context here is used
+// to provide a timeout for shutting down.
+func (f *Fan) stop(ctx context.Context) error {
+	f.mu.Lock()
+	if f.mu.stopFlag {
+		f.mu.Unlock()
+		return nil
+	}
+	f.mu.stopFlag = true
+
+	// Snapshot the buckets here, so we can unlock the mutex, allowing
+	// the flushLoop below to also read the map.
+	waitFor := make([]*bucket, len(f.mu.buckets))
+	idx := 0
+	for _, bucket := range f.mu.buckets {
+		waitFor[idx] = bucket
+		idx++
+	}
+	f.mu.Unlock()
+
+	// This will trigger a wakeup in flushLoop, which will propagate
+	// the call to bucket.stop.
+	close(f.stopped)
+
+	// Wait for all buckets to clean up.
+	for _, bucket := range waitFor {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-bucket.Stopped():
+		}
+	}
+	return nil
+}

--- a/internal/target/apply/fan/fan_test.go
+++ b/internal/target/apply/fan/fan_test.go
@@ -1,0 +1,120 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fan
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/target/sinktest"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/stretchr/testify/assert"
+)
+
+type intStamp int
+
+func (s intStamp) Less(other stamp.Stamp) bool {
+	return s < other.(intStamp)
+}
+
+func TestFanSmoke(t *testing.T) {
+	a := assert.New(t)
+
+	ctx, dbInfo, cancel := sinktest.Context()
+	defer cancel()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	watchers, cancel := schemawatch.NewWatchers(dbInfo.Pool())
+	defer cancel()
+
+	tbl, err := sinktest.CreateTable(ctx, dbName,
+		"CREATE TABLE %s (k INT PRIMARY KEY, v STRING)")
+	if !a.NoError(err) {
+		return
+	}
+
+	appliers, cancel := apply.NewAppliers(watchers)
+	defer cancel()
+
+	// Provide a correct way for the callback to report where the
+	// consistent point has advanced to.
+	consistentUpdated := sync.NewCond(&sync.Mutex{})
+	var consistentPoint intStamp
+
+	imm, cancel, err := New(
+		appliers,
+		dbInfo.Pool(),
+		func(stamp stamp.Stamp) {
+			consistentUpdated.L.Lock()
+			defer consistentUpdated.L.Unlock()
+			consistentPoint = stamp.(intStamp)
+			consistentUpdated.Broadcast()
+		},
+		16,
+	)
+	defer cancel()
+	if !a.NoError(err) {
+		return
+	}
+
+	// Generate data to be applied.
+	waitFor, err := generateMutations(ctx, imm, tbl.Name(), 1024)
+	if !a.NoError(err) {
+		return
+	}
+
+	// Wait for the data to land, but also respect test timeout.
+	consistentUpdated.L.Lock()
+	for consistentPoint != waitFor {
+		if !a.NoError(ctx.Err()) {
+			return
+		}
+		consistentUpdated.Wait()
+	}
+	consistentUpdated.L.Unlock()
+}
+
+func generateMutations(
+	ctx context.Context, imm *Fan, tbl ident.Table, batchCount int,
+) (intStamp, error) {
+	id := 0
+	for batchID := 0; batchID < batchCount; batchID++ {
+		muts := make([]types.Mutation, 10)
+		for idx := range muts {
+			id++
+			muts[idx].Key = []byte(fmt.Sprintf(`[%d]`, id))
+			muts[idx].Data = []byte(fmt.Sprintf(`{"k":%d,"v":"%d"}`, id, id))
+		}
+
+		if err := imm.Enqueue(ctx, intStamp(batchID), tbl, muts); err != nil {
+			return 0, err
+		}
+		if batchID%10 == 0 {
+			if err := imm.Mark(intStamp(batchID)); err != nil {
+				return 0, err
+			}
+		}
+	}
+	// Ensure that we close out the last batch with an explicit mark.
+	lastStamp := intStamp(batchCount - 1)
+	return lastStamp, imm.Mark(lastStamp)
+}

--- a/internal/target/apply/fan/key.go
+++ b/internal/target/apply/fan/key.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fan
+
+import (
+	"hash/maphash"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+type bucketKey struct {
+	table ident.Table
+	shard int
+}
+
+// keyFor produces a bucketKey to group mutations together by key.
+// This function assumes that the encoding of the key is stable for
+// any given row.
+func keyFor(table ident.Table, shardCount int, mut types.Mutation) bucketKey {
+	if shardCount <= 1 {
+		return bucketKey{table, 0}
+	}
+
+	h := maphash.Hash{}
+	_, _ = h.Write(mut.Key)
+	shard := int(h.Sum64() % uint64(shardCount))
+	return bucketKey{table, shard}
+}

--- a/internal/target/apply/fan/stamped_batch.go
+++ b/internal/target/apply/fan/stamped_batch.go
@@ -1,0 +1,95 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fan
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/batches"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+)
+
+// A stampedBatch of mutations.
+type stampedBatch struct {
+	stamp stamp.Stamp
+	mu    struct {
+		sync.Mutex
+		immutable bool // If true, prevents coalescing.
+		muts      []types.Mutation
+	}
+}
+
+var _ stamp.Coalescing = (*stampedBatch)(nil)
+
+func newBatch(stamp stamp.Stamp, muts []types.Mutation) *stampedBatch {
+	ret := &stampedBatch{stamp: stamp}
+	ret.mu.muts = muts
+	return ret
+}
+
+// Coalesce allows a tail element to be merged if it has the same Stamp.
+func (b *stampedBatch) Coalesce(tail stamp.Stamped) stamp.Stamped {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// If this stampedBatch is in the process of being flushed, we don't
+	// want it to allow coalescing.
+	if b.mu.immutable {
+		return tail
+	}
+
+	other := tail.(*stampedBatch)
+	if stamp.Compare(b.stamp, other.stamp) != 0 {
+		return tail
+	}
+
+	// This is really for pedantry's sake, since we're reaching into
+	// the mu struct. The tail value being passed in shouldn't be
+	// visible to any other goroutine, since the datastructure is
+	// single-threaded through the owning bucket's mutex.
+	other.mu.Lock()
+	defer other.mu.Unlock()
+
+	// This is not an expected case.
+	if other.mu.immutable {
+		return tail
+	}
+
+	// Append as many elements as will bring us up to the configured
+	// batching size.
+	toAppend := other.mu.muts
+	maxCount := batches.Size() - len(b.mu.muts)
+	if maxCount > len(toAppend) {
+		maxCount = len(toAppend)
+	}
+	b.mu.muts = append(b.mu.muts, toAppend[:maxCount]...)
+
+	// Return the remainder, or nil if we've consumed all elements.
+	toAppend = toAppend[maxCount:]
+	if len(toAppend) > 0 {
+		other.mu.muts = toAppend
+		return other
+	}
+	return nil
+}
+
+// Pick marks the batch as immutable, to prevent coalescing, and returns
+// the enclosed mutations.
+func (b *stampedBatch) Pick() []types.Mutation {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.mu.immutable = true
+	return b.mu.muts
+}
+
+// Stamp implements stamp.Stamped.
+func (b *stampedBatch) Stamp() stamp.Stamp { return b.stamp }

--- a/internal/target/sinktest/sinktest.go
+++ b/internal/target/sinktest/sinktest.go
@@ -28,7 +28,10 @@ import (
 )
 
 var connString = flag.String("testConnect",
-	"postgresql://root@localhost:26257/defaultdb?sslmode=disable&experimental_enable_hash_sharded_indexes=true",
+	"postgresql://root@localhost:26257/defaultdb"+
+		"?sslmode=disable"+
+		"&experimental_enable_hash_sharded_indexes=true"+
+		"&pool_max_conns=1024",
 	"the connection string to use for testing")
 
 var globalDBInfo struct {

--- a/internal/util/serial/serial.go
+++ b/internal/util/serial/serial.go
@@ -1,0 +1,250 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package serial allows an otherwise-concurrent use of a database pool
+// to be transparently deoptimized into serial use of a single
+// transaction.
+package serial
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/jackc/pgtype/pgxtype"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+)
+
+// Pool is a wrapper around a database connection pool that
+// concentrates database queries into a single transaction. This type
+// is used when it is necessary to de-optimize concurrent database
+// performance in favor of transactional consistency.
+//
+// This type is internally synchronized, and the query method calls will
+// block each other. Queries will also be blocked while there is an
+// active pgx.Rows or un-scanned pgx.Row that has been returned from a
+// query.
+type Pool struct {
+	Pool *pgxpool.Pool
+
+	mu struct {
+		sync.Mutex
+		tx pgx.Tx
+	}
+}
+
+var _ pgxtype.Querier = (*Pool)(nil)
+
+// Begin opens a new transaction to concentrate work into.
+func (s *Pool) Begin(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.mu.tx != nil {
+		return errors.New("transaction already in progress")
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	s.mu.tx = tx
+	return nil
+}
+
+// Commit commits the underlying transaction.
+func (s *Pool) Commit(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx := s.mu.tx
+	if tx == nil {
+		return errors.New("no transaction in progress")
+	}
+	s.mu.tx = nil
+	return tx.Commit(ctx)
+}
+
+// Rollback abort the underlying transaction, if one is present.
+// This method is always safe to call.
+func (s *Pool) Rollback(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx := s.mu.tx
+	if tx == nil {
+		return nil
+	}
+	s.mu.tx = nil
+	return tx.Rollback(ctx)
+}
+
+// Exec implements pgxtype.Querier and can only be called after Begin.
+func (s *Pool) Exec(
+	ctx context.Context, sql string, arguments ...interface{},
+) (pgconn.CommandTag, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx := s.mu.tx
+	if tx == nil {
+		return nil, errors.New("no transaction in progress")
+	}
+	return tx.Exec(ctx, sql, arguments...)
+}
+
+// Query implements pgxtype.Querier and can only be called after Begin.
+// The Rows that are returned from this method must be closed, fully
+// consumed, or encounter an error before other query methods will be
+// allowed to proceed.
+func (s *Pool) Query(
+	ctx context.Context, sql string, optionsAndArgs ...interface{},
+) (pgx.Rows, error) {
+	s.mu.Lock()
+
+	tx := s.mu.tx
+	if tx == nil {
+		s.mu.Unlock()
+		return nil, errors.New("no transaction in progress")
+	}
+
+	rows, err := tx.Query(ctx, sql, optionsAndArgs...)
+	if err == nil {
+		rows = &rowsUnlocker{rows, &s.mu}
+		runtime.SetFinalizer(rows, func(r *rowsUnlocker) {
+			r.unlock()
+		})
+	} else {
+		s.mu.Unlock()
+	}
+	return rows, err
+}
+
+// QueryRow implements pgxtype.Querier and can only be called after
+// Begin. The Row that is returned must be scanned before any other
+// query methods wil be allowed to proceed.
+func (s *Pool) QueryRow(ctx context.Context, sql string, optionsAndArgs ...interface{}) pgx.Row {
+	s.mu.Lock()
+
+	tx := s.mu.tx
+	if tx == nil {
+		return &rowUnlocker{
+			err: errors.New("no transaction in progress"),
+			u:   &s.mu,
+		}
+	}
+	row := &rowUnlocker{
+		r: tx.QueryRow(ctx, sql, optionsAndArgs...),
+		u: &s.mu,
+	}
+	runtime.SetFinalizer(row, func(row *rowUnlocker) {
+		row.unlock()
+	})
+	return row
+}
+
+// rowUnlocker calls an Unlock method once it has been scanned.
+// It can also be configured to always return a specific error.
+type rowUnlocker struct {
+	err error
+	r   pgx.Row
+	u   interface{ Unlock() }
+}
+
+var _ pgx.Row = (*rowUnlocker)(nil)
+
+func (r *rowUnlocker) Scan(dest ...interface{}) error {
+	defer r.unlock()
+	var err error
+	if r.err == nil {
+		err = r.r.Scan(dest...)
+	} else {
+		err = r.err
+	}
+	return err
+}
+
+func (r *rowUnlocker) unlock() {
+	if r.u != nil {
+		runtime.SetFinalizer(r, nil)
+		r.u.Unlock()
+		r.u = nil
+	}
+}
+
+// rowsUnlocker will call an Unlock method once the Rows has been
+// closed, exhausted, or enters an error state.
+type rowsUnlocker struct {
+	r pgx.Rows
+	u interface{ Unlock() }
+}
+
+var _ pgx.Rows = (*rowsUnlocker)(nil)
+
+func (r *rowsUnlocker) CommandTag() pgconn.CommandTag {
+	return r.r.CommandTag()
+}
+
+func (r *rowsUnlocker) Close() {
+	r.r.Close()
+	r.unlock()
+}
+
+func (r *rowsUnlocker) Err() error {
+	err := r.r.Err()
+	if err != nil {
+		r.unlock()
+	}
+	return err
+}
+
+func (r *rowsUnlocker) FieldDescriptions() []pgproto3.FieldDescription {
+	return r.r.FieldDescriptions()
+}
+
+func (r *rowsUnlocker) Next() bool {
+	if r.r.Next() {
+		return true
+	}
+	r.unlock()
+	return false
+}
+
+func (r *rowsUnlocker) RawValues() [][]byte {
+	return r.r.RawValues()
+}
+
+func (r *rowsUnlocker) Scan(dest ...interface{}) error {
+	err := r.r.Scan(dest...)
+	if err != nil {
+		r.unlock()
+	}
+	return err
+}
+
+func (r *rowsUnlocker) Values() ([]interface{}, error) {
+	ret, err := r.r.Values()
+	if err != nil {
+		r.unlock()
+	}
+	return ret, err
+}
+
+func (r *rowsUnlocker) unlock() {
+	if u := r.u; u != nil {
+		runtime.SetFinalizer(r, nil)
+		u.Unlock()
+		r.u = nil
+	}
+}

--- a/internal/util/stamp/min_map.go
+++ b/internal/util/stamp/min_map.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stamp
+
+import "container/heap"
+
+// A MinMap provides a mapping of keys to Stamp values, while also
+// tracking the minimum value.
+//
+// A MinMap is not internally synchronized. A MinMap should not be
+// copied once created.
+type MinMap struct {
+	noCopy
+
+	m map[interface{}]*minMapElt
+	h minMapHeap
+}
+
+// NewMinMap constructs an empty MinMap.
+func NewMinMap() *MinMap {
+	return &MinMap{
+		m: make(map[interface{}]*minMapElt),
+	}
+}
+
+// Delete removes the mapping for the specified key, if one is present.
+func (m *MinMap) Delete(key interface{}) {
+	elt, ok := m.m[key]
+	if !ok {
+		return
+	}
+	delete(m.m, key)
+	heap.Remove(&m.h, elt.Index)
+}
+
+// Get returns the previously set Stamp for the key, or nil if no
+// mapping is present.
+func (m *MinMap) Get(key interface{}) Stamp {
+	if found, ok := m.m[key]; ok {
+		return found.Stamp
+	}
+	return nil
+}
+
+// Len returns the number of elements within the map.
+func (m *MinMap) Len() int {
+	return len(m.h)
+}
+
+// Min returns the minimum Stamp in the map, or nil if the map is empty.
+func (m *MinMap) Min() Stamp {
+	if len(m.h) > 0 {
+		return m.h[0].Stamp
+	}
+	return nil
+}
+
+// Put adds or updates an entry in the map. This method returns the
+// minimum Stamp within the map and a boolean flag to indicate if the
+// call to Put changed the minimum value.
+func (m *MinMap) Put(key interface{}, stamp Stamp) (minStamp Stamp, minChanged bool) {
+	startMin := m.Min()
+	if elt, ok := m.m[key]; ok {
+		// If there's already an entry in the map, update the Stamp
+		// and then fix the heap ordering.
+		elt.Stamp = stamp
+		heap.Fix(&m.h, elt.Index)
+	} else {
+		// Otherwise, we just add the new element to the lookup map
+		// and to the heap.
+		elt = &minMapElt{Stamp: stamp}
+		heap.Push(&m.h, elt)
+		m.m[key] = elt
+	}
+	endMin := m.h[0].Stamp
+	return endMin, Compare(startMin, endMin) != 0
+}
+
+// A minMapElt is an entry in a minMapHeap which tracks its current
+// index. This allows us to reduce the cost of restoring the heap
+// invariants when the Stamp is updated.
+type minMapElt struct {
+	Index int
+	Stamp Stamp
+}
+
+// A min-heap of elements.
+type minMapHeap []*minMapElt
+
+var _ heap.Interface = (*minMapHeap)(nil)
+
+// Len implements heap.Interface.
+func (h minMapHeap) Len() int {
+	return len(h)
+}
+
+// Less implements heap.Interface.
+func (h minMapHeap) Less(i, j int) bool {
+	return Compare(h[i].Stamp, h[j].Stamp) < 0
+}
+
+// Pop implements heap.Interface.
+func (h *minMapHeap) Pop() interface{} {
+	idx := len(*h) - 1
+	elt := (*h)[idx]
+	*h = (*h)[:idx]
+	return elt
+}
+
+// Push implements heap.Interface.
+func (h *minMapHeap) Push(x interface{}) {
+	elt := x.(*minMapElt)
+	elt.Index = len(*h)
+	*h = append(*h, elt)
+}
+
+// Swap implements heap.Interface.
+func (h minMapHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].Index, h[j].Index = i, j
+}

--- a/internal/util/stamp/min_map_test.go
+++ b/internal/util/stamp/min_map_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stamp
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinMap(t *testing.T) {
+	a := assert.New(t)
+
+	// Insert some elements in random order.
+	const count = 1024
+	elts := make([]intStamp, count)
+	for idx := range elts {
+		elts[idx] = intStamp(idx)
+	}
+	rand.Shuffle(count, func(i, j int) { elts[i], elts[j] = elts[j], elts[i] })
+
+	m := NewMinMap()
+	a.Equal(0, m.Len())
+	a.Nil(m.Min())
+
+	var lastMin Stamp
+	for _, elt := range elts {
+		lastMin, _ = m.Put(int(elt), elt)
+	}
+
+	a.Equal(intStamp(0), lastMin)
+	a.Equal(lastMin, m.Min())
+	a.Equal(count, m.Len())
+
+	// Get all values.
+	for idx := range elts {
+		a.Equal(intStamp(idx), m.Get(idx))
+	}
+	a.Nil(m.Get("not found"))
+
+	// Replace all values.
+	for idx := range elts {
+		lastMin, _ = m.Put(idx, intStamp(count+idx))
+	}
+	a.Equal(intStamp(count), lastMin)
+
+	// Delete all values.
+	for _, elt := range elts {
+		m.Delete(int(elt))
+	}
+
+	a.Equal(0, m.Len())
+	a.Nil(m.Get(0))
+	a.Nil(m.Min())
+
+	// Verify redundant delete is ok.
+	m.Delete(0)
+
+	// Verify that adding a nil value is ok.
+	lastMin, changed := m.Put("nil", nil)
+	a.Nil(lastMin)
+	a.False(changed) // The previous result for Min() was already nil.
+
+	lastMin, changed = m.Put("nil2", nil)
+	a.Nil(lastMin)
+	a.False(changed)
+}

--- a/internal/util/stamp/queue.go
+++ b/internal/util/stamp/queue.go
@@ -1,0 +1,262 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stamp
+
+import (
+	"container/list"
+
+	"github.com/pkg/errors"
+)
+
+// Queue maintains ordered Stamped values.
+//
+// Draining values from the queue advances a "consistent point", derived
+// from the stamps of the dequeued values and a queue of candidate,
+// "marked" stamps. The lowest-valued marked stamp becomes the
+// consistent point when there are no more stamped values in the queue
+// whose stamps are less than the mark.
+//
+// Queue is not internally synchronized. The zero value is
+// ready to use. A Queue should not be copied once created.
+//
+// At present, this implementation assumes that it is being driven from
+// a serial source of data that provides monotonic stamps. It would be
+// possible to extend the behavior to allow for out-of-order insertion,
+// albeit with increased algorithmic complexity, provided that the stamp
+// of the enqueued data is still greater than the consistent point.
+//
+// The following Stamp-ordering invariants are maintained:
+//   1) enqueued[0] <= enqueued[1] ...  <= enqueued[n] (softly monotonic)
+//   2) marked[0] < marked[1] ... < marked[n] (strictly monotonic)
+//   3) consistent < enqueued[0]
+//   4) consistent < marked[0]
+//   5) consistent > previousConsistent.
+type Queue struct {
+	noCopy
+
+	consistent Stamp
+	enqueued   list.List // Stamped values.
+	marked     list.List // Stamp values. Strictly monotonic.
+}
+
+// Consistent returns a Stamp which is less than all enqueued or marked
+// stamps. This value will be nil if none of Drain, Mark, or
+// setConsistent have been called.
+func (s *Queue) Consistent() Stamp {
+	return s.consistent
+}
+
+// Drain returns the next enqueued, Stamped value, or nil if the Queue
+// is empty. Draining a value will advance the consistent stamp to the
+// greatest marked value that is strictly less than the Stamp of the
+// value returned.  That is, the consistent stamp will be in the
+// half-open range of [ nil, Drain().Stamp() ).
+func (s *Queue) Drain() Stamped {
+	front := s.enqueued.Front()
+	if front == nil {
+		return nil
+	}
+
+	ret := s.enqueued.Remove(front).(Stamped)
+	if err := s.advanceConsistentPoint(); err != nil {
+		// Panic here, since this should only fail if invariants
+		// are not correctly maintained elsewhere in the code.
+		panic(err)
+	}
+
+	return ret
+}
+
+// Enqueue adds a Stamped value to the end of the queue. If the tail
+// value in the Queue implements Coalescing, the Queue will attempt to
+// merge the tail and next values.
+func (s *Queue) Enqueue(next Stamped) error {
+	// To support out-of-order behavior, this method would need to
+	// (reverse-)scan the queue to find the correct insertion point.
+	// Another option is to switch the fields from lists to min-heaps.
+
+	if tail := s.enqueued.Back(); tail != nil {
+		if c, ok := tail.Value.(Coalescing); ok {
+			next = c.Coalesce(next)
+			if next == nil {
+				return nil
+			}
+		}
+	}
+
+	added := s.enqueued.PushBack(next)
+	if err := s.validate(); err != nil {
+		s.enqueued.Remove(added)
+		return err
+	}
+	return nil
+}
+
+// Enqueued returns all currently-enqueued values. The returned slice
+// may be modified by the caller.
+func (s *Queue) Enqueued() []Stamped {
+	elt := s.enqueued.Front()
+	ret := make([]Stamped, s.enqueued.Len())
+	for idx := range ret {
+		ret[idx] = elt.Value.(Stamped)
+		elt = elt.Next()
+	}
+	return ret
+}
+
+// Mark schedules the marked Stamp to be made consistent. This method
+// will update the consistent point if the provided stamp is greater
+// than the current consistent point and less than the stamp of the head
+// of the queue or if the queue is empty.
+func (s *Queue) Mark(next Stamp) error {
+	elt := s.marked.PushBack(next)
+	if err := s.validate(); err != nil {
+		s.marked.Remove(elt)
+		return err
+	}
+	return s.advanceConsistentPoint()
+}
+
+// Marked returns all currently-marked values. The returned slice
+// may be modified by the caller.
+func (s *Queue) Marked() []Stamp {
+	elt := s.marked.Front()
+	ret := make([]Stamp, s.marked.Len())
+	for idx := range ret {
+		ret[idx] = elt.Value.(Stamp)
+		elt = elt.Next()
+	}
+	return ret
+}
+
+// PeekMarked returns the head of the marked queue, without modifying it.
+func (s *Queue) PeekMarked() Stamp {
+	if elt := s.marked.Front(); elt != nil {
+		return elt.Value.(Stamp)
+	}
+	return nil
+}
+
+// PeekQueued returns the head of the queue, without modifying it.
+func (s *Queue) PeekQueued() Stamped {
+	if elt := s.enqueued.Front(); elt != nil {
+		return elt.Value.(Stamped)
+	}
+	return nil
+}
+
+// advanceConsistentPoint updates the consistent point to the greatest
+// marked value that is less than the queue-head stamp.
+func (s *Queue) advanceConsistentPoint() error {
+	var nextConsistent Stamp
+
+	if queuedHead := s.enqueued.Front(); queuedHead == nil {
+		// Nothing queued, set the next consistent stamp to the tail
+		// (greatest) marked value and reset the marked list.
+		if tail := s.marked.Back(); tail != nil {
+			nextConsistent = tail.Value.(Stamp)
+			s.marked.Init()
+		}
+	} else {
+		// Remove elements from the head of the marked list that are
+		// strictly less than the stamp of the value at the beginning of
+		// the queued data.
+		queuedHeadStamp := queuedHead.Value.(Stamped).Stamp()
+		for {
+			if markHead := s.marked.Front(); markHead != nil {
+				mark := markHead.Value.(Stamp)
+				if mark.Less(queuedHeadStamp) {
+					nextConsistent = mark
+					s.marked.Remove(markHead)
+					continue
+				}
+			}
+			break
+		}
+	}
+
+	if nextConsistent == nil {
+		return nil
+	}
+	return s.setConsistent(nextConsistent)
+}
+
+// setConsistent allows the consistent point to be seeded or updated
+// to any value which satisfies the order invariants.
+func (s *Queue) setConsistent(next Stamp) error {
+	prev := s.consistent
+
+	// Invariant 5: consistent > previousConsistent
+	if Compare(next, prev) <= 0 {
+		return errors.Errorf("consistent stamp %s must always increase %s", next, prev)
+	}
+
+	s.consistent = next
+	if err := s.validate(); err != nil {
+		s.consistent = prev
+		return err
+	}
+	return nil
+}
+
+// validate enforces the invariants.
+// TODO(bob): Pass some kind of mutation flag to cut down on unnecessary tests.
+func (s *Queue) validate() error {
+	// Invariant 1: enqueued[0] <= enqueued[1] ...  <= enqueued[idx]
+	// Check only the last two elements of the enqueued list, since
+	// we're only ever appending.
+	if b := s.enqueued.Back(); b != nil {
+		bStamp := b.Value.(Stamped).Stamp()
+		if a := b.Prev(); a != nil {
+			aStamp := a.Value.(Stamped).Stamp()
+			if Compare(bStamp, aStamp) < 0 {
+				idx := s.enqueued.Len() - 1
+				return errors.Errorf(
+					"enqueued[%d] %s must be >= than enqueued[%d] %s",
+					idx, bStamp, idx-1, aStamp)
+			}
+		}
+	}
+
+	// Invariant 2: marked[0] < marked[1] ...  < marked[idx]
+	// Check only the last two elements of the enqueued list, since
+	// we're only ever appending.
+	if b := s.marked.Back(); b != nil {
+		bStamp := b.Value.(Stamp)
+		if a := b.Prev(); a != nil {
+			aStamp := a.Value.(Stamp)
+			if Compare(bStamp, aStamp) <= 0 {
+				idx := s.enqueued.Len() - 1
+				return errors.Errorf(
+					"enqueued[%d] %s must be strictly greater than enqueued[%d] %s",
+					idx, bStamp, idx-1, aStamp)
+			}
+		}
+	}
+
+	// Invariant 3: consistent < enqueued[0]
+	if queued := s.PeekQueued(); queued != nil {
+		if Compare(s.consistent, queued.Stamp()) >= 0 {
+			return errors.Errorf(
+				"consistent stamp %s must be strictly less than first enqueued stamp %s",
+				s.consistent, queued.Stamp())
+		}
+	}
+
+	// Invariant 4: consistent < marked[0]
+	if mark := s.PeekMarked(); mark != nil {
+		if Compare(s.consistent, mark) >= 0 {
+			return errors.Errorf("consistent stamp %s > marked stamp %s", s.consistent, mark)
+		}
+	}
+
+	return nil
+}

--- a/internal/util/stamp/queue_test.go
+++ b/internal/util/stamp/queue_test.go
@@ -1,0 +1,120 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stamp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue(t *testing.T) {
+	a := assert.New(t)
+	var q Queue
+	a.Equal([]Stamped{}, q.Enqueued())
+	a.Nil(q.Consistent())
+
+	// Verify that marking an empty queue advances the consistent point.
+	a.NoError(q.Mark(intStamp(-1)))
+	a.Equal(intStamp(-1), q.Consistent())
+
+	// Verify that Mark is strictly monotonic.
+	a.Error(q.Mark(intStamp(-1)))
+
+	// Check setConsistent is strictly monotonic.
+	a.NoError(q.setConsistent(intStamp(0)))
+	a.Equal(intStamp(0), q.Consistent())
+	a.Error(q.setConsistent(intStamp(0)))
+	a.Error(q.setConsistent(intStamp(-1)))
+	a.Equal(intStamp(0), q.Consistent())
+
+	// Enqueue duplicate values, which will be coalesced by intStamp.
+	a.NoError(q.Enqueue(intStamp(1)))
+	a.NoError(q.Mark(intStamp(1)))
+
+	a.NoError(q.Enqueue(intStamp(2)))
+	a.NoError(q.Enqueue(intStamp(2)))
+	a.NoError(q.Mark(intStamp(2)))
+
+	a.NoError(q.Enqueue(intStamp(3)))
+	a.NoError(q.Enqueue(intStamp(3)))
+	a.NoError(q.Enqueue(intStamp(3)))
+	a.NoError(q.Mark(intStamp(3)))
+
+	a.Equal([]Stamped{intStamp(1), intStamp(2), intStamp(3)}, q.Enqueued())
+	a.Equal([]Stamp{intStamp(1), intStamp(2), intStamp(3)}, q.Marked())
+
+	// Make sure enqueued can't go backwards.
+	a.Error(q.Enqueue(intStamp(1)))
+	a.Len(q.Enqueued(), 3)
+
+	// Make sure marked can't go backwards.
+	a.Error(q.Mark(intStamp(1)))
+	a.Len(q.Enqueued(), 3)
+
+	// Make sure that consistent is always less than first enqueued.
+	a.Error(q.setConsistent(intStamp(1)))
+	a.Error(q.setConsistent(intStamp(2)))
+	a.Error(q.setConsistent(intStamp(3)))
+	a.Error(q.setConsistent(intStamp(100)))
+
+	a.Equal(intStamp(1), q.PeekQueued())
+	a.Equal(intStamp(1), q.PeekMarked())
+	a.Len(q.Enqueued(), 3)
+	a.Len(q.Marked(), 3)
+
+	// Pull values out, verify that consistent point also increases.
+	a.Equal(intStamp(1), q.Drain())
+	a.Equal(intStamp(1), q.Consistent())
+	a.Equal(intStamp(2), q.Drain())
+	a.Equal(intStamp(2), q.Consistent())
+	a.Equal(intStamp(3), q.Drain())
+	a.Equal(intStamp(3), q.Consistent())
+	a.Nil(q.Drain())
+	a.Nil(q.PeekQueued())
+	a.Nil(q.PeekMarked())
+	a.Empty(q.Enqueued())
+
+	// Add and drain some additional values, but don't expect the
+	// consistent point to advance until we add a mark.
+	a.NoError(q.Enqueue(intStamp(4)))
+	a.NoError(q.Enqueue(intStamp(5)))
+	a.Equal(intStamp(4), q.Drain())
+	a.Equal(intStamp(5), q.Drain())
+	a.Equal(intStamp(3), q.Consistent())
+	a.Nil(q.PeekMarked())
+
+	a.NoError(q.Mark(intStamp(5)))
+	a.Equal(intStamp(5), q.Consistent())
+
+	a.Equal([]Stamped{}, q.Enqueued())
+	a.Equal([]Stamp{}, q.Marked())
+
+	// Make sure consistent point can't be set backwards.
+	a.Error(q.setConsistent(intStamp(1)))
+
+	// Make sure mark can't be set below consistent point.
+	a.Error(q.Mark(intStamp(1)))
+}
+
+func TestQueueDrainPanic(t *testing.T) {
+	a := assert.New(t)
+	var q Queue
+
+	a.NoError(q.Enqueue(intStamp(1)))
+	a.NoError(q.Enqueue(intStamp(2)))
+	a.NoError(q.Mark(intStamp(1)))
+
+	// Violate invariant by making consistent > marked.
+	q.consistent = intStamp(3)
+
+	a.Panics(func() { q.Drain() })
+}

--- a/internal/util/stamp/stamp.go
+++ b/internal/util/stamp/stamp.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package stamp contains a utility for maintaining certain ordering
+// invariants when queuing (time-)stamped values.
+package stamp
+
+import "sync"
+
+// A Stamp is a comparable value (possibly a time, or an offset within a
+// log file).
+type Stamp interface {
+	// Less returns true if the callee should be sorted before the other
+	// Stamp.
+	Less(other Stamp) bool
+}
+
+// Compare returns -1, 0, or 1 if a is less than, equal to, or
+// greater than b. This function is nil-safe; a nil Stamp is less than
+// any non-nil Stamp.
+func Compare(a, b Stamp) int {
+	switch {
+	// Identity or nil-nil case.
+	case a == b:
+		return 0
+	case a == nil, a == Stamp(nil):
+		return -1
+	case b == nil, b == Stamp(nil):
+		return 1
+	case a.Less(b):
+		return -1
+	case b.Less(a):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// A Stamped value has some key by which it can be ordered.
+type Stamped interface {
+	// Stamp returns the Stamp associated with the value.
+	Stamp() Stamp
+}
+
+// Coalescing is an optional interface that may be implemented by
+// Stamped values.
+type Coalescing interface {
+	Stamped
+
+	// Coalesce may be implemented to allow the tail node in the queue
+	// to be coalesced with some proposed value to be added to the end
+	// of the queue. Implementations should modify the callee as
+	// appropriate to append the next tail value. This method can return
+	// an alternate, non-nil value to still be added to the queue. If
+	// this method returns nil, then the tail value will be considered
+	// to have been fully coalesced and no new value will be added to
+	// the queue.
+	Coalesce(tail Stamped) (remainder Stamped)
+}
+
+// Tie into go vet static check for copying a Locker instance.
+type noCopy struct{}
+
+var _ sync.Locker = (*noCopy)(nil)
+
+func (c *noCopy) Lock()   {}
+func (c *noCopy) Unlock() {}

--- a/internal/util/stamp/stamp_test.go
+++ b/internal/util/stamp/stamp_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stamp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// intStamp is its own Stamp.
+type intStamp int
+
+var _ Coalescing = intStamp(0)
+var _ Stamp = intStamp(0)
+var _ Stamped = intStamp(0)
+
+// Create a deduplication effect of identical values.
+func (s intStamp) Coalesce(tail Stamped) Stamped {
+	o := tail.(intStamp)
+	if o == s {
+		return nil
+	}
+	return tail
+}
+
+func (s intStamp) Less(other Stamp) bool {
+	if ptr, ok := other.(*intStamp); ok {
+		return s < *ptr
+	}
+	return s < other.(intStamp)
+}
+
+func (s intStamp) Stamp() Stamp {
+	return s
+}
+
+func TestCompareStamp(t *testing.T) {
+	one := intStamp(1)
+	otherOne := intStamp(1)
+	two := intStamp(2)
+
+	tcs := []struct {
+		a, b     Stamp
+		expected int
+	}{
+		{nil, nil, 0},
+		{nil, one, -1},
+		{one, nil, 1},
+
+		{Stamp(nil), Stamp(nil), 0},
+		{Stamp(nil), one, -1},
+		{one, Stamp(nil), 1},
+
+		{one, two, -1},
+		{two, one, 1},
+		{one, one, 0},
+		{two, two, 0},
+
+		{&one, &otherOne, 0},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			a := assert.New(t)
+			a.Equal(tc.expected, Compare(tc.a, tc.b))
+		})
+	}
+}


### PR DESCRIPTION
This change improves the throughput of a pglogical replication connection by
fanning the row-level mutations across multiple database connections.

Each row mutation is assigned to a bucket based on the destination table and
the encoded primary-key bytes. This ensures that changes to any given row are
linear.

The bulk of the complexity in this commit is being able to track the LSN offset
to report back to the server as batches of mutations are flushed.

The stamp package adds a Queue datastructure which tracks the (time-)stamps of
batches of data. The behavior is roughly analogous to closed and resolved
timestamps used in CRDB's changefeed mechanism. A "consistent point" is
advanced to certain "marked" points as batches of data are dequeued. The
invariants maintained by the Queue are called out in its docstring.

The new "apply/fan" package implements a wrapper around the core "apply"
package to apply batches of mutations in a concurrent fashion. The fan.Fan type
buckets incoming mutations by destination table and primary key, to ensure
linear behavior for any given row. Each fan.bucket feeds an applier, using a
stamp.Queue, and the overall consistent point is aggregated in the owning
fan.Fan instance.

The existing pgconn package is updated to use apply/fan.

In cases where transactionally-consistent behavior is desired, the fan.Fan is
configured with a serial.Pool, that serialized concurrent database calls into a
single transaction.

In terms of practical impact, the throughput on my laptop is improved
approximately ten-fold when using an in-memory CRDB node.