### PR TITLE
mylogical: Fix missing CLI flags.

### DIFF
--- a/internal/source/logical/config.go
+++ b/internal/source/logical/config.go
@@ -70,6 +70,8 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 		"the maximum amount of time to wait for an update to be applied")
 	f.IntVar(&c.BytesInFlight, "bytesInFlight", 10*1024*1024,
 		"apply backpressure when amount of in-flight mutation data reaches this limit")
+	// ConsistentPointKey used only by mylogical.
+	// DefaultConsistentPoint used only by mylogical.
 	f.BoolVar(&c.Immediate, "immediate", false, "apply data without waiting for transaction boundaries")
 	f.DurationVar(&c.RetryDelay, "retryDelay", 10*time.Second,
 		"the amount of time to sleep between replication retries")

--- a/internal/source/mylogical/config.go
+++ b/internal/source/mylogical/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
 )
 
 // Config contains the configuration necessary for creating a
@@ -40,6 +41,17 @@ type Config struct {
 	tlsConfig *tls.Config
 	// user is for MySQL user.
 	user string
+}
+
+// Bind adds flags to the set. It delegates to the embedded Config.Bind.
+func (c *Config) Bind(f *pflag.FlagSet) {
+	c.Config.Bind(f)
+	f.StringVar(&c.DefaultConsistentPoint, "defaultGTIDSet", "",
+		"default GTIDSet. Used if no state is persisted")
+	f.StringVar(&c.ConsistentPointKey, "consistentPointKey", "",
+		"unique key used for this process to persist state information")
+	f.StringVar(&c.SourceConn, "sourceConn", "",
+		"the source database's connection string")
 }
 
 func newClientTLSConfig(


### PR DESCRIPTION
The change made in PR #159 dropped some CLI flags that were used only by the
mylogical package. This change restores them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/169)
<!-- Reviewable:end -->
