### PR TITLE
Enable Dependabot for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Enable automatic version updates.
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "gomod"


### PR DESCRIPTION
This change will allow Dependabot to create a PR once a week to update go module dependencies.