### PR TITLE
apply: De-duplicate applied mutations

### DIFF
--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/metrics"
+	"github.com/cockroachdb/cdc-sink/internal/util/msort"
 	"github.com/jackc/pgtype/pgxtype"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -107,6 +108,14 @@ func (a *apply) Apply(ctx context.Context, tx pgxtype.Querier, muts []types.Muta
 	defer r()
 	upserts, r := batches.Mutation()
 	defer r()
+
+	// We want to ensure that we achieve a last-one-wins behavior within
+	// an immediate-mode batch. This does perform unnecessary work
+	// in the staged mode, since we perform the per-key deduplication
+	// and sorting as part of de-queuing mutations.
+	//
+	// See also the discussion on TestRepeatedKeysWithIgnoredColumns
+	muts = msort.UniqueByKey(muts)
 
 	countError := func(err error) error {
 		if err != nil {

--- a/internal/util/msort/msort.go
+++ b/internal/util/msort/msort.go
@@ -1,0 +1,65 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package msort contains utility functions for sorting and
+// de-duplicating batches of mutations.
+package msort
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+)
+
+// UniqueByKey implements a "last one wins" approach to removing
+// mutations with duplicate keys from the input slice. If two mutations
+// share the same Key, then the one with the later Time is returned. If
+// there are mutations with identical Keys and Times, exactly one of the
+// values will be chosen arbitrarily.
+//
+// The modified slice is returned.
+//
+// This function will panic if any of the mutation Key fields are
+// entirely empty. An empty json array (i.e. `[]`) is acceptable.
+func UniqueByKey(x []types.Mutation) []types.Mutation {
+	// For any given Key, we're going to track the index in the slice
+	// that holds data for the key.
+	seenIdx := make(map[string]int, len(x))
+
+	// We want to iterate backwards over the input slice, moving
+	// elements to the rear when their HLC time is greater than the
+	// value currently tracked for that key.
+	dest := len(x)
+	for src := len(x) - 1; src >= 0; src-- {
+		// This is a sanity-check to ensure that we don't silently
+		// discard mutations due to some upstream coding error where a
+		// mutation does not have its Key field set.
+		if len(x[src].Key) == 0 {
+			panic("empty mutation key")
+		}
+		key := string(x[src].Key)
+
+		// Is there already an index in the slice for that key?
+		if curIdx, found := seenIdx[key]; found {
+			// If so, replace the value if the HLC time is greater.
+			if hlc.Compare(x[src].Time, x[curIdx].Time) > 0 {
+				x[curIdx] = x[src]
+			}
+		} else {
+			// Otherwise, allocate a new index for that key, and copy
+			// the value out.
+			dest--
+			seenIdx[key] = dest
+			x[dest] = x[src]
+		}
+	}
+
+	// Return the compacted view of the slice.
+	return x[dest:]
+}

--- a/internal/util/msort/msort_test.go
+++ b/internal/util/msort/msort_test.go
@@ -1,0 +1,112 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package msort
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/stretchr/testify/assert"
+)
+
+func mut(k int, v string, t ...hlc.Time) types.Mutation {
+	ret := types.Mutation{
+		Data: []byte(fmt.Sprintf(`{"key":%d, "value":%s}`, k, v)),
+		Key:  []byte(fmt.Sprintf(`[%d]`, k)),
+		Time: hlc.New(int64(k), k),
+	}
+	if len(t) >= 1 {
+		ret.Time = t[0]
+	}
+	return ret
+}
+
+func TestUniqueByKey(t *testing.T) {
+	tcs := []struct {
+		data, expected []types.Mutation
+	}{
+		{data: nil, expected: nil},
+		{data: []types.Mutation{}, expected: []types.Mutation{}},
+		{data: []types.Mutation{mut(1, "1")}, expected: []types.Mutation{mut(1, "1")}},
+		{
+			data: []types.Mutation{
+				mut(1, "deleted"),
+				mut(1, "expected"),
+			},
+			expected: []types.Mutation{
+				mut(1, "expected"),
+			},
+		},
+		{
+			data: []types.Mutation{
+				mut(2, "expected"),
+				mut(1, "deleted"),
+				mut(1, "deleted"),
+				mut(4, "expected"),
+				mut(1, "deleted"),
+				mut(1, "deleted"),
+				mut(1, "deleted"),
+				mut(1, "expected"),
+				mut(3, "expected"),
+			},
+			expected: []types.Mutation{
+				mut(2, "expected"),
+				mut(4, "expected"),
+				mut(1, "expected"),
+				mut(3, "expected"),
+			},
+		},
+		{
+			data: []types.Mutation{
+				mut(1, "deleted"),
+				mut(2, "expected"),
+				mut(1, "expected"),
+			},
+			expected: []types.Mutation{
+				mut(2, "expected"),
+				mut(1, "expected"),
+			},
+		},
+		// Test the case where timestamps are out of order for a key.
+		{
+			data: []types.Mutation{
+				mut(1, "expected", hlc.New(100, 100)),
+				mut(2, "expected"),
+				mut(1, "expected"),
+			},
+			expected: []types.Mutation{
+				mut(2, "expected"),
+				mut(1, "expected", hlc.New(100, 100)),
+			},
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			a := assert.New(t)
+
+			data := UniqueByKey(tc.data)
+			a.Equal(tc.expected, data)
+		})
+	}
+}
+
+// Document the panic behavior.
+func TestUniqueByKeyPanic(t *testing.T) {
+	a := assert.New(t)
+	a.Panics(func() {
+		UniqueByKey([]types.Mutation{
+			{Key: nil},
+		})
+	})
+}


### PR DESCRIPTION
Note to reviewers, this includes PR #145 

This change works around a CockroachDB implementation quirk wherein an UPSERT
is unable to read its own writes, which prevents the same row from being
upserted twice within the same statement. This also corrects a potential source
of data inconsistency in the applier code, if a single call to Apply contains
both upserts and deletes of the same row.

Both of the above issues can be addressed by sorting the mutations according to
their HLC time and then de-duplicating them by primary key.

The newly-added test in the apply package checks for the specific upsert
behavior, so that this workaround can be reconsidered if a future version of
CockroachDB allows duplicate rows within an UPSERT or CTE.

X-Ref: https://github.com/cockroachdb/cockroach/issues/44466
X-Ref: https://github.com/cockroachdb/cockroach/issues/70731
X-Ref: https://github.com/cockroachdb/cockroach/pull/45372

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/144)
<!-- Reviewable:end -->
