### PR TITLE
fan: Avoid redundant enqueuing of mutations

### DIFF
--- a/internal/target/apply/fan/bucket.go
+++ b/internal/target/apply/fan/bucket.go
@@ -79,7 +79,7 @@ func (b *bucket) Consistent() stamp.Stamp {
 }
 
 // Enqueue adds mutations to be processed and their associated stamp.
-func (b *bucket) Enqueue(stamp stamp.Stamp, muts []types.Mutation) error {
+func (b *bucket) Enqueue(stamp stamp.Stamp, mut types.Mutation) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.mu.stopFlag {
@@ -87,10 +87,7 @@ func (b *bucket) Enqueue(stamp stamp.Stamp, muts []types.Mutation) error {
 	}
 
 	// Apply backpressure based on the number of bytes in the mutations.
-	toAcquire := int64(0)
-	for _, mut := range muts {
-		toAcquire += mutationWeight(mut)
-	}
+	toAcquire := mutationWeight(mut)
 	// This should succeed in the majority case.  If not, the target
 	// cluster is likely under-sized or the connection pool is too
 	// small.
@@ -105,7 +102,7 @@ func (b *bucket) Enqueue(stamp stamp.Stamp, muts []types.Mutation) error {
 		log.Debugf("backpressure relieved")
 	}
 
-	return b.mu.work.Enqueue(newBatch(stamp, muts))
+	return b.mu.work.Enqueue(newBatch(stamp, mut))
 }
 
 // Flush requests the bucket to flush any in-memory data it has. Results

--- a/internal/target/apply/fan/fan.go
+++ b/internal/target/apply/fan/fan.go
@@ -109,7 +109,7 @@ func (f *Fan) Enqueue(
 			return err
 		}
 		// The bucket will coalesce tail values.
-		if err := bucket.Enqueue(stamp, muts); err != nil {
+		if err := bucket.Enqueue(stamp, mut); err != nil {
 			return err
 		}
 	}

--- a/internal/target/apply/fan/stamped_batch.go
+++ b/internal/target/apply/fan/stamped_batch.go
@@ -30,9 +30,9 @@ type stampedBatch struct {
 
 var _ stamp.Coalescing = (*stampedBatch)(nil)
 
-func newBatch(stamp stamp.Stamp, muts []types.Mutation) *stampedBatch {
+func newBatch(stamp stamp.Stamp, mut types.Mutation) *stampedBatch {
 	ret := &stampedBatch{stamp: stamp}
-	ret.mu.muts = muts
+	ret.mu.muts = []types.Mutation{mut}
 	return ret
 }
 


### PR DESCRIPTION
The Fan.Equeue method was passing the entire slice of mutations into each call
to bucket.Enqueue. This API can actually be simplified to only accept a single
mutation at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/145)
<!-- Reviewable:end -->
