### PR TITLE
workflow: Avoid redundant testing

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -12,7 +12,7 @@ permissions:
 on:
   push:
     branches: [ master ]
-    tags: [ 'v*' ]
+    tags: [ 'v*.*.*' ]
   # PR's will trigger an image build, but the push action is disabled.
   pull_request:
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,8 @@ name: Tests
 permissions: read-all
 on:
   push:
+    branches: [ master ]
+    tags: [ 'v*.*.*' ]
   pull_request:
   workflow_dispatch: # Allow manual runs to kick off benchmarks
     inputs:


### PR DESCRIPTION
This change updates the testing workflow only to run on pushes to master or to
a version tag.  This will eliminate the redundant testing for PRs that merge to
master. The tag format in the releases workflow is also changed to a more
conservative v-3-dots pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/125)
<!-- Reviewable:end -->
