### PR TITLE
apply: Support user-defined types with mixed-case idents.

### DIFF
--- a/internal/target/apply/queries/common.tmpl
+++ b/internal/target/apply/queries/common.tmpl
@@ -20,6 +20,8 @@ adds explicit typecasts: ($1::STRING, $2::INT), (...), (...), ...
             {{- if $pairIdx -}},{{- end -}}
             {{- if $pair.Expr -}}
                 ({{ $pair.Expr }})::{{ $pair.Column.Type }}
+            {{- else if isUDT $pair.Column.Type -}}
+                ${{ $pair.Index }}::{{ $pair.Column.Type }}
             {{- else if eq $pair.Column.Type "GEOGRAPHY" -}}
                 st_geogfromgeojson(${{ $pair.Index }}::JSONB)
             {{- else if eq $pair.Column.Type "GEOMETRY" -}}

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -29,6 +29,10 @@ var (
 	queries embed.FS
 
 	parsed = template.Must(template.New("").Funcs(template.FuncMap{
+		"isUDT": func(x interface{}) bool {
+			_, ok := x.(ident.UDT)
+			return ok
+		},
 		// nl is a hack to force the inclusion of newlines in the output
 		// since we generally use the whitespace-consuming template
 		// syntax.

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -60,6 +60,13 @@ func TestQueryTemplates(t *testing.T) {
 			Name: ident.New("geog"),
 			Type: "GEOGRAPHY",
 		},
+		{
+			Name: ident.New("enum"),
+			Type: ident.NewUDT(
+				ident.New("database"),
+				ident.New("schema"),
+				ident.New("MyEnum")),
+		},
 	}
 
 	tableID := ident.NewTable(
@@ -79,20 +86,20 @@ func TestQueryTemplates(t *testing.T) {
 		{
 			name: "base",
 			upsert: `UPSERT INTO "database"."schema"."table" (
-"pk0","pk1","val0","val1","geom","geog"
+"pk0","pk1","val0","val1","geom","geog","enum"
 ) VALUES
-($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB)),
-($7::STRING,$8::INT8,$9::STRING,$10::STRING,st_geomfromgeojson($11::JSONB),st_geogfromgeojson($12::JSONB))`,
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum"),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,st_geomfromgeojson($12::JSONB),st_geogfromgeojson($13::JSONB),$14::"database"."schema"."MyEnum")`,
 		},
 		{
 			name: "cas",
 			cfg: &Config{
 				CASColumns: []ident.Ident{ident.New("val1"), ident.New("val0")},
 			},
-			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog") AS (
+			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog","enum") AS (
 VALUES
-($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB)),
-($7::STRING,$8::INT8,$9::STRING,$10::STRING,st_geomfromgeojson($11::JSONB),st_geogfromgeojson($12::JSONB))),
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum"),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,st_geomfromgeojson($12::JSONB),st_geogfromgeojson($13::JSONB),$14::"database"."schema"."MyEnum")),
 current AS (
 SELECT "pk0","pk1", "table"."val1","table"."val0"
 FROM "database"."schema"."table"
@@ -104,7 +111,7 @@ LEFT JOIN current
 USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
 ("data"."val1","data"."val0") > ("current"."val1","current"."val0"))
-UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog")
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum")
 SELECT * FROM action`,
 		},
 		{
@@ -115,12 +122,12 @@ SELECT * FROM action`,
 					ident.New("val0"): time.Hour,
 				},
 			},
-			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog") AS (
+			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog","enum") AS (
 VALUES
-($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB)),
-($7::STRING,$8::INT8,$9::STRING,$10::STRING,st_geomfromgeojson($11::JSONB),st_geogfromgeojson($12::JSONB))),
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum"),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,st_geomfromgeojson($12::JSONB),st_geogfromgeojson($13::JSONB),$14::"database"."schema"."MyEnum")),
 deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL))
-UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog")
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum")
 SELECT * FROM deadlined`,
 		},
 		{
@@ -132,10 +139,10 @@ SELECT * FROM deadlined`,
 					ident.New("val1"): time.Second,
 				},
 			},
