### PR TITLE
server: Add pprof endpoints

### DIFF
--- a/internal/source/server/server.go
+++ b/internal/source/server/server.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // Register pprof debugging endpoints.
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
@@ -127,6 +128,11 @@ func newServer(
 	}
 
 	mux := &http.ServeMux{}
+	// The pprof handlers attach themselves to the system-default mux.
+	// The index page also assumes that the handlers are reachable from
+	// this specific prefix. It seems unlikely that this would collide
+	// with an actual database schema.
+	mux.Handle("/debug/pprof/", http.DefaultServeMux)
 	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if err := pool.Ping(r.Context()); err != nil {
 			log.WithError(err).Warn("health check failed")


### PR DESCRIPTION
This change adds the system-provided pprof endpoints, to aid in runtime
debugging and profiling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/156)
<!-- Reviewable:end -->
