### PR TITLE
logical: Prevent missed consistent-point notification

### DIFF
--- a/internal/source/logical/provider.go
+++ b/internal/source/logical/provider.go
@@ -61,7 +61,7 @@ func ProvideLoop(
 		targetDB:           config.TargetDB,
 		targetPool:         pool,
 	}
-	loop.consistentPointUpdated = sync.NewCond(&loop.mu)
+	loop.consistentPoint.Cond = sync.NewCond(&sync.Mutex{})
 
 	if config.ConsistentPointKey != "" {
 		var err error
@@ -75,7 +75,7 @@ func ProvideLoop(
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "could not restore consistentPoint")
 		}
-		loop.mu.consistentPoint, err = dialect.UnmarshalStamp(cp)
+		loop.consistentPoint.stamp, err = dialect.UnmarshalStamp(cp)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "could not restore consistentPoint")
 		}


### PR DESCRIPTION
The loop.setConsistentPoint() method calls sync.Cond.Broadcast() outside of a
locked region. This can lead to a missed wakeup in loop.OnCommit() when running
in serial mode. The current code also has two ways to access the mutex that
guards the consistent point stamp: through the mu field as well as the
consistentPointUpdated sync.Cond.

This change moves the condition variable (and associated Locker) into the same
struct as the consistent-point stamp. It also ensures that the lock is held
when calling Broadcast().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/173)
<!-- Reviewable:end -->
