### PR TITLE
Remove the webhook default when testing CDC feeds.

### DIFF
--- a/internal/source/server/provider.go
+++ b/internal/source/server/provider.go
@@ -21,7 +21,6 @@ import (
 	"math/big"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
@@ -236,15 +235,9 @@ func ProvideTLSConfig(config Config) (*tls.Config, error) {
 }
 
 func provideTestConfig(dbInfo *sinktest.DBInfo) Config {
-	// Prefer the webhook format for current versions of CRDB.
-	useWebhook := true
-	if strings.Contains(dbInfo.Version(), "v20.2.") || strings.Contains(dbInfo.Version(), "v21.1.") {
-		useWebhook = false
-	}
-
 	return Config{
 		BindAddr: "127.0.0.1:0",
 		// ConnectionString unnecessary; injected by sinktest provider instead.
-		GenerateSelfSigned: useWebhook,
+		GenerateSelfSigned: false, /* don't use webhook */
 	}
 }


### PR DESCRIPTION
After discussions with the CDC team, the preferred method of http endpoint
should not be webhook as it is optimized and will throttle the outgoing CDC
feed.  This change now tests the http instead, even when the webhook endpoint
is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/164)
<!-- Reviewable:end -->
