### PR TITLE
Remove the preference for webhook in the integration tests.

### DIFF
--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -30,11 +30,12 @@ type testFixture struct {
 	Server        *Server
 }
 
-func newTestFixture() (*testFixture, func(), error) {
+func newTestFixture(shouldUseWebhook) (*testFixture, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
 		sinktest.TestSet,
+		provideConnectionMode,
 		provideTestConfig,
 		wire.Struct(new(testFixture), "*"),
 	))

--- a/internal/source/server/wire_gen.go
+++ b/internal/source/server/wire_gen.go
@@ -103,7 +103,7 @@ func NewServer(ctx context.Context, config Config) (*Server, func(), error) {
 
 // Injectors from test_fixture.go:
 
-func newTestFixture() (*testFixture, func(), error) {
+func newTestFixture(serverShouldUseWebhook shouldUseWebhook) (*testFixture, func(), error) {
 	contextContext, cleanup, err := sinktest.ProvideContext()
 	if err != nil {
 		return nil, nil, err
@@ -182,7 +182,8 @@ func newTestFixture() (*testFixture, func(), error) {
 		MetaTable:   metaTable,
 		Watcher:     watcher,
 	}
-	config := provideTestConfig(dbInfo)
+	serverConnectionMode := provideConnectionMode(dbInfo, serverShouldUseWebhook)
+	config := provideTestConfig(serverConnectionMode)
 	authenticator, cleanup8, err := ProvideAuthenticator(contextContext, pool, config, stagingDB)
 	if err != nil {
 		cleanup7()


### PR DESCRIPTION
After discussions with the CDC team, the preferred endpoint for http based CDC
feeds should not be webhook as it is unoptimized and will throttle the outgoing
CDC feed.

This change removes the preference for testing only webhook when available and
now tests both the http and webhook endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/170)
<!-- Reviewable:end -->
