### PR TITLE
leases: Add leases package

### DIFF
--- a/internal/target/leases/leases.go
+++ b/internal/target/leases/leases.go
@@ -1,0 +1,393 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package leases coordinates global, singleton activities.
+package leases
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/retry"
+	"github.com/google/uuid"
+	"github.com/jackc/pgtype/pgxtype"
+	"github.com/jackc/pgx/v4"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Table contains a default table name for managing leases.
+var Table = ident.NewTable(ident.StagingDB, ident.Public, ident.New("leases"))
+
+const (
+	defaultLifetime = time.Minute
+	defaultPoll     = time.Second
+	defaultRetry    = time.Second
+)
+
+// Config is passed to New.
+type Config struct {
+	Pool   pgxtype.Querier // Database access.
+	Target ident.Table     // The lease table.
+
+	// Guard provides a quiescent period between when a lease is
+	// considered to be expired (i.e. a lease callback's context is
+	// canceled) and its published expiration time. This is useful for
+	// situations where it may not be possible to immediately cancel all
+	// side effects of a lease callback (e.g. it makes an external
+	// network request).
+	Guard time.Duration
+
+	Lifetime   time.Duration // Duration of the lease.
+	Poll       time.Duration // How often to re-check for an available lease.
+	RetryDelay time.Duration // Delay between re-executing a callback.
+}
+
+// sanitize checks for mis-configuration and applies sane defaults.
+func (c *Config) sanitize() error {
+	if c.Pool == nil {
+		return errors.New("pool must not be nil")
+	}
+	if c.Target == (ident.Table{}) {
+		return errors.New("target must be set")
+	}
+	// OK for Guard to be zero.
+	if c.Lifetime == 0 {
+		c.Lifetime = defaultLifetime
+	}
+	if c.Poll == 0 {
+		c.Poll = defaultPoll
+	}
+	if c.RetryDelay == 0 {
+		c.RetryDelay = defaultRetry
+	}
+	return nil
+}
+
+type lease struct {
+	expires time.Time
+	name    string
+	nonce   uuid.UUID
+}
+
+// leases coordinates global, singleton activities.
+type leases struct {
+	cfg Config
+	sql struct {
+		acquire string
+		release string
+		renew   string
+	}
+}
+
+var _ types.Leases = (*leases)(nil)
+
+const (
+	schema = `
+CREATE TABLE IF NOT EXISTS %s (
+  name STRING PRIMARY KEY,
+  expires TIMESTAMP NOT NULL,
+  nonce UUID NOT NULL
+)`
+)
+
+// New constructs an instance of types.Leases.
+func New(ctx context.Context, cfg Config) (types.Leases, error) {
+	if err := cfg.sanitize(); err != nil {
+		return nil, err
+	}
+	_, err := cfg.Pool.Exec(ctx, fmt.Sprintf(schema, cfg.Target))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	l := &leases{cfg: cfg}
+	l.sql.acquire = fmt.Sprintf(acquireTemplate, cfg.Target)
+	l.sql.release = fmt.Sprintf(releaseTemplate, cfg.Target)
+	l.sql.renew = fmt.Sprintf(renewTemplate, cfg.Target)
+
+	return l, nil
+}
+
+// Singleton executes a callback when the named lease is acquired.
+//
+// The lease will be released in the following circumstances:
+//   * The callback returns nil.
+//   * The lease cannot be renewed before it expires.
+//   * The outer context is canceled.
+//
+// If the callback returns a non-nil error, the error will be logged. If
+// the callback returns ErrCancelSingleton, it will not be retried. In
+// all other cases, the callback function is retried once a lease is
+// re-acquired.
+func (l *leases) Singleton(ctx context.Context, name string, fn func(ctx context.Context) error) {
+	// It's easier to ensure cleanup behavior using defer keyword. This
+	// function returns false when the singleton should be torn down.
+	loopBehavior := func() bool {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		tgt, ok := l.waitToAcquire(ctx, name)
+		if !ok {
+			// Context cancellation.
+			return false
+		}
+
+		// Try to clean up, if possible. This uses a background context
+		// so that the release code will still run if the outer context
+		// was cancelled.
+		defer func() {
+			_, _ = l.release(context.Background(), tgt)
+		}()
+
+		// Create a channel to delay the return from this function until
+		// we know that the renewal goroutine has shut down.
+		renewStopped := make(chan struct{})
+		go func() {
+			l.keepRenewed(ctx, tgt)
+			cancel()
+			close(renewStopped)
+		}()
+
+		// Execute the callback.
+		err := fn(ctx)
+
+		// Ensure the renewal goroutine has stopped.
+		cancel()
+		<-renewStopped
+
+		if errors.Is(err, types.ErrCancelSingleton) || errors.Is(err, context.Canceled) {
+			log.WithField("lease", name).Trace("callback requested shutdown or was canceled")
+			return false
+		}
+		log.WithField("lease", name).WithError(err).Error("lease callback exited; continuing")
+		return true
+	}
+
+	for loopBehavior() {
+		time.Sleep(l.cfg.RetryDelay)
+	}
+}
+
+// waitToAcquire blocks until the named lease can be acquired. If the
+// context is canceled, this method will return nil.
+func (l *leases) waitToAcquire(ctx context.Context, name string) (acquired lease, ok bool) {
+	entry := log.WithField("lease", name)
+
+	// The zero value means the first read to the timer channel will
+	// return immediately.
+	t := time.NewTimer(0)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			entry.Trace("context canceled before acquisition")
+			return lease{}, false
+		case <-t.C:
+		}
+
+		entry.Trace("attempting to acquire")
+		ret, ok, err := l.acquire(ctx, name)
+
+		switch {
+		case err != nil:
+			entry.WithError(err).Warn("unable to acquire, will retry")
+		case ok:
+			entry.Trace("acquired")
+			return ret, true
+		default:
+			entry.Trace("waiting")
+		}
+
+		// We want to poll, rather than to wait for the known lease to
+		// expire to detect a deleted lease sooner. The random delay
+		// helps to smear the requests over time. The expected value of
+		// the rand call is Poll/2, so we add to only half of the
+		// polling interval to hit the desired rate.
+		pollDelay := l.cfg.Poll/2 + time.Duration(rand.Int63n(int64(l.cfg.Poll)))
+		t.Reset(pollDelay)
+	}
+}
+
+// keepRenewed will return when the lease cannot be renewed or when the
+// context is canceled. It returns the status of the lease at the last
+// successful renewal to aid in testing.
+func (l *leases) keepRenewed(ctx context.Context, tgt lease) lease {
+	for {
+		now := time.Now().UTC()
+		remaining := tgt.expires.Sub(now)
+		// We haven't been able to renew before hitting the guard
+		// duration, so return and allow the lease to be canceled.
+		if remaining < l.cfg.Guard {
+			return tgt
+		}
+		// Wait up to half of the remaining validity time before
+		// attempting to renew, but rate-limit to the polling interval.
+		delay := remaining / 2
+		if delay < l.cfg.Poll {
+			delay = l.cfg.Poll
+		}
+
+		// Wait until it's time to do something, or we're canceled.
+		select {
+		case <-ctx.Done():
+			return tgt
+		case <-time.After(delay):
+		}
+
+		var ok bool
+		var err error
+		tgt, ok, err = l.renew(ctx, tgt)
+
+		entry := log.WithFields(log.Fields{
+			"expires": tgt.expires, // Include renewed expiration time.
+			"lease":   tgt.name,
+		})
+
+		switch {
+		case errors.Is(err, context.Canceled):
+			entry.Trace("context canceled")
+			return tgt
+		case err != nil:
+			entry.WithError(err).Warn("could not renew lease")
+			continue
+		case !ok:
+			entry.Debug("lease was hijacked")
+			return tgt
+		default:
+			entry.Trace("renewed successfully")
+		}
+	}
+}
+
+// acquire returns a non-nil lease if it was able to acquire the named lease.
+func (l *leases) acquire(ctx context.Context, name string) (acquired lease, ok bool, err error) {
+	err = retry.Retry(ctx, func(ctx context.Context) error {
+		var err error
+		acquired, ok, err = l.tryAcquire(ctx, name, time.Now())
+		return err
+	})
+	return
+}
+
+// SQL template to claim a lease
+//   $1 = name
+//   $2 = caller-assigned expiration
+//   $3 = caller-assigned now(), to ease testing
+// Returns a nonce value if the lease was acquired.
+//
+// If needed, this could be extended to support atomic acquisition of
+// multiple names by making $1 an array and unnest().
+const acquireTemplate = `
+WITH
+  proposed (name, expires, nonce) AS (VALUES ($1::STRING, $2::TIMESTAMP, gen_random_uuid())),
+  blocking AS (
+    SELECT 1
+    FROM %[1]s x
+    JOIN proposed USING (name)
+    WHERE x.expires > $3::TIMESTAMP
+    LIMIT 1)
+UPSERT INTO %[1]s 
+  SELECT name, expires, nonce
+  FROM proposed
+  WHERE (SELECT count(*) FROM blocking) = 0
+  RETURNING nonce
+`
+
+// tryAcquire returns a non-nil lease if it was able to acquire the named lease.
+func (l *leases) tryAcquire(
+	ctx context.Context, name string, now time.Time,
+) (acquired lease, ok bool, err error) {
+	now = now.UTC()
+	expires := now.Add(l.cfg.Lifetime)
+	var nonce uuid.UUID
+
+	// Explicit call to Format needed for compatibility with CRDB 20.2.
+	row := l.cfg.Pool.QueryRow(ctx, l.sql.acquire, name,
+		expires.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
+	if err := row.Scan(&nonce); errors.Is(err, pgx.ErrNoRows) {
+		return lease{}, false, nil
+	} else if err != nil {
+		return lease{}, false, errors.WithStack(err)
+	}
+
+	return lease{expires, name, nonce}, true, nil
+}
+
+// release destroys the given lease.
+func (l *leases) release(ctx context.Context, rel lease) (bool, error) {
+	var ret bool
+	err := retry.Retry(ctx, func(ctx context.Context) error {
+		var err error
+		ret, err = l.tryRelease(ctx, rel)
+		return err
+	})
+	return ret, err
+}
+
+// SQL template for the current owner to release a lease.
+//   $1 = name
+//   $2 = nonce previously allocated by the database
+const releaseTemplate = `DELETE FROM %s WHERE name=$1::STRING AND nonce=$2::UUID`
+
+// tryRelease deletes the lease from the database.
+func (l *leases) tryRelease(ctx context.Context, rel lease) (ok bool, err error) {
+	tag, err := l.cfg.Pool.Exec(ctx, l.sql.release, rel.name, rel.nonce)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return false, nil
+	}
+	rel.expires = time.Time{}
+	rel.nonce = uuid.UUID{}
+	return true, nil
+}
+
+func (l *leases) renew(ctx context.Context, tgt lease) (renewed lease, ok bool, err error) {
+	err = retry.Retry(ctx, func(ctx context.Context) error {
+		var err error
+		renewed, ok, err = l.tryRenew(ctx, tgt, time.Now())
+		return err
+	})
+	return
+}
+
+// SQL template to update the expiration time on a lease.
+//   $1 = new expiration time
+//   $2 = name
+//   $3 = nonce
+const renewTemplate = `UPDATE %s SET expires=$1::TIMESTAMP WHERE name=$2::STRING AND nonce=$3::UUID`
+
+// tryRenew updates the lease record in the database. If successful, the
+// input lease struct will be updated with the new expiration time and
+// returned to the caller. The boolean return value will be false if the
+// lease was stolen.
+func (l *leases) tryRenew(ctx context.Context, tgt lease, now time.Time) (lease, bool, error) {
+	now = now.UTC()
+	expires := now.Add(l.cfg.Lifetime)
+
+	tag, err := l.cfg.Pool.Exec(ctx, l.sql.renew, expires, tgt.name, tgt.nonce)
+	if err != nil {
+		return tgt, false, errors.WithStack(err)
+	}
+
+	if tag.RowsAffected() == 0 {
+		return tgt, false, nil
+	}
+
+	tgt.expires = expires
+	return tgt, true, nil
+}

