### PR TITLE
schemawatch: Handle tables with no columns.

### DIFF
--- a/internal/target/schemawatch/coldata.go
+++ b/internal/target/schemawatch/coldata.go
@@ -100,6 +100,19 @@ func getColumns(
 			columns = append(columns, column)
 		}
 
+		// It's legal, if unusual, to create a table with no columns.
+		if len(columns) == 0 {
+			columns = []types.ColData{
+				{
+					Ignored: false,
+					Name:    ident.New("rowid"),
+					Primary: true,
+					Type:    "INT8",
+				},
+			}
+			return nil
+		}
+
 		// If there are no primary key columns, we know that a synthetic
 		// rowid column will exist. We'll create a new slice which
 		// respects the ordering guarantees.

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -42,6 +42,11 @@ func TestGetColumns(t *testing.T) {
 	}
 	testcases := []testcase{
 		{
+			"", // It's legal to create a table with no columns.
+			[]string{"rowid"},
+			nil,
+		},
+		{
 			"a INT",
 			[]string{"rowid"},
 			[]string{"a"},


### PR DESCRIPTION
It is legal to create a table with no columns. This change avoids a panic by
explicitly testing for this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/150)
<!-- Reviewable:end -->
