### PR TITLE
workflow: Run CRDB with in-memory store.

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -11,19 +11,19 @@ services:
   cockroachdb-v20.2:
     image: cockroachdb/cockroach:latest-v20.2
     network_mode: host
-    command: start-single-node --insecure
+    command: start-single-node --insecure --store type=mem,size=2G
   cockroachdb-v21.1:
     image: cockroachdb/cockroach:latest-v21.1
     network_mode: host
-    command: start-single-node --insecure
+    command: start-single-node --insecure --store type=mem,size=2G
   cockroachdb-v21.2:
     image: cockroachdb/cockroach:latest-v21.2
     network_mode: host
-    command: start-single-node --insecure
+    command: start-single-node --insecure --store type=mem,size=2G
   cockroachdb-v22.1:
     image: cockroachdb/cockroach:latest-v22.1
     network_mode: host
-    command: start-single-node --insecure
+    command: start-single-node --insecure --store type=mem,size=2G
   mysql-v8:
     image: mysql:8-debian
     platform: linux/x86_64


### PR DESCRIPTION
This change shaves off about 30 seconds per test suite, or about 20% of the
time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/148)
<!-- Reviewable:end -->
