### PR TITLE
stdpool: Return nil instead of nil err variable

### DIFF
--- a/internal/util/stdpool/stdpool.go
+++ b/internal/util/stdpool/stdpool.go
@@ -83,10 +83,10 @@ func ParseConfig(connectString string) (*pgxpool.Config, error) {
 		if timed, ok := conn.PgConn().Conn().(*timedConn); ok {
 			readyLatency.Observe(time.Since(timed.start).Seconds())
 		}
-		return err
+		return nil
 	}
 
-	return cfg, err
+	return cfg, nil
 }
 
 type timedConn struct {


### PR DESCRIPTION
This code had a copy-pasto in it; the value of err in the changed lines is
always nil. This change makes the behavior obvious.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/167)
<!-- Reviewable:end -->
