### PR TITLE
logical: Extract base behaviors for logical replication.

### DIFF
--- a/internal/source/logical/chaos.go
+++ b/internal/source/logical/chaos.go
@@ -1,0 +1,101 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package logical
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/pkg/errors"
+)
+
+// ErrChaos is the error that will be injected by the WithChaos wrappers
+// in this package.
+var ErrChaos = errors.New("chaos")
+
+// WithChaos returns a wrapper around a Dialect that will inject errors
+// at various points throughout the execution.
+func WithChaos(delegate Dialect, prob float32) Dialect {
+	return &chaosDialect{
+		delegate: delegate,
+		prob:     prob,
+	}
+}
+
+// This could include a *rand.Rand, but as soon as we start calling
+// methods from multiple goroutines, there's no hope of repeatable
+// behavior.
+type chaosDialect struct {
+	delegate Dialect
+	prob     float32
+}
+
+var _ Dialect = (*chaosDialect)(nil)
+
+func (d *chaosDialect) ReadInto(ctx context.Context, ch chan<- Message, state State) error {
+	if rand.Float32() < d.prob {
+		return ErrChaos
+	}
+	return d.delegate.ReadInto(ctx, ch, state)
+}
+
+func (d *chaosDialect) Process(ctx context.Context, ch <-chan Message, events Events) error {
+	if rand.Float32() < d.prob {
+		return ErrChaos
+	}
+	return d.delegate.Process(ctx, ch, &chaosEvents{events, d.prob})
+}
+
+type chaosEvents struct {
+	delegate Events
+	prob     float32
+}
+
+var _ Events = (*chaosEvents)(nil)
+
+func (e *chaosEvents) GetConsistentPoint() stamp.Stamp {
+	return e.delegate.GetConsistentPoint()
+}
+
+func (e *chaosEvents) GetTargetDB() ident.Ident {
+	return e.delegate.GetTargetDB()
+}
+
+func (e *chaosEvents) OnBegin(ctx context.Context, point stamp.Stamp) error {
+	if rand.Float32() < e.prob {
+		return ErrChaos
+	}
+	return e.delegate.OnBegin(ctx, point)
+}
+
+func (e *chaosEvents) OnCommit(ctx context.Context) error {
+	if rand.Float32() < e.prob {
+		return ErrChaos
+	}
+	return e.delegate.OnCommit(ctx)
+}
+
+func (e *chaosEvents) OnData(ctx context.Context, target ident.Table, muts []types.Mutation) error {
+	if rand.Float32() < e.prob {
+		return ErrChaos
+	}
+	return e.delegate.OnData(ctx, target, muts)
+}
+
+func (e *chaosEvents) OnRollback(ctx context.Context, msg Message) error {
+	if rand.Float32() < e.prob {
+		return ErrChaos
+	}
+	return e.delegate.OnRollback(ctx, msg)
+}

--- a/internal/source/logical/config.go
+++ b/internal/source/logical/config.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package logical
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+const (
+	defaultApplyTimeout  = 30 * time.Second
+	defaultRetryDelay    = 10 * time.Second
+	defaultTargetDBConns = 1024
+	defaultBytesInFlight = 10 * 1024 * 1024
+)
+
+// Config defines the core configuration required by logical.Loop.
+type Config struct {
+	// The maximum length of time to wait for an incoming transaction
+	// to settle (i.e. to detect stalls in the target database).
+	ApplyTimeout time.Duration
+	// The maximum number of raw tuple-data that has yet to be applied
+	// to the target database. This will act as an approximate upper
+	// bound on the amount of in-memory tuple data by pausing the
+	// replication receiver until sufficient number of other mutations
+	// have been applied.
+	BytesInFlight int
+	// Place the configuration into immediate mode, where mutations are
+	// applied without waiting for transaction boundaries.
+	Immediate bool
+	// The amount of time to sleep between replication-loop retries.
+	// If zero, a default value will be used.
+	RetryDelay time.Duration
+	// Connection string for the target cluster.
+	TargetConn string
+	// The SQL database in the target cluster to write into.
+	TargetDB ident.Ident
+	// The number of connections to the target database. If zero, a
+	// default value will be used.
+	TargetDBConns int
+}
+
+// Preflight ensures that unset configuration options have sane defaults
+// and returns an error if the Config is missing any fields for which a
+// default connot be provided.
+func (c *Config) Preflight() error {
+	if c.ApplyTimeout == 0 {
+		c.ApplyTimeout = defaultApplyTimeout
+	}
+	if c.BytesInFlight == 0 {
+		c.BytesInFlight = defaultBytesInFlight
+	}
+	if c.RetryDelay == 0 {
+		c.RetryDelay = defaultRetryDelay
+	}
+	if c.TargetConn == "" {
+		return errors.New("no target connection string specified")
+	}
+	if c.TargetDB.IsEmpty() {
+		return errors.New("no target database specified")
+	}
+	if c.TargetDBConns == 0 {
+		c.TargetDBConns = defaultTargetDBConns
+	}
+	return nil
+}

--- a/internal/source/logical/dialect.go
+++ b/internal/source/logical/dialect.go
@@ -1,0 +1,94 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package logical
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+)
+
+// Dialect encapsulates the source-specific implementation details.
+type Dialect interface {
+	// ReadInto represents a potentially-fragile source of
+	// logical-replication messages.
+	//
+	// If this method returns with an error, a Rollback message will be
+	// injected into the channel given to Process. ReadInto will then be
+	// called again to restart the replication feed from the most recent
+	// consistent point.
+	//
+	// The "from" argument is the last consistent point that was
+	// processed by the stream. This can be used to verify successful
+	// resynchronization with the source database.
+	ReadInto(ctx context.Context, ch chan<- Message, state State) error
+
+	// Process decodes the logical replication messages, to call the
+	// various OnEvent methods. If this method returns an error, the
+	// entire replication loop will be restarted.
+	Process(ctx context.Context, ch <-chan Message, events Events) error
+}
+
+// A Message is specific to a Dialect.
+type Message interface{}
+
+// Rollback is a sentinel message that will be injected into the values
+// received by Dialect.Process.
+var msgRollback Message = &struct{}{}
+
+// IsRollback returns true if the message represents a break in the data
+// emitted from Dialect.ReadInto.
+func IsRollback(m Message) bool {
+	return m == msgRollback
+}
+
+// Events extends State to drive the state of the replication loop.
+type Events interface {
+	State
+	// OnBegin denotes the beginning of a transactional block in the
+	// underlying logical feed.
+	OnBegin(ctx context.Context, point stamp.Stamp) error
+	// OnCommit denotes the end of a transactional black in the underlying
+	// logical feed.
+	OnCommit(ctx context.Context) error
+	// OnData adds data to the transaction block.
+	OnData(ctx context.Context, target ident.Table, muts []types.Mutation) error
+	// OnRollback must be called by Dialect.Process when a rollback
+	// message is encountered, to ensure that all internal state has
+	// been resynchronized.
+	OnRollback(ctx context.Context, msg Message) error
+}
+
+// State provides information about a replication loop.
+type State interface {
+	// GetConsistentPoint returns the most recent consistent point that
+	// has been committed to the target database.
+	GetConsistentPoint() stamp.Stamp
+	// GetTargetDB returns the target database name.
+	GetTargetDB() ident.Ident
+}
+
+// OffsetStamp is a Stamp which can represent itself as an absolute
+// offset value. This is used for optional metrics reporting.
+type OffsetStamp interface {
+	stamp.Stamp
+	AsOffset() uint64
+}
+
+// TimeStamp is a Stamp which can represent itself as a time.Time. This
+// is used for optional metrics reporting.
+type TimeStamp interface {
+	stamp.Stamp
+	AsTime() time.Time
+}

