### PR TITLE
workflow: Matrix testing refinements

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -1,6 +1,7 @@
 name: Golang
 permissions:
   contents: read
+  packages: read
 on:
   push:
     branches: [ master ]
@@ -130,9 +131,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cockroachdb: [ v20.2, v21.1, v21.2, v22.1 ]
-        # This matrix component should use the target names listed
-        # in the docker-compose.yml file in the parent directory.
+        # Pick a primary version to test all of the integration sources
+        # against. The matrix component names should use the target
+        # names listed in the docker-compose.yml file in the parent
+        # directory.
+        cockroachdb: [ v22.1 ]
         integration:
           - "mysql-v8"
           - "mysql-mariadb-v10"
@@ -140,6 +143,16 @@ jobs:
           - "postgresql-v12"
           - "postgresql-v13"
           - "postgresql-v14"
+        # The cockroachdb value in this include block will collide with
+        # the value from the auto-expanded matrix. The net effect is
+        # that we'll skip integration tests against older versions of
+        # CRDB. These tests are kept around to ensure that the target
+        # package doesn't use any SQL that couldn't be run on older CRDB
+        # versions.
+        include:
+          - cockroachdb: v20.2
+          - cockroachdb: v21.1
+          - cockroachdb: v21.2
     env:
       COVER_OUT: coverage-${{ matrix.cockroachdb }}-${{ matrix.integration }}.out
       JUNIT_OUT: junit-${{ matrix.cockroachdb }}-${{ matrix.integration }}.xml
@@ -157,6 +170,14 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: CACHE_KEY
+
+      # Ensure we can grab any private images we need for testing.
+      - name: Log in to GitHub Package Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start CockroachDB
         working-directory: .github


### PR DESCRIPTION
This change simplifies the number of integration tests that are run by only
testing a single version of CockroachDB with the various logical-replication
sources. Older versions of CRDB are still tested for compatibility, but we
assume that the logical-replication source won't make a practical difference.

There is also a prepatory change to log into the GitHub Packages docker
repository, to facilitate an upcoming logical-replication source which requires
a non-trivial emulator environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/189)
<!-- Reviewable:end -->
