### PR TITLE
Remove the preference for webhook in the integration tests.

### DIFF
--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -70,7 +70,6 @@ func testIntegration(t *testing.T, immediate bool) {
 	targetCtx := targetFixture.Context
 	targetDB := targetFixture.TestDB.Ident()
 	targetPool := targetFixture.Pool
-	useWebhook := targetFixture.Config.GenerateSelfSigned
 
 	// Set up source and target tables.
 	source, err := sourceFixture.CreateTable(sourceCtx, "CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")
@@ -106,38 +105,152 @@ func testIntegration(t *testing.T, immediate bool) {
 	if immediate {
 		params.Set(cdc.ImmediateParam, "true")
 	}
-	if useWebhook {
-		params.Set("insecure_tls_skip_verify", "true")
-	}
 	// Set up the changefeed.
 	var feedURL url.URL
 	var createStmt string
-	if useWebhook {
-		feedURL = url.URL{
-			Scheme:   "webhook-https",
-			Host:     targetFixture.Listener.Addr().String(),
-			Path:     path.Join(target.Name().Database().Raw(), target.Name().Schema().Raw()),
-			RawQuery: params.Encode(),
-		}
-		createStmt = "CREATE CHANGEFEED FOR TABLE %s " +
-			"INTO '" + feedURL.String() + "' " +
-			"WITH updated," +
-			"     resolved='1s'," +
-			"     webhook_auth_header='Bearer " + token + "'"
-	} else {
-		// No webhook_auth_header, so bake it into the query string.
-		// See comments in cdc.Handler.ServeHTTP checkAccess.
-		params.Set("access_token", token)
-		feedURL = url.URL{
-			Scheme:   "experimental-http",
-			Host:     targetFixture.Listener.Addr().String(),
-			Path:     path.Join(target.Name().Database().Raw(), target.Name().Schema().Raw()),
-			RawQuery: params.Encode(),
-		}
-		createStmt = "CREATE CHANGEFEED FOR TABLE %s " +
-			"INTO '" + feedURL.String() + "' " +
-			"WITH updated,resolved='1s'"
+
+	// No webhook_auth_header, so bake it into the query string.
+	// See comments in cdc.Handler.ServeHTTP checkAccess.
+	params.Set("access_token", token)
+	feedURL = url.URL{
+		Scheme:   "experimental-http",
+		Host:     targetFixture.Listener.Addr().String(),
+		Path:     path.Join(target.Name().Database().Raw(), target.Name().Schema().Raw()),
+		RawQuery: params.Encode(),
 	}
+	createStmt = "CREATE CHANGEFEED FOR TABLE %s " +
+		"INTO '" + feedURL.String() + "' " +
+		"WITH updated,resolved='1s'"
+
+	log.Debugf("changefeed URL is %s", feedURL.String())
+	if !a.NoError(source.Exec(sourceCtx, createStmt)) {
+		return
+	}
+
+	// Wait for the backfilled value.
+	for {
+		ct, err := target.RowCount(targetCtx)
+		if !a.NoError(err) {
+			return
+		}
+		if ct >= 1 {
+			break
+		}
+		log.Debug("waiting for backfill")
+		time.Sleep(time.Second)
+	}
+
+	// Insert an additional value
+	a.NoError(source.Exec(sourceCtx, "INSERT INTO %s (pk, val) VALUES (2, 'two')"))
+	ct, err = source.RowCount(sourceCtx)
+	a.NoError(err)
+	a.Equal(2, ct)
+
+	// Wait for the streamed value.
+	for {
+		ct, err := target.RowCount(targetCtx)
+		if !a.NoError(err) {
+			return
+		}
+		if ct >= 2 {
+			break
+		}
+		log.Debug("waiting for stream")
+		time.Sleep(time.Second)
+	}
+
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	a.NoError(err)
+	log.WithField("metrics", metrics).Debug()
+}
+
+func testIntegrationWebhook(t *testing.T, immediate bool) {
+	a := assert.New(t)
+
+	var stopped <-chan struct{}
+	defer func() {
+		if stopped != nil {
+			<-stopped
+		}
+	}()
+
+	// Create a source database connection.
+	sourceFixture, cancel, err := sinktest.NewFixture()
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	sourceCtx := sourceFixture.Context
+
+	// The target fixture contains the cdc-sink server.
+	targetFixture, cancel, err := newTestFixture()
+	if !a.NoError(err) {
+		return
+	}
+	defer cancel()
+
+	targetCtx := targetFixture.Context
+	targetDB := targetFixture.TestDB.Ident()
+	targetPool := targetFixture.Pool
+	useWebhook := targetFixture.Config.GenerateSelfSigned
+
+	// Webhook is not supported so we can skip this test.
+	if !useWebhook {
+		return
+	}
+
+	// Set up source and target tables.
+	source, err := sourceFixture.CreateTable(sourceCtx, "CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")
+	if !a.NoError(err) {
+		return
+	}
+
+	// Since we're creating the target table without using the helper
+	// CreateTable(), we need to manually refresh the target's Watcher.
+	target := sinktest.NewTableInfo(targetFixture.DBInfo, ident.NewTable(targetDB, ident.Public, source.Name().Table()))
+	if !a.NoError(target.Exec(targetCtx, "CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")) {
+		return
+	}
+	a.NoError(targetFixture.Watcher.Refresh(targetCtx, targetPool))
+
+	// Add base data to the source table.
+	a.NoError(source.Exec(sourceCtx, "INSERT INTO %s (pk, val) VALUES (1, 'one')"))
+	ct, err := source.RowCount(sourceCtx)
+	a.NoError(err)
+	a.Equal(1, ct)
+
+	// Allow access.
+	method, priv, err := jwt.InsertTestingKey(targetCtx, targetPool, targetFixture.Authenticator, targetFixture.StagingDB)
+	if !a.NoError(err) {
+		return
+	}
+	_, token, err := jwt.Sign(method, priv, []ident.Schema{target.Name().AsSchema()})
+	if !a.NoError(err) {
+		return
+	}
+
+	params := make(url.Values)
+	if immediate {
+		params.Set(cdc.ImmediateParam, "true")
+	}
+	params.Set("insecure_tls_skip_verify", "true")
+
+	// Set up the changefeed.
+	var feedURL url.URL
+	var createStmt string
+	feedURL = url.URL{
+		Scheme:   "webhook-https",
+		Host:     targetFixture.Listener.Addr().String(),
+		Path:     path.Join(target.Name().Database().Raw(), target.Name().Schema().Raw()),
+		RawQuery: params.Encode(),
+	}
+	createStmt = "CREATE CHANGEFEED FOR TABLE %s " +
+		"INTO '" + feedURL.String() + "' " +
+		"WITH updated," +
+		"     resolved='1s'," +
+		"     webhook_auth_header='Bearer " + token + "'"
+
 	log.Debugf("changefeed URL is %s", feedURL.String())
 	if !a.NoError(source.Exec(sourceCtx, createStmt)) {
 		return

--- a/internal/source/server/provider.go
+++ b/internal/source/server/provider.go
@@ -236,12 +236,13 @@ func ProvideTLSConfig(config Config) (*tls.Config, error) {
 }
 
 func provideTestConfig(dbInfo *sinktest.DBInfo) Config {
-	// Prefer the webhook format for current versions of CRDB.
+	// In older versions of CRDB, the webhook endpoint is not available so no
+	// self signed certificate is needed. This acts as a signal as to wether the
+	// webhook endpoint is available.
 	useWebhook := true
 	if strings.Contains(dbInfo.Version(), "v20.2.") || strings.Contains(dbInfo.Version(), "v21.1.") {
 		useWebhook = false
 	}
-
 	return Config{
 		BindAddr: "127.0.0.1:0",
 		// ConnectionString unnecessary; injected by sinktest provider instead.


### PR DESCRIPTION
After discussions with the CDC team, the preferred endpoint for http based CDC
feeds should not be webhook as it is unoptimized and will throttle the outgoing
CDC feed.

This change removes the preference for testing only webhook when available and
now tests both the http and webhook endpoints.