### PR TITLE
workflow: Generalize integration testing matrix

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -2,6 +2,10 @@
 # Actions workflows. Host networking is used, because it simplifies
 # the connectivity from the cockroach process back to the cdc-sink
 # test rig.
+#
+# Note that the names of the services in this file must align with
+# the integration matrix variable in workflows/tests.yaml, as well
+# as the values passed to sinktest.IntegrationMain.
 version: "3.9"
 services:
   cockroachdb-v20.2:
@@ -16,6 +20,18 @@ services:
     image: cockroachdb/cockroach:latest-v21.2
     network_mode: host
     command: start-single-node --insecure
+  mysql-v8:
+    image: mysql:8-debian
+    platform: linux/x86_64
+    environment:
+      MYSQL_ROOT_PASSWORD: SoupOrSecret
+      MYSQL_DATABASE: _cdc_sink
+    command: |
+      --default-authentication-plugin=mysql_native_password
+      --gtid_mode=on
+      --enforce_gtid_consistency=on
+    ports:
+      - "3306:3306"
   postgresql-v11:
     image: postgres:11
     environment:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,15 +59,22 @@ jobs:
         run: go run honnef.co/go/tools/cmd/staticcheck -checks all ./...
 
   integration:
-    name: Integration Tests crdb-${{ matrix.cockroachdb }} pg-${{ matrix.postgresql }}
+    name: Integration Tests crdb-${{ matrix.cockroachdb }} ${{ matrix.integration }}
     strategy:
       fail-fast: false
       matrix:
         cockroachdb: [ v20.2, v21.1, v21.2 ]
-        postgresql: [ v11, v12, v13, v14 ]
+        # This matrix component should use the target names listed
+        # in the docker-compose.yml file in the parent directory.
+        integration:
+          - "mysql-v8"
+          - "postgresql-v11"
+          - "postgresql-v12"
+          - "postgresql-v13"
+          - "postgresql-v14"
     runs-on: ubuntu-latest
     env:
-      COVER_OUT: coverage-${{ matrix.coverage }}.out
+      COVER_OUT: coverage.out
     steps:
       - uses: actions/checkout@v2
 
@@ -98,19 +105,22 @@ jobs:
         working-directory: .github
         run: docker-compose up -d cockroachdb-${{ matrix.cockroachdb }}
 
-      - name: Start PostgreSQL
+      - name: Start ${{ matrix.integration }}
+        if: ${{ matrix.integration }}
         working-directory: .github
-        run: docker-compose up -d postgresql-${{ matrix.postgresql }}
+        run: docker-compose up -d ${{ matrix.integration }}
 
       - name: Go Tests
         env:
           COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
+          CDC_INTEGRATION: ${{ matrix.integration }}
         run: go test -v -race -coverpkg=./internal/... -covermode=atomic -coverprofile=${{ env.COVER_OUT }} ./...
 
       - name: Manual Benchmarks
         if: ${{ github.event.inputs.run_bench }}
         env:
           COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
+          CDC_INTEGRATION: ${{ matrix.integration }}
         run: go test -v -benchtime 10s -bench . ./...
 
       - name: Stop databases

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -38,6 +38,10 @@ var (
 		"connection string for PostgreSQL instance")
 )
 
+func TestMain(m *testing.M) {
+	sinktest.IntegrationMain(m, sinktest.PostgreSQLName)
+}
+
 // This is a general smoke-test of the logical replication feed.
 func TestPGLogical(t *testing.T) {
 	t.Run("consistent", func(t *testing.T) { testPGLogical(t, false) })

--- a/internal/target/sinktest/integration.go
+++ b/internal/target/sinktest/integration.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sinktest
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// IntegrationEnvName is an environment variable that enables
+	// integration tests for some databases. We expect this to be of the
+	// format "database-v123".
+	IntegrationEnvName = "CDC_INTEGRATION"
+	// PostgreSQLName must be kept in alignment with the
+	// .github/docker-compose.yml file and the integration matrix
+	// variable in workflows/tests.yaml.
+	PostgreSQLName = "postgresql"
+)
+
+// IntegrationMain runs the tests if the value of IntegrationEnvName
+// equals the given string, or starts with the given string, followed by
+// a hyphen. This method calls os.Exit() and therefore never returns.
+func IntegrationMain(m *testing.M, db string) {
+	found := os.Getenv(IntegrationEnvName)
+	if found == db || strings.HasPrefix(found, db+"-") {
+		os.Exit(m.Run())
+	}
+	log.Infof("skipping %s integration tests: %s=%q", db, IntegrationEnvName, found)
+	os.Exit(0)
+}


### PR DESCRIPTION
This change prepares the testing workflow for additional integration-testing
targets. An environment variable, CDC_INTEGRATION is used to selectively enable
integration tests by declaring a TestMain function in a target-specific
package.

This change also adds a no-op matrix test against MySQL 8, in preparation for
the MySQL logical-feed support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/113)
<!-- Reviewable:end -->
