### PR TITLE
apply: Add support for overflow properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,26 @@ clause such as `WHERE incoming.updated_at > now() - '1m'::INTERVAL`.
 
 Deletes from the source cluster are always applied.
 
+#### Extras column
+
+By default, `cdc-sink` will reject any incoming data that cannot be mapped onto a column in the
+target table. Users may specify a JSONB column in a target table to receive otherwise-unmapped
+properties. This is useful in logical-replication scenarios where the source data has a variable
+schema (e.g. migrations from document stores). Values in the JSONB column can be extracted in
+subsequent schema-change operations
+using [computed columns](https://www.cockroachlabs.com/docs/stable/jsonb.html#create-a-table-with-a-jsonb-column-and-a-computed-column)
+.
+
+To enable extras mode for a table, set the `extras` column to `true` in the `apply_config` for
+exactly one column in the target table. The name of the extras column should be chosen to avoid any
+conflicts with properties in incoming mutations.
+
+```sql
+UPSERT
+INTO _cdc_sink.apply_config (target_db, target_schema, target_table, target_column, extras)
+VALUES ('some_db', 'public', 'my_table', 'overflow_data', true);
+```
+
 #### Ignore columns
 
 By default, `cdc-sink` will reject incoming mutations that have columns which do not map to a column

--- a/internal/target/apply/conf_test.go
+++ b/internal/target/apply/conf_test.go
@@ -66,6 +66,7 @@ func TestPersistenceRoundTrip(t *testing.T) {
 			ident.New("expr1"): "1 + $0",
 			ident.New("expr2"): "2 + $0",
 		},
+		Extras: ident.New("extras"),
 		Ignore: map[ident.Ident]bool{
 			ident.New("ignore1"): true,
 			ident.New("ignore2"): true,


### PR DESCRIPTION
This change supports document-store use cases by allowing the
otherwise-unmapped properties of incoming mutations to be stored as a JSONB
"extras" column in the target table.

Closes #194

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/199)
<!-- Reviewable:end -->
