### PR TITLE
apply: Fix unparseable DECIMAL representations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cockroachdb/cdc-sink
 go 1.17
 
 require (
+	github.com/cockroachdb/apd v1.1.0
 	github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79
 	github.com/go-mysql-org/go-mysql v1.5.0
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -185,6 +185,12 @@ func (a *apply) deleteLocked(ctx context.Context, db pgxtype.Querier, muts []typ
 		allArgs = append(allArgs, args...)
 	}
 
+	for idx, arg := range allArgs {
+		if num, ok := arg.(json.Number); ok {
+			allArgs[idx] = removeExponent(num)
+		}
+	}
+
 	tag, err := db.Exec(ctx, sql, allArgs...)
 	if err != nil {
 		return errors.Wrap(err, sql)
@@ -273,6 +279,12 @@ func (a *apply) upsertLocked(ctx context.Context, db pgxtype.Querier, muts []typ
 					"unexpected columns %v: "+
 					"key %s@%s",
 				a.target, unexpected, string(muts[i].Key), muts[i].Time)
+		}
+	}
+
+	for idx, arg := range allArgs {
+		if num, ok := arg.(json.Number); ok {
+			allArgs[idx] = removeExponent(num)
 		}
 	}
 

--- a/internal/target/apply/exponent_fix.go
+++ b/internal/target/apply/exponent_fix.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package apply
+
+import (
+	"encoding/json"
+	"log"
+	"regexp"
+
+	"github.com/cockroachdb/apd"
+)
+
+var exponentSuffix = regexp.MustCompile(`[Ee][+-]?\d+$`)
+
+// removeExponent detects instances of json.Number which are formatted
+// using an explicit exponent and converts them to a non-exponential
+// form. This addresses a minor incompatibility with the numeric formats
+// accepted by the pgx type-coercion logic. This only appears to be
+// relevant when using DECIMAL columns, where their json representation
+// may sometimes look like "4E+2".
+func removeExponent(val json.Number) json.Number {
+	// It's tempting to just call the Int64 or Float64 methods on the
+	// json.Number, but we fall into a trap if the values can't be
+	// represented exactly with native types, as is sometimes the case
+	// for using the DECIMAL sql types. We'll delegate to the
+	// arbitrary-precision-decimal library used by CRDB itself. We also
+	// know that the input value parses as a numeric value and matches
+	// the above regex, so we can treat any error as a fatal failure.
+	if exponentSuffix.Match([]byte(val)) {
+		parsed, _, err := apd.NewFromString(val.String())
+		if err != nil {
+			log.Fatal(err)
+		}
+		return json.Number(parsed.Text('f'))
+	}
+	return val
+}

--- a/internal/target/apply/exponent_fix_test.go
+++ b/internal/target/apply/exponent_fix_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package apply
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveExponent(t *testing.T) {
+	tcs := []struct{ data, expected json.Number }{
+		{"", ""},
+		{"1", "1"},
+		{"4E2", "400"},
+		{"4E+2", "400"},
+		{"4E-2", "0.04"},
+		{"4.321E10", "43210000000"},
+		{"not a number", "not a number"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(string(tc.data), func(t *testing.T) {
+			a := assert.New(t)
+			a.Equal(tc.expected, removeExponent(tc.data))
+		})
+	}
+}


### PR DESCRIPTION
The pgx library doesn't like the scientific notation (e.g. "4E+2") that
Cockroach can return for DECIMAL-type columns. This patch looks for these cases
and expands them via Cockroach's own APD library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/143)
<!-- Reviewable:end -->
