### PR TITLE
fan: Advance consistent point in high-rate scenario

### DIFF
--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -567,13 +567,14 @@ func (c *Conn) readReplicationData(ctx context.Context, ch chan<- pglogrepl.Mess
 		}
 
 		if time.Now().After(standbyDeadline) {
+			logPos := c.getLogPos()
 			err = pglogrepl.SendStandbyStatusUpdate(ctx, replConn, pglogrepl.StandbyStatusUpdate{
-				WALWritePosition: c.getLogPos(),
+				WALWritePosition: logPos,
 			})
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			log.Trace("Sent Standby status message")
+			log.WithField("WALWritePosition", logPos).Trace("sent Standby status message")
 			standbyDeadline = time.Now().Add(standbyTimeout)
 		}
 


### PR DESCRIPTION
The existing code would never execute the onConsistent callback if the bucket
never becomes idle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/114)
<!-- Reviewable:end -->