--- a/internal/source/logical/logical.go
+++ b/internal/source/logical/logical.go
@@ -1,0 +1,307 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package logical provides a common logical-replication loop behavior.
+package logical
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/apply/fan"
+	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/serial"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/jackc/pgtype/pgxtype"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// impl provides a common feature set for processing single-stream,
+// logical replication feeds. This can be used to build feeds from any
+// data source which has well-defined "consistent points", such as
+// write-ahead-log offsets or explicit transaction ids.
+//
+// impl is not internally synchronized; it assumes that it is being
+// driven by a serial stream of data.
+type impl struct {
+	// Locked on mu.
+	consistentPointUpdated *sync.Cond
+	// The Dialect contains message-processing, specific to a particular
+	// source database.
+	dialect Dialect
+	// The fan manages the fan-out of applying mutations across multiple
+	// SQL connections.
+	fan *fan.Fan
+	// openTransaction tracks the latest value passed to OnCommit.
+	openTransaction stamp.Stamp
+	// The amount of time to sleep between retries of the replication
+	// loop.
+	retryDelay time.Duration
+	// Allows us to force the concurrent applier logic to concentrate
+	// its work into a single underlying database transaction. This will
+	// be nil when running in the default, concurrent, mode.
+	serializer *serial.Pool
+	// The SQL database we're going to be writing into.
+	targetDB ident.Ident
+
+	mu struct {
+		sync.Mutex
+
+		// This represents a position in the source's transaction log.
+		// It is subject to a mutex, since we receive the notifications
+		// from the Fan in an asynchronous manner.
+		consistentPoint stamp.Stamp
+	}
+}
+
+// Start constructs a new replication loop that will process messages
+// until the context is cancelled. The returned channel can be monitored
+// to know when the loop has halted.
+func Start(
+	ctx context.Context, config *Config, dialect Dialect,
+) (stopped <-chan struct{}, _ error) {
+	if err := config.Preflight(); err != nil {
+		return nil, err
+	}
+
+	// Bring up connection to target database.
+	targetCfg, err := pgxpool.ParseConfig(config.TargetConn)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse %q", config.TargetConn)
+	}
+	// Identify traffic.
+	targetCfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET application_name=$1", "cdc-sink")
+		return err
+	}
+	// Bigger pools are better for CRDB.
+	targetCfg.MaxConns = int32(config.TargetDBConns)
+	// Ensure connection diversity through long-lived loadbalancers.
+	targetCfg.MaxConnLifetime = 10 * time.Minute
+	// Keep one spare connection.
+	targetCfg.MinConns = 1
+
+	targetPool, err := pgxpool.ConnectConfig(ctx, targetCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not connect to CockroachDB")
+	}
+
+	watchers, cancelWatchers := schemawatch.NewWatchers(targetPool)
+	appliers, cancelAppliers := apply.NewAppliers(watchers)
+
+	loop := &impl{
+		dialect:    dialect,
+		retryDelay: config.RetryDelay,
+		targetDB:   config.TargetDB,
+	}
+	loop.consistentPointUpdated = sync.NewCond(&loop.mu)
+
+	// If the user wants to preserve transaction boundaries, we inject a
+	// helper which forces all database operations to be applied within
+	// a single transaction.
+	var applyQuerier pgxtype.Querier = targetPool
+	applyShards := 16
+	if !config.Immediate {
+		loop.serializer = &serial.Pool{Pool: targetPool}
+		applyQuerier = loop.serializer
+		applyShards = 1
+	}
+	var cancelFan func()
+	loop.fan, cancelFan, err = fan.New(
+		appliers,
+		config.ApplyTimeout,
+		applyQuerier,
+		loop.setConsistentPoint,
+		applyShards,
+		config.BytesInFlight,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	stopper := make(chan struct{})
+	go func() {
+		loop.run(ctx)
+		cancelFan()
+		cancelAppliers()
+		cancelWatchers()
+		targetPool.Close()
+		close(stopper)
+	}()
+
+	return stopper, nil
+}
+
+// GetConsistentPoint implements State.
+func (l *impl) GetConsistentPoint() stamp.Stamp {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.mu.consistentPoint
+}
+
+// GetTargetDB implements State.
+func (l *impl) GetTargetDB() ident.Ident {
+	return l.targetDB
+}
+
+// OnBegin implements Events.
+func (l *impl) OnBegin(ctx context.Context, point stamp.Stamp) error {
+	if l.openTransaction != nil {
+		return errors.Errorf("OnBegin already called at %s", l.openTransaction)
+	}
+	l.openTransaction = point
+	if l.serializer == nil {
+		return nil
+	}
+	return l.serializer.Begin(ctx)
+}
+
+// OnCommit implements Events.
+func (l *impl) OnCommit(ctx context.Context) error {
+	if l.openTransaction == nil {
+		return errors.New("OnCommit called without matching OnBegin")
+	}
+
+	var err error
+	defer func() {
+		tx := l.openTransaction
+		l.openTransaction = nil
+		if err != nil {
+			commitFailureCount.Inc()
+		} else {
+			commitSuccessCount.Inc()
+			if x, ok := tx.(TimeStamp); ok {
+				commitTime.Set(float64(x.AsTime().UnixNano()))
+			}
+			if x, ok := tx.(OffsetStamp); ok {
+				commitOffset.Set(float64(x.AsOffset()))
+			}
+		}
+	}()
+
+	if err = l.fan.Mark(l.openTransaction); err != nil {
+		return err
+	}
+
+	// If we're running in serial (as opposed to concurrent) mode, we
+	// want to wait for the pending mutations to be flushed to the
+	// single transaction, and then we'll commit the transaction.
+	if l.serializer != nil {
+		l.mu.Lock()
+		for stamp.Compare(l.mu.consistentPoint, l.openTransaction) < 0 {
+			l.consistentPointUpdated.Wait()
+		}
+		l.mu.Unlock()
+		// err is checked by the deferred call above.
+		err = l.serializer.Commit(ctx)
+	}
+	return err
+}
+
+// OnData implements Events.
+func (l *impl) OnData(ctx context.Context, target ident.Table, muts []types.Mutation) error {
+	return l.fan.Enqueue(ctx, l.openTransaction, target, muts)
+}
+
+// OnRollback implements Events.
+func (l *impl) OnRollback(ctx context.Context, msg Message) error {
+	if !IsRollback(msg) {
+		return errors.New("the rollback message must be passed to OnRollback")
+	}
+	l.reset()
+	return nil
+}
+
+// reset is called before every attempt at running the replication loop.
+func (l *impl) reset() {
+	l.fan.Reset()
+	l.openTransaction = nil
+	if s := l.serializer; s != nil {
+		// Don't really care about the transaction state.
+		_ = s.Rollback(context.Background())
+	}
+}
+
+// run blocks while the connection is processing messages.
+func (l *impl) run(ctx context.Context) {
+	defer log.Info("replication loop shut down")
+	for {
+		// Ensure that we're in a clear state when recovering.
+		l.reset()
+		group, groupCtx := errgroup.WithContext(ctx)
+
+		// Start a background goroutine to maintain the replication
+		// connection. This source goroutine is set up to be robust; if
+		// there's an error talking to the source database, we send a
+		// rollback message to the consumer and retry the connection.
+		ch := make(chan Message, 16)
+		group.Go(func() error {
+			defer close(ch)
+			for {
+				if err := l.dialect.ReadInto(groupCtx, ch, l); err != nil {
+					log.WithError(err).Error("error from replication source; continuing")
+				}
+				// If the context was canceled, just exit.
+				if err := groupCtx.Err(); err != nil {
+					return nil
+				}
+				// Otherwise, we'll recover by injecting a new rollback
+				// message and then restarting the message stream from
+				// the previous consistent point.
+				select {
+				case ch <- msgRollback:
+					continue
+				case <-groupCtx.Done():
+					return nil
+				}
+			}
+		})
+
+		// This goroutine applies the incoming mutations to the target
+		// database. It is fragile, when it errors, we need to also
+		// restart the source goroutine.
+		group.Go(func() error {
+			err := l.dialect.Process(groupCtx, ch, l)
+			if err != nil {
+				log.WithError(err).Error("error while applying replication messages; stopping")
+			}
+			return err
+		})
+
+		err := group.Wait()
+
+		// If the outer context is done, just return.
+		if ctx.Err() != nil {
+			return
+		}
+
+		log.WithError(err).Errorf("error in replication loop; retrying in %s", l.retryDelay)
+		select {
+		case <-time.After(l.retryDelay):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (l *impl) setConsistentPoint(p stamp.Stamp) {
+	l.mu.Lock()
+	l.mu.consistentPoint = p
+	l.mu.Unlock()
+	l.consistentPointUpdated.Broadcast()
+}

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -1,0 +1,278 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package logical
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/target/sinktest"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeMessage int
+
+var _ stamp.Stamp = fakeMessage(0)
+
+func (f fakeMessage) Less(other stamp.Stamp) bool {
+	return f < other.(fakeMessage)
+}
+
+// generatorDialect implements logical.Dialect to generate mutations
+// for a KV table.
+type generatorDialect struct {
+	// Send an update for each table.
+	tables []ident.Table
+
+	// Counters to ensure we shut down cleanly.
+	atomic struct {
+		readIntoExits int32
+		processExits  int32
+	}
+
+	workRequested chan struct{}
+	readIntoMu    struct {
+		sync.Mutex
+		totalRequested int
+		lastBatchSent  int
+	}
+
+	processMu struct {
+		sync.Mutex
+		messages []Message
+	}
+}
+
+var _ Dialect = (*generatorDialect)(nil)
+
+func newGenerator(tables []ident.Table) *generatorDialect {
+	return &generatorDialect{
+		tables:        tables,
+		workRequested: make(chan struct{}, 1),
+	}
+}
+
+func (g *generatorDialect) emit(numBatches int) {
+	g.readIntoMu.Lock()
+	defer g.readIntoMu.Unlock()
+	g.readIntoMu.totalRequested += numBatches
+	select {
+	case g.workRequested <- struct{}{}:
+	default:
+		panic("work request channel is full")
+	}
+}
+
+// ReadInto waits to be woken up by a call to emit, then writes
+// n-many counter messages into the channel.
+func (g *generatorDialect) ReadInto(ctx context.Context, ch chan<- Message, state State) error {
+	log.Trace("ReadInto starting")
+	defer atomic.AddInt32(&g.atomic.readIntoExits, 1)
+
+	nextBatchNumber := 0
+	// If we're recovering from a failure condition, reset to a consistent point.
+	if prev := state.GetConsistentPoint(); prev != nil {
+		nextBatchNumber = int(prev.(fakeMessage)) + 1
+		log.Tracef("restarting at %d", nextBatchNumber)
+	}
+
+	for {
+		g.readIntoMu.Lock()
+		requested := g.readIntoMu.totalRequested
+		g.readIntoMu.Unlock()
+
+		// emit requested number of messages.
+		for nextBatchNumber < requested {
+			log.Tracef("sending %d", nextBatchNumber)
+			// Non-blocking send if the ctx is shut down.
+			select {
+			case ch <- fakeMessage(nextBatchNumber):
+				g.readIntoMu.Lock()
+				g.readIntoMu.lastBatchSent = nextBatchNumber
+				g.readIntoMu.Unlock()
+
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			nextBatchNumber++
+		}
+
+		// Wait for more work or to be shut down
+		select {
+		case <-g.workRequested:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// Each message triggers a transaction flow to send one mutation to each
+//  configured table.
+func (g *generatorDialect) Process(ctx context.Context, ch <-chan Message, events Events) error {
+	log.Trace("Process starting")
+	defer atomic.AddInt32(&g.atomic.processExits, 1)
+
+	for {
+		// Non-blocking read if the context is shut down.
+		var msg fakeMessage
+		select {
+		case m := <-ch:
+			g.processMu.Lock()
+			g.processMu.messages = append(g.processMu.messages, m)
+			g.processMu.Unlock()
+
+			// Ensure that rollbacks result in proper resynchronization.
+			if IsRollback(m) {
+				if err := events.OnRollback(ctx, m); err != nil {
+					return err
+				}
+				continue
+			}
+			msg = m.(fakeMessage)
+			log.Tracef("received %d", msg)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		if err := events.OnBegin(ctx, msg); err != nil {
+			return err
+		}
+
+		for _, tbl := range g.tables {
+			mut := types.Mutation{
+				Key:  []byte(fmt.Sprintf(`[%d]`, msg)),
+				Data: []byte(fmt.Sprintf(`{"k":%d,"v":"%d"}`, msg, msg)),
+			}
+			if err := events.OnData(ctx, tbl, []types.Mutation{mut}); err != nil {
+				return err
+			}
+		}
+
+		if err := events.OnCommit(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func TestLogical(t *testing.T) {
+	t.Run("consistent", func(t *testing.T) { testLogicalSmoke(t, false, false) })
+	t.Run("consistent-chaos", func(t *testing.T) { testLogicalSmoke(t, false, true) })
+	t.Run("immediate", func(t *testing.T) { testLogicalSmoke(t, true, false) })
+	t.Run("immediate-chaos", func(t *testing.T) { testLogicalSmoke(t, true, true) })
+}
+
+func testLogicalSmoke(t *testing.T, immediate, withChaos bool) {
+	a := assert.New(t)
+
+	ctx, info, cancel := sinktest.Context()
+	defer cancel()
+	pool := info.Pool()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	// Create some tables.
+	tgts := []ident.Table{
+		ident.NewTable(dbName, ident.Public, ident.New("t1")),
+		ident.NewTable(dbName, ident.Public, ident.New("t2")),
+		ident.NewTable(dbName, ident.Public, ident.New("t3")),
+		ident.NewTable(dbName, ident.Public, ident.New("t4")),
+	}
+
+	for _, tgt := range tgts {
+		var schema = fmt.Sprintf(`CREATE TABLE %s (k INT PRIMARY KEY, v TEXT)`, tgt)
+		if _, err := pool.Exec(ctx, schema); !a.NoError(err) {
+			return
+		}
+	}
+
+	gen := newGenerator(tgts)
+	const numEmits = 100
+	gen.emit(numEmits)
+
+	var dialect Dialect = gen
+	if withChaos {
+		dialect = WithChaos(gen, 0.01)
+	}
+
+	cfg := &Config{
+		ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
+		Immediate:    immediate,
+		RetryDelay:   time.Nanosecond,
+		TargetConn:   pool.Config().ConnString(),
+		TargetDB:     dbName,
+	}
+	loopCtx, cancelLoop := context.WithCancel(ctx)
+	defer cancelLoop()
+	stopped, err := Start(loopCtx, cfg, dialect)
+	if !a.NoError(err) {
+		return
+	}
+
+	// Wait for replication.
+	for _, tgt := range tgts {
+		for {
+			var count int
+			if err := pool.QueryRow(ctx, fmt.Sprintf("SELECT count(*) FROM %s", tgt)).Scan(&count); !a.NoError(err) {
+				return
+			}
+			log.Trace("backfill count", count)
+			if count == numEmits {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Wait for the loop to shut down, or a timeout.
+	cancelLoop()
+	gen.emit(0) // Kick the simplistic ReadInto loop so that it exits.
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		a.Fail("timed out waiting for shutdown")
+	}
+	if !withChaos {
+		a.Equal(int32(1), atomic.LoadInt32(&gen.atomic.processExits))
+		a.Equal(int32(1), atomic.LoadInt32(&gen.atomic.readIntoExits))
+	}
+
+	// Verify that we did drain the generator.
+	gen.readIntoMu.Lock()
+	defer gen.readIntoMu.Unlock()
+	a.Equal(numEmits-1, gen.readIntoMu.lastBatchSent)
+
+	// Verify that we saw all messages.
+	gen.processMu.Lock()
+	defer gen.processMu.Unlock()
+	// Verify that we saw each unique key at least once. The actual
+	// slice of messages will contain repeated entries in the chaos
+	// tests.
+	found := make(map[fakeMessage]struct{})
+	for _, msg := range gen.processMu.messages {
+		if fake, ok := msg.(fakeMessage); ok {
+			found[fake] = struct{}{}
+		}
+	}
+	a.Len(found, numEmits)
+}

--- a/internal/source/logical/metrics.go
+++ b/internal/source/logical/metrics.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package logical
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	commitSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "logical_commit_success_total",
+		Help: "the number transactions from the source database that were applied",
+	})
+	commitFailureCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "logical_commit_failure_total",
+		Help: "the number transactions from the source database that failed to apply",
+	})
+	commitOffset = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "logical_last_commit_offset_bytes",
+		Help: "the offset that we are reporting to the source database",
+	})
+	commitTime = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "logical_last_commit_seconds",
+		Help: "the original time of the most recently applied commit from the source database",
+	})
+)

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -16,38 +16,32 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
-	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
-	"github.com/cockroachdb/cdc-sink/internal/target/apply/fan"
-	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
-	"github.com/cockroachdb/cdc-sink/internal/target/timekeeper"
+	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/cockroachdb/cdc-sink/internal/util/serial"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
 	"github.com/google/uuid"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgproto3/v2"
-	"github.com/jackc/pgtype/pgxtype"
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 // lsnStamp adapts the LSN offset type to a comparable Stamp value.
 type lsnStamp pglogrepl.LSN
 
-func (s lsnStamp) Less(other stamp.Stamp) bool {
-	o := other.(lsnStamp)
-	return s < o
-}
+var (
+	_ stamp.Stamp         = lsnStamp(0)
+	_ logical.OffsetStamp = lsnStamp(0)
+)
+
+func (s lsnStamp) AsLSN() pglogrepl.LSN        { return pglogrepl.LSN(s) }
+func (s lsnStamp) AsOffset() uint64            { return uint64(s) }
+func (s lsnStamp) Less(other stamp.Stamp) bool { return s < other.(lsnStamp) }
 
 // A Conn encapsulates all wire-connection behavior. It is
 // responsible for receiving replication messages and replying with
@@ -55,76 +49,25 @@ func (s lsnStamp) Less(other stamp.Stamp) bool {
 type Conn struct {
 	// Columns, as ordered by the source database.
 	columns map[ident.Table][]types.ColData
-	// The fan manages the fan-out of applying mutations across multiple
-	// SQL connections.
-	fan *fan.Fan
-	// Locked on mu.
-	logPosUpdated *sync.Cond
 	// The pg publication name to subscribe to.
 	publicationName string
 	// Map source ids to target tables.
 	relations map[uint32]ident.Table
-	// The amount of time to sleep between retries of the replication
-	// loop.
-	retryDelay time.Duration
-	// Allows us to force the concurrent applier logic to concentrate
-	// its work into a single underlying database transaction. This will
-	// be nil when running in the default, concurrent, mode.
-	serializer *serial.Pool
 	// The name of the slot within the publication.
 	slotName string
 	// The configuration for opening replication connections.
 	sourceConfig *pgconn.Config
-	// The SQL database we're going to be writing into.
-	targetDB ident.Ident
-	// Likely nil.
-	testControls *TestControls
-	// Drain.
-	timeKeeper types.TimeKeeper
-	// The log offset of the transaction being processed.
-	txLSN pglogrepl.LSN
-	// The (eventual) commit time of the transaction being processed.
-	txTime hlc.Time
-
-	mu struct {
-		sync.Mutex
-
-		// This is the position in the transaction log that we'll
-		// occasionally report back to the server. It is updated when we
-		// successfully commit an entire transaction's worth of data.
-		clientXLogPos pglogrepl.LSN
-	}
 }
+
+var _ logical.Dialect = (*Conn)(nil)
 
 // NewConn constructs a new pglogical replication feed.
 //
 // The feed will terminate when the context is canceled and the stopped
 // channel will be closed once shutdown is complete.
 func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struct{}, _ error) {
-	// Some pre-flight checks.
-	if config.Publication == "" {
-		return nil, nil, errors.New("no publication name was configured")
-	}
-	if config.Slot == "" {
-		return nil, nil, errors.New("no replication slot name was configured")
-	}
-	if config.SourceConn == "" {
-		return nil, nil, errors.New("no source connection was configured")
-	}
-	if config.TargetConn == "" {
-		return nil, nil, errors.New("no target connection was configured")
-	}
-	if config.TargetDB.IsEmpty() {
-		return nil, nil, errors.New("no target db was configured")
-	}
-	if config.ApplyTimeout == 0 {
-		config.ApplyTimeout = defaultApplyTimeout
-	}
-	if config.BytesInFlight == 0 {
-		config.BytesInFlight = defaultBytesInFlight
-	}
-	if config.TargetDBConns == 0 {
-		config.TargetDBConns = defaultTargetDBConns
+	if err := config.Preflight(); err != nil {
+		return nil, nil, err
 	}
 
 	// Verify that the publication and replication slots were configured
@@ -171,350 +114,71 @@ func NewConn(ctx context.Context, config *Config) (_ *Conn, stopped <-chan struc
 	sourceConfig := source.Config().Config.Copy()
 	sourceConfig.RuntimeParams["replication"] = "database"
 
-	// Bring up connection to target database.
-	targetCfg, err := pgxpool.ParseConfig(config.TargetConn)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "could not parse %q", config.TargetConn)
-	}
-	// Identify traffic.
-	targetCfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
-		_, err := conn.Exec(ctx, "SET application_name=$1", "cdc-sink")
-		return err
-	}
-	// Bigger pools are better for CRDB.
-	targetCfg.MaxConns = int32(config.TargetDBConns)
-	// Ensure connection diversity through long-lived loadbalancers.
-	targetCfg.MaxConnLifetime = 10 * time.Minute
-	// Keep one spare connection.
-	targetCfg.MinConns = 1
-
-	targetPool, err := pgxpool.ConnectConfig(ctx, targetCfg)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not connect to CockroachDB")
-	}
-
-	timeKeeper, cancelTimeKeeper, err := timekeeper.NewTimeKeeper(ctx, targetPool, cdc.Resolved)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	watchers, cancelWatchers := schemawatch.NewWatchers(targetPool)
-	appliers, cancelAppliers := apply.NewAppliers(watchers)
-
 	ret := &Conn{
 		columns:         make(map[ident.Table][]types.ColData),
 		publicationName: config.Publication,
 		relations:       make(map[uint32]ident.Table),
-		retryDelay:      config.RetryDelay,
 		slotName:        config.Slot,
 		sourceConfig:    sourceConfig,
-		targetDB:        config.TargetDB,
-		testControls:    config.TestControls,
-		timeKeeper:      timeKeeper,
 	}
-	ret.logPosUpdated = sync.NewCond(&ret.mu)
-	if ret.retryDelay == 0 {
-		ret.retryDelay = defaultRetryDelay
+	// Add chaos, for testing.
+	var dialect logical.Dialect = ret
+	if config.withChaosProb > 0 {
+		dialect = logical.WithChaos(dialect, config.withChaosProb)
 	}
 
-	// If the user wants to preserve transaction boundaries, we inject a
-	// helper which forces all database operations to be applied within
-	// a single transaction.
-	var applyQuerier pgxtype.Querier = targetPool
-	applyShards := 16
-	if !config.Immediate {
-		ret.serializer = &serial.Pool{Pool: targetPool}
-		applyQuerier = ret.serializer
-		applyShards = 1
-	}
-	var cancelFan func()
-	ret.fan, cancelFan, err = fan.New(
-		appliers,
-		config.ApplyTimeout,
-		applyQuerier,
-		func(stamp stamp.Stamp) { ret.setLogPos(pglogrepl.LSN(stamp.(lsnStamp))) },
-		applyShards,
-		config.BytesInFlight,
-	)
+	stopper, err := logical.Start(ctx, &config.Config, dialect)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	stopper := make(chan struct{})
-	go func() {
-		_ = ret.run(ctx)
-		cancelFan()
-		cancelAppliers()
-		cancelWatchers()
-		cancelTimeKeeper()
-		targetPool.Close()
-		close(stopper)
-	}()
-
 	return ret, stopper, nil
 }
 
-// reset the connection's internal status to an idle state. This
-// will be called any time there is an error applying mutations.
-func (c *Conn) reset() {
-	c.fan.Reset()
-	c.txLSN = 0
-	c.txTime = hlc.Zero()
-	if s := c.serializer; s != nil {
-		// Don't really care about the transaction state.
-		_ = s.Rollback(context.Background())
-	}
-}
-
-// run blocks while the connection is processing messages.
-func (c *Conn) run(ctx context.Context) error {
-	for ctx.Err() == nil {
-		// Ensure that we're in a clear state when recovering.
-		c.reset()
-		group, ctx := errgroup.WithContext(ctx)
-
-		// Start a background goroutine to maintain the replication
-		// connection. This source goroutine is set up to be robust; if
-		// there's an error talking to the source database, we send a
-		// rollback message to the consumer and retry the connection.
-		ch := make(chan pglogrepl.Message, 16)
-		group.Go(func() error {
-			defer close(ch)
-			for ctx.Err() == nil {
-				if err := c.readReplicationData(ctx, ch); err != nil {
-					log.WithError(err).Error("error from replication channel; continuing")
-				}
-				select {
-				case ch <- &rollbackMessage{}:
-				case <-ctx.Done():
-					return nil
-				}
-			}
-			return nil
-		})
-
-		// This goroutine applies the incoming mutations to the target
-		// database. It is fragile, when it errors, we need to also
-		// restart the source goroutine.
-		group.Go(func() error {
-			err := c.processMessages(ctx, ch)
-			if err != nil {
-				log.WithError(err).Error("error while applying replication messages; stopping")
-			}
-			return err
-		})
-
-		if err := group.Wait(); err != nil {
-			log.WithError(err).Errorf("error in replication loop; retrying in %s", c.retryDelay)
-			select {
-			case <-ctx.Done():
-			case <-time.After(c.retryDelay):
-			}
-		}
-	}
-	log.Info("shut down replication loop")
-	return nil
-}
-
-func (c *Conn) getLogPos() pglogrepl.LSN {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.mu.clientXLogPos
-}
-
-func (c *Conn) setLogPos(pos pglogrepl.LSN) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.mu.clientXLogPos = pos
-	log.WithField("LSN", pos).Trace("updated LSN")
-	lsnOffset.Set(float64(pos))
-	c.logPosUpdated.Broadcast()
-}
-
-// decodeMutation converts the incoming tuple data into a Mutation.
-func (c *Conn) decodeMutation(
-	tbl ident.Table, data *pglogrepl.TupleData, isDelete bool,
-) (types.Mutation, error) {
-	mut := types.Mutation{Time: c.txTime}
-	var key []string
-	enc := make(map[string]interface{})
-	targetCols, ok := c.columns[tbl]
-	if !ok {
-		return mut, errors.Errorf("no column data for %s", tbl)
-	}
-	if len(targetCols) != len(data.Columns) {
-		return mut, errors.Errorf("column count mismatch is %s: %d vs %d",
-			tbl, len(targetCols), len(data.Columns))
-	}
-	for idx, sourceCol := range data.Columns {
-		targetCol := targetCols[idx]
-		switch sourceCol.DataType {
-		case pglogrepl.TupleDataTypeNull:
-			enc[targetCol.Name.Raw()] = nil
-		case pglogrepl.TupleDataTypeText:
-			// The incoming data is in a textual format.
-			enc[targetCol.Name.Raw()] = string(sourceCol.Data)
-			if targetCol.Primary {
-				key = append(key, string(sourceCol.Data))
-			}
-		case pglogrepl.TupleDataTypeToast:
-			return mut, errors.Errorf(
-				"TOASTed columns are not supported in %s.%s", tbl, targetCol.Name)
-		default:
-			return mut, errors.Errorf(
-				"unimplemented tuple data type %q", string(sourceCol.DataType))
-		}
-	}
-
-	// In the pathological case where a table has no primary key, we'll
-	// generate a random uuid value to use as the staging key. This is
-	// fine, because the underlying data has no particular identity to
-	// update. In fact, it's not possible to issue an UPDATE to Postgres
-	// when a row has no replication identity.
-	if len(key) == 0 {
-		key = []string{uuid.New().String()}
-	}
-
-	var err error
-	mut.Key, err = json.Marshal(key)
-	if err != nil {
-		return mut, errors.WithStack(err)
-	}
-	// We don't need the actual column data for delete operations.
-	if !isDelete {
-		mut.Data, err = json.Marshal(enc)
-		if err != nil {
-			return mut, errors.WithStack(err)
-		}
-	}
-	return mut, errors.WithStack(err)
-}
-
-// learn updates the source database namespace mappings.
-func (c *Conn) learn(msg *pglogrepl.RelationMessage) {
-	// The replication protocol says that we'll see these
-	// descriptors before any use of the relation id in the
-	// stream. We'll map the int value to our table identifiers.
-	tbl := ident.NewTable(
-		c.targetDB,
-		ident.New(msg.Namespace),
-		ident.New(msg.RelationName))
-	c.relations[msg.RelationID] = tbl
-
-	colNames := make([]types.ColData, len(msg.Columns))
-	for idx, col := range msg.Columns {
-		colNames[idx] = types.ColData{
-			Name:    ident.New(col.Name),
-			Primary: col.Flags == 1,
-			// This could be made textual if we used the
-			// ConnInfo metadata methods.
-			Type: fmt.Sprintf("%d", col.DataType),
-		}
-	}
-	c.columns[tbl] = colNames
-
-	log.WithFields(log.Fields{
-		"Columns":    colNames,
-		"RelationID": msg.RelationID,
-		"Table":      tbl,
-	}).Trace("learned relation")
-}
-
-// onCommit ensure that all in-memory data has been committed to the
-// target cluster. It will also update the WAL position that we report
-// back to the source database.
-func (c *Conn) onCommit(ctx context.Context, msg *pglogrepl.CommitMessage) error {
-	commitCount.Inc()
-	commitTime.Set(float64(msg.CommitTime.Unix()))
-
-	mark := lsnStamp(msg.CommitLSN)
-	if err := c.fan.Mark(mark); err != nil {
-		return err
-	}
-
-	// If we're running in serial (as opposed to concurrent) mode, we
-	// want to wait for the pending mutations to be flushed to the
-	// single transaction, and then we'll commit it.
-	if c.serializer == nil {
-		return nil
-	}
-
-	c.mu.Lock()
-	for c.mu.clientXLogPos < msg.CommitLSN {
-		c.logPosUpdated.Wait()
-	}
-	c.mu.Unlock()
-	return c.serializer.Commit(ctx)
-}
-
-// onDataTuple will add an incoming row tuple to the in-memory slice,
-// possibly flushing it when the batch size limit is reached.
-func (c *Conn) onDataTuple(
-	ctx context.Context, relation uint32, tuple *pglogrepl.TupleData, isDelete bool,
+// Process implements logical.Dialect and receives a sequence of logical
+// replication messages, or possibly a rollbackMessage.
+func (c *Conn) Process(
+	ctx context.Context, ch <-chan logical.Message, events logical.Events,
 ) error {
-	if ctrl := c.testControls; ctrl != nil {
-		if fn := c.testControls.BreakOnDataTuple; fn != nil {
-			if fn() {
-				return errors.New("breaking onDataTuple for test")
+	for {
+		// Perform context-aware read.
+		var msg logical.Message
+		select {
+		case msg = <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		// Ensure that we resynchronize.
+		if logical.IsRollback(msg) {
+			if err := events.OnRollback(ctx, msg); err != nil {
+				return err
 			}
 		}
-	}
 
-	traceTuple(tuple)
-	tbl, ok := c.relations[relation]
-	if !ok {
-		return errors.Errorf("unknown relation id %d", relation)
-	}
-	mut, err := c.decodeMutation(tbl, tuple, isDelete)
-	if err != nil {
-		return err
-	}
-
-	return c.fan.Enqueue(ctx, lsnStamp(c.txLSN), tbl, []types.Mutation{mut})
-}
-
-// processMessages receives a sequence of logical replication messages,
-// or possibly a rollbackMessage. If this loop fails out, we'll need to
-// stop and restart the underlying replication network connection.
-func (c *Conn) processMessages(ctx context.Context, ch <-chan pglogrepl.Message) error {
-	for msg := range ch {
 		log.Tracef("message %T", msg)
 		var err error
 		switch msg := msg.(type) {
-		case *rollbackMessage:
-			// This is a custom message that we'll insert to indicate
-			// that the upstream message provider is going to restart
-			// the feed. We want to abandon any in-memory mutations,
-			// since the restart will wind up replaying them.
-			c.reset()
-
 		case *pglogrepl.RelationMessage:
 			// The replication protocol says that we'll see these
 			// descriptors before any use of the relation id in the
 			// stream. We'll map the int value to our table identifiers.
-			c.learn(msg)
+			c.onRelation(msg, events.GetTargetDB())
 
 		case *pglogrepl.BeginMessage:
-			// Starting a new transaction. We're going to accept the
-			// transaction time as reported by the server as our
-			// HLC timestamp for staging purposes.
-			c.txLSN = msg.FinalLSN
-			c.txTime = hlc.From(msg.CommitTime)
-			if s := c.serializer; s != nil {
-				err = s.Begin(ctx)
-			}
+			err = events.OnBegin(ctx, lsnStamp(msg.FinalLSN))
 
 		case *pglogrepl.CommitMessage:
-			err = c.onCommit(ctx, msg)
+			err = events.OnCommit(ctx)
 
 		case *pglogrepl.DeleteMessage:
-			err = c.onDataTuple(ctx, msg.RelationID, msg.OldTuple, true /* isDelete */)
+			err = c.onDataTuple(ctx, events, msg.RelationID, msg.OldTuple, true /* isDelete */)
 
 		case *pglogrepl.InsertMessage:
-			err = c.onDataTuple(ctx, msg.RelationID, msg.Tuple, false /* isDelete */)
+			err = c.onDataTuple(ctx, events, msg.RelationID, msg.Tuple, false /* isDelete */)
 
 		case *pglogrepl.UpdateMessage:
-			err = c.onDataTuple(ctx, msg.RelationID, msg.NewTuple, false /* isDelete */)
+			err = c.onDataTuple(ctx, events, msg.RelationID, msg.NewTuple, false /* isDelete */)
 
 		case *pglogrepl.TruncateMessage:
 			err = errors.Errorf("the TRUNCATE operation cannot be supported on table %d", msg.RelationNum)
@@ -526,22 +190,24 @@ func (c *Conn) processMessages(ctx context.Context, ch <-chan pglogrepl.Message)
 			return err
 		}
 	}
-	return nil
 }
 
-// readReplicationData opens a replication connection and writes parsed
-// messages into the provided channel. This method also manages the
-// keepalive protocol. The consuming code should call Conn.setLogPos
-// in order to advance the server-side high-water mark.
-func (c *Conn) readReplicationData(ctx context.Context, ch chan<- pglogrepl.Message) error {
+// ReadInto implements logical.Dialect, opens a replication connection,
+// and writes parsed messages into the provided channel. This method
+// also manages the keepalive protocol.
+func (c *Conn) ReadInto(ctx context.Context, ch chan<- logical.Message, state logical.State) error {
 	replConn, err := pgconn.ConnectConfig(ctx, c.sourceConfig)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	defer replConn.Close(context.Background())
 
+	var startLogPos pglogrepl.LSN
+	if x, ok := state.GetConsistentPoint().(lsnStamp); ok {
+		startLogPos = x.AsLSN()
+	}
 	if err := pglogrepl.StartReplication(ctx,
-		replConn, c.slotName, c.getLogPos(),
+		replConn, c.slotName, startLogPos,
 		pglogrepl.StartReplicationOptions{
 			PluginArgs: []string{
 				"proto_version '1'",
@@ -557,17 +223,8 @@ func (c *Conn) readReplicationData(ctx context.Context, ch chan<- pglogrepl.Mess
 	standbyDeadline := time.Now().Add(standbyTimeout)
 
 	for ctx.Err() == nil {
-		if ctrl := c.testControls; ctrl != nil {
-			if fn := c.testControls.BreakReplicationFeed; fn != nil {
-				if fn() {
-					log.Debug("closing replication connection for test")
-					_ = replConn.Close(ctx)
-				}
-			}
-		}
-
 		if time.Now().After(standbyDeadline) {
-			logPos := c.getLogPos()
+			logPos := state.GetConsistentPoint().(lsnStamp).AsLSN()
 			err = pglogrepl.SendStandbyStatusUpdate(ctx, replConn, pglogrepl.StandbyStatusUpdate{
 				WALWritePosition: logPos,
 			})
@@ -650,7 +307,118 @@ func (c *Conn) readReplicationData(ctx context.Context, ch chan<- pglogrepl.Mess
 	return nil
 }
 
-// traceTuple
+// decodeMutation converts the incoming tuple data into a Mutation.
+func (c *Conn) decodeMutation(
+	tbl ident.Table, data *pglogrepl.TupleData, isDelete bool,
+) (types.Mutation, error) {
+	var mut types.Mutation
+	var key []string
+	enc := make(map[string]interface{})
+	targetCols, ok := c.columns[tbl]
+	if !ok {
+		return mut, errors.Errorf("no column data for %s", tbl)
+	}
+	if len(targetCols) != len(data.Columns) {
+		return mut, errors.Errorf("column count mismatch is %s: %d vs %d",
+			tbl, len(targetCols), len(data.Columns))
+	}
+	for idx, sourceCol := range data.Columns {
+		targetCol := targetCols[idx]
+		switch sourceCol.DataType {
+		case pglogrepl.TupleDataTypeNull:
+			enc[targetCol.Name.Raw()] = nil
+		case pglogrepl.TupleDataTypeText:
+			// The incoming data is in a textual format.
+			enc[targetCol.Name.Raw()] = string(sourceCol.Data)
+			if targetCol.Primary {
+				key = append(key, string(sourceCol.Data))
+			}
+		case pglogrepl.TupleDataTypeToast:
+			return mut, errors.Errorf(
+				"TOASTed columns are not supported in %s.%s", tbl, targetCol.Name)
+		default:
+			return mut, errors.Errorf(
+				"unimplemented tuple data type %q", string(sourceCol.DataType))
+		}
+	}
+
+	// In the pathological case where a table has no primary key, we'll
+	// generate a random uuid value to use as the staging key. This is
+	// fine, because the underlying data has no particular identity to
+	// update. In fact, it's not possible to issue an UPDATE to Postgres
+	// when a row has no replication identity.
+	if len(key) == 0 {
+		key = []string{uuid.New().String()}
+	}
+
+	var err error
+	mut.Key, err = json.Marshal(key)
+	if err != nil {
+		return mut, errors.WithStack(err)
+	}
+	// We don't need the actual column data for delete operations.
+	if !isDelete {
+		mut.Data, err = json.Marshal(enc)
+		if err != nil {
+			return mut, errors.WithStack(err)
+		}
+	}
+	return mut, errors.WithStack(err)
+}
+
+// onDataTuple will add an incoming row tuple to the in-memory slice,
+// possibly flushing it when the batch size limit is reached.
+func (c *Conn) onDataTuple(
+	ctx context.Context,
+	events logical.Events,
+	relation uint32,
+	tuple *pglogrepl.TupleData,
+	isDelete bool,
+) error {
+	traceTuple(tuple)
+	tbl, ok := c.relations[relation]
+	if !ok {
+		return errors.Errorf("unknown relation id %d", relation)
+	}
+	mut, err := c.decodeMutation(tbl, tuple, isDelete)
+	if err != nil {
+		return err
+	}
+
+	return events.OnData(ctx, tbl, []types.Mutation{mut})
+}
+
+// learn updates the source database namespace mappings.
+func (c *Conn) onRelation(msg *pglogrepl.RelationMessage, targetDB ident.Ident) {
+	// The replication protocol says that we'll see these
+	// descriptors before any use of the relation id in the
+	// stream. We'll map the int value to our table identifiers.
+	tbl := ident.NewTable(
+		targetDB,
+		ident.New(msg.Namespace),
+		ident.New(msg.RelationName))
+	c.relations[msg.RelationID] = tbl
+
+	colNames := make([]types.ColData, len(msg.Columns))
+	for idx, col := range msg.Columns {
+		colNames[idx] = types.ColData{
+			Name:    ident.New(col.Name),
+			Primary: col.Flags == 1,
+			// This could be made textual if we used the
+			// ConnInfo metadata methods.
+			Type: fmt.Sprintf("%d", col.DataType),
+		}
+	}
+	c.columns[tbl] = colNames
+
+	log.WithFields(log.Fields{
+		"Columns":    colNames,
+		"RelationID": msg.RelationID,
+		"Table":      tbl,
+	}).Trace("learned relation")
+}
+
+// traceTuple emits log messages if tracing is enabled.
 func traceTuple(t *pglogrepl.TupleData) {
 	if !log.IsLevelEnabled(log.TraceLevel) {
 		return
@@ -666,17 +434,4 @@ func traceTuple(t *pglogrepl.TupleData) {
 		}
 	}
 	log.WithField("data", s).Trace("values")
-}
-
-// A rollbackMessage is inserted into the message channel to indicate
-// that some error occurred and the receiver should unwind to a safe
-// state.
-type rollbackMessage struct{}
-
-var _ pglogrepl.Message = &rollbackMessage{}
-
-// Type implements pglogrepl.Message and returns a value which is
-// not used by any real message type.
-func (r rollbackMessage) Type() pglogrepl.MessageType {
-	return '!'
 }

--- a/internal/source/pglogical/metrics.go
+++ b/internal/source/pglogical/metrics.go
@@ -16,14 +16,6 @@ import (
 )
 
 var (
-	commitCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pglogical_commit_total",
-		Help: "the number transactions from the source database that were applied",
-	})
-	commitTime = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pglogical_last_commit_seconds",
-		Help: "the original time of the most recently applied commit from the source database",
-	})
 	dialFailureCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pglogical_dial_failure_total",
 		Help: "the number of times we failed to create a replication connection",
@@ -31,9 +23,5 @@ var (
 	dialSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pglogical_dial_success_total",
 		Help: "the number of times we successfully dialed a replication connection",
-	})
-	lsnOffset = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pglogical_lsn_offset_bytes",
-		Help: "the LSN offset that we are reporting to the source database",
 	})
 )


### PR DESCRIPTION
This change separates the read-and-apply loop from the pglogical package. It
retains the two-goroutine approach of having a generator which connects to a
source database and an applier which drives an event-style API provided by the
logical replication loop.

When the producer routine encounters an error (e.g. a network glitch), it can
resynchronize with the upstream source and the applier via a rollback message.
This allows the least amount of disruption to any state which may be maintained
by the applier goroutine, as opposed to having to tear everything down and
restart.

The logical loop is tested by having a fake generator data source. A chaotic
wrapper around the Dialect APIs makes it easier to introduce errors throughout
the various code-paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/115)
<!-- Reviewable:end -->