-			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog") AS (
+			upsert: `WITH data("pk0","pk1","val0","val1","geom","geog","enum") AS (
 VALUES
-($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB)),
-($7::STRING,$8::INT8,$9::STRING,$10::STRING,st_geomfromgeojson($11::JSONB),st_geogfromgeojson($12::JSONB))),
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum"),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,st_geomfromgeojson($12::JSONB),st_geogfromgeojson($13::JSONB),$14::"database"."schema"."MyEnum")),
 deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL)),
 current AS (
 SELECT "pk0","pk1", "table"."val1","table"."val0"
@@ -148,7 +155,7 @@ LEFT JOIN current
 USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
 ("deadlined"."val1","deadlined"."val0") > ("current"."val1","current"."val0"))
-UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog")
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum")
 SELECT * FROM action`,
 		},
 		{
@@ -160,10 +167,10 @@ SELECT * FROM action`,
 				},
 			},
 			upsert: `UPSERT INTO "database"."schema"."table" (
-"pk0","pk1","val0","val1"
+"pk0","pk1","val0","val1","enum"
 ) VALUES
-($1::STRING,$2::INT8,$3::STRING,$4::STRING),
-($5::STRING,$6::INT8,$7::STRING,$8::STRING)`,
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,$5::"database"."schema"."MyEnum"),
+($6::STRING,$7::INT8,$8::STRING,$9::STRING,$10::"database"."schema"."MyEnum")`,
 		},
 		{
 			// Changing the source names should have no effect on the
@@ -178,10 +185,10 @@ SELECT * FROM action`,
 				},
 			},
 			upsert: `UPSERT INTO "database"."schema"."table" (
-"pk0","pk1","val0","val1","geom","geog"
+"pk0","pk1","val0","val1","geom","geog","enum"
 ) VALUES
-($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB)),
-($7::STRING,$8::INT8,$9::STRING,$10::STRING,st_geomfromgeojson($11::JSONB),st_geogfromgeojson($12::JSONB))`,
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum"),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,st_geomfromgeojson($12::JSONB),st_geogfromgeojson($13::JSONB),$14::"database"."schema"."MyEnum")`,
 		},
 		{
 			// Verify user-configured expressions, with zero, one, and
@@ -201,10 +208,10 @@ SELECT * FROM action`,
 			delete: `DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1")IN(($1::STRING,($2+$2)::INT8),
 ($3::STRING,($4+$4)::INT8))`,
 			upsert: `UPSERT INTO "database"."schema"."table" (
-"pk0","pk1","val0","val1"
+"pk0","pk1","val0","val1","enum"
 ) VALUES
-($1::STRING,($2+$2)::INT8,('fixed')::STRING,($3||'foobar')::STRING),
-($4::STRING,($5+$5)::INT8,('fixed')::STRING,($6||'foobar')::STRING)`,
+($1::STRING,($2+$2)::INT8,('fixed')::STRING,($3||'foobar')::STRING,$4::"database"."schema"."MyEnum"),
+($5::STRING,($6+$6)::INT8,('fixed')::STRING,($7||'foobar')::STRING,$8::"database"."schema"."MyEnum")`,
 		},
 	}
 
@@ -227,7 +234,6 @@ SELECT * FROM action`,
 			s, err = tmpls.upsert(2)
 			a.NoError(err)
 			a.Equal(tc.upsert, s)
-
 		})
 
 	}

--- a/internal/util/ident/ident.go
+++ b/internal/util/ident/ident.go
@@ -269,3 +269,63 @@ func (t *Table) UnmarshalJSON(data []byte) error {
 	t.table = parts[2]
 	return nil
 }
+
+// A UDT is the name of a user-defined type, such as an enum.
+type UDT struct {
+	db, schema, udt Ident
+}
+
+// NewUDT constructs an identifier for a user-defined type.
+func NewUDT(db, schema, name Ident) UDT {
+	return UDT{db, schema, name}
+}
+
+// AsSchema returns the schema from the UDT.
+func (t UDT) AsSchema() Schema {
+	return NewSchema(t.Database(), t.Schema())
+}
+
+// Database returns the UDT's enclosing database.
+func (t UDT) Database() Ident { return t.db }
+
+// MarshalJSON returns the ident as a three-element array.
+func (t UDT) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]string{t.Database().Raw(), t.Schema().Raw(), t.Name().Raw()})
+}
+
+// MarshalText returns the raw, dotted form of the UDT.
+func (t UDT) MarshalText() ([]byte, error) {
+	return []byte(t.Raw()), nil
+}
+
+// Schema returns the UDT's enclosing schema.
+func (t UDT) Schema() Ident { return t.schema }
+
+// Name returns the UDT's leaf name identifier.
+func (t UDT) Name() Ident { return t.udt }
+
+// Raw returns the original, raw value.
+func (t UDT) Raw() string {
+	return fmt.Sprintf("%s.%s.%s", t.Database().Raw(), t.Schema().Raw(), t.Name().Raw())
+}
+
+// String returns the identifier in a manner suitable for constructing a
+// query.
+func (t UDT) String() string {
+	return fmt.Sprintf("%s.%s.%s", t.Database(), t.Schema(), t.Name())
+}
+
+// UnmarshalJSON parses a three-element array.
+func (t *UDT) UnmarshalJSON(data []byte) error {
+	parts := make([]Ident, 0, 3)
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return err
+	}
+	if len(parts) != 3 {
+		return errors.Errorf("expecting 3 parts, had %d", len(parts))
+	}
+	t.db = parts[0]
+	t.schema = parts[1]
+	t.udt = parts[2]
+	return nil
+}

--- a/internal/util/ident/ident_test.go
+++ b/internal/util/ident/ident_test.go
@@ -158,3 +158,15 @@ func TestTableJson(t *testing.T) {
 	a.NoError(json.Unmarshal(data, &id2))
 	a.Equal(id, id2)
 }
+
+func TestUDTJson(t *testing.T) {
+	a := assert.New(t)
+
+	id := NewUDT(New("db"), New("schema"), New("my_enum"))
+	data, err := json.Marshal(id)
+	a.NoError(err)
+
+	var id2 UDT
+	a.NoError(json.Unmarshal(data, &id2))
+	a.Equal(id, id2)
+}


### PR DESCRIPTION
This change adds explict support for user-defined types (e.g. enums) to the
schemawatch code. It also ensures that UDT's with mixed-case identifiers are
correctly supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/200)
<!-- Reviewable:end -->