--- a/internal/target/leases/leases_test.go
+++ b/internal/target/leases/leases_test.go
@@ -1,0 +1,290 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package leases
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/target/sinktest"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestLeases(t *testing.T) {
+	a := assert.New(t)
+	ctx, dbInfo, cancel := sinktest.Context()
+	defer cancel()
+
+	dbName, cancel, err := sinktest.CreateDB(ctx)
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	tbl, err := sinktest.CreateTable(ctx, dbName, schema)
+	if !a.NoError(err) {
+		return
+	}
+
+	intf, err := New(ctx, Config{
+		Pool:   dbInfo.Pool(),
+		Target: tbl.Name(),
+	})
+	l := intf.(*leases)
+	if !a.NoError(err) {
+		return
+	}
+
+	now := time.Now().UTC()
+
+	t.Run("tryAcquire", func(t *testing.T) {
+		a := assert.New(t)
+
+		// No present state, this should succeed.
+		initial, ok, err := l.tryAcquire(ctx, t.Name(), now)
+		a.NoError(err)
+		a.True(ok)
+		a.NotZero(initial)
+
+		// Acquiring at the same time should not do anything.
+		_, ok, err = l.tryAcquire(ctx, t.Name(), now)
+		a.NoError(err)
+		a.False(ok)
+
+		// Acquire within the validity period should be a no-op.
+		_, ok, err = l.tryAcquire(ctx, t.Name(), now.Add(l.cfg.Lifetime/2))
+		a.NoError(err)
+		a.False(ok)
+
+		// Acquire at the expiration time should succeed.
+		next, ok, err := l.tryAcquire(ctx, t.Name(), now.Add(l.cfg.Lifetime))
+		a.NoError(err)
+		if a.True(ok) {
+			a.Equal(initial.name, next.name)
+			a.NotEqual(initial.expires, next.expires)
+			a.NotEqual(initial.nonce, next.nonce)
+		}
+
+		// Acquire within the extended lifetime should be a no-op.
+		_, ok, err = l.tryAcquire(ctx, t.Name(), now.Add(2*l.cfg.Lifetime/3))
+		a.NoError(err)
+		a.False(ok)
+	})
+
+	t.Run("tryRelease", func(t *testing.T) {
+		a := assert.New(t)
+
+		initial, ok, err := l.tryAcquire(ctx, t.Name(), now)
+		a.NoError(err)
+		a.True(ok)
+		a.NotZero(initial)
+
+		// Verify that we can't release with a mis-matched nonce.
+		l2 := initial
+		l2.nonce = uuid.Must(uuid.NewRandom())
+		ok, err = l.tryRelease(ctx, l2)
+		a.NoError(err)
+		a.False(ok)
+
+		// Initial release should succeed.
+		ok, err = l.tryRelease(ctx, initial)
+		a.NoError(err)
+		a.True(ok)
+
+		// Duplicate release is a no-op.
+		ok, err = l.tryRelease(ctx, initial)
+		a.NoError(err)
+		a.False(ok)
+	})
+
+	t.Run("tryRenew", func(t *testing.T) {
+		a := assert.New(t)
+
+		initial, ok, err := l.tryAcquire(ctx, t.Name(), now)
+		a.NoError(err)
+		a.True(ok)
+		a.NotZero(initial)
+
+		// Extend by a second.
+		renewed, ok, err := l.tryRenew(ctx, initial, now.Add(time.Second))
+		a.NoError(err)
+		a.True(ok)
+		a.Equal(now.Add(time.Second+l.cfg.Lifetime), renewed.expires)
+		a.Equal(initial.name, renewed.name)
+		a.Equal(initial.nonce, renewed.nonce)
+
+		// Ensure that we can't cross-renew.
+		mismatched := renewed
+		mismatched.nonce = uuid.Must(uuid.NewRandom())
+		_, ok, err = l.tryRenew(ctx, mismatched, now.Add(2*time.Second))
+		a.NoError(err)
+		a.False(ok)
+	})
+
+	t.Run("waitToAcquire", func(t *testing.T) {
+		a := assert.New(t)
+
+		// Increase polling rate for this test.
+		oldCfg := l.cfg
+		l.cfg.Poll = 10 * time.Millisecond
+		defer func() { l.cfg = oldCfg }()
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		initial, ok, err := l.acquire(ctx, t.Name())
+		a.NoError(err)
+		a.True(ok)
+		a.NotZero(initial)
+
+		eg, egCtx := errgroup.WithContext(ctx)
+		eg.Go(func() error {
+			acquired, ok := l.waitToAcquire(egCtx, initial.name)
+			a.True(ok)
+			a.NotZero(acquired)
+			return nil
+		})
+		eg.Go(func() error {
+			time.Sleep(l.cfg.Poll)
+			ok, err := l.release(egCtx, initial)
+			a.True(ok)
+			a.NoError(err)
+			return err
+		})
+
+		a.NoError(eg.Wait())
+		// Make sure the context has not timed out.
+		a.Nil(ctx.Err())
+	})
+
+	t.Run("keepRenewed", func(t *testing.T) {
+		a := assert.New(t)
+
+		// Increase polling rate and lower lifetime.
+		oldCfg := l.cfg
+		l.cfg.Lifetime = 100 * time.Millisecond
+		l.cfg.Poll = 5 * time.Millisecond
+		defer func() { l.cfg = oldCfg }()
+
+		initial, ok, err := l.acquire(ctx, t.Name())
+		a.NoError(err)
+		a.True(ok)
+		a.NotZero(initial)
+
+		// Keep the
+		renewCtx, cancel := context.WithTimeout(ctx, 3*l.cfg.Lifetime)
+		defer cancel()
+		final := l.keepRenewed(renewCtx, initial)
+
+		a.Greater(final.expires, initial.expires)
+	})
+
+	// Verify that keepRenewed will return if the lease row in the
+	// database is deleted from underneath.
+	t.Run("keepRenewedExitsIfHijacked", func(t *testing.T) {
+		a := assert.New(t)
+
+		// Increase polling rate.
+		oldCfg := l.cfg
+		l.cfg.Lifetime = 100 * time.Millisecond
+		l.cfg.Poll = 5 * time.Millisecond
+		defer func() { l.cfg = oldCfg }()
+
+		initial, ok, err := l.acquire(ctx, t.Name())
+		a.NoError(err)
+		a.True(ok)
+		a.NotZero(initial)
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		eg, egCtx := errgroup.WithContext(ctx)
+		// Start a goroutine to keep the lease renewed, and a
+		// second one to cause it to be released.
+		eg.Go(func() error {
+			l.keepRenewed(egCtx, initial)
+			return nil
+		})
+		eg.Go(func() error {
+			time.Sleep(l.cfg.Poll)
+			ok, err := l.release(egCtx, initial)
+			a.True(ok)
+			a.NoError(err)
+			return err
+		})
+
+		a.NoError(eg.Wait())
+		// Make sure the context has not timed out.
+		a.Nil(ctx.Err())
+	})
+
+	t.Run("singleton", func(t *testing.T) {
+		a := assert.New(t)
+
+		oldCfg := l.cfg
+		// Ensure that cancel and cleanup are working; the lease
+		// lifetime will be longer than that of the test.
+		l.cfg.Lifetime = time.Hour
+		// Increase polling rate.
+		l.cfg.Poll = 5 * time.Millisecond
+		defer func() { l.cfg = oldCfg }()
+
+		ctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+
+		eg, egCtx := errgroup.WithContext(ctx)
+		var running int32
+		for i := 0; i < 100; i++ {
+			eg.Go(func() error {
+				// Each callback verifies that it's the only instance
+				// running, then requests to be shut down.
+				l.Singleton(egCtx, t.Name(), func(ctx context.Context) error {
+					a.NoError(ctx.Err())
+					if a.True(atomic.CompareAndSwapInt32(&running, 0, 1)) {
+						time.Sleep(3 * l.cfg.Poll)
+						atomic.StoreInt32(&running, 0)
+					}
+					return types.ErrCancelSingleton
+				})
+				return nil
+			})
+		}
+
+		a.NoError(eg.Wait())
+		// Make sure the context has not timed out.
+		a.NoError(ctx.Err())
+	})
+}
+
+func TestSanitize(t *testing.T) {
+	a := assert.New(t)
+
+	cfg := Config{}
+	a.EqualError(cfg.sanitize(), "pool must not be nil")
+
+	cfg.Pool = &pgxpool.Pool{}
+	a.EqualError(cfg.sanitize(), "target must be set")
+
+	cfg.Target = ident.NewTable(ident.New("db"), ident.Public, ident.New("tbl"))
+	a.NoError(cfg.sanitize())
+
+	a.Zero(cfg.Guard)
+	a.Equal(defaultLifetime, cfg.Lifetime)
+	a.Equal(defaultPoll, cfg.Poll)
+	a.Equal(defaultRetry, cfg.RetryDelay)
+}


### PR DESCRIPTION
This change adds a new API for running exactly one instance of some named,
global task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/151)
<!-- Reviewable:end -->
