### PR TITLE
fan: Make use of mapHash stable.

### DIFF
--- a/internal/target/apply/fan/key.go
+++ b/internal/target/apply/fan/key.go
@@ -22,6 +22,10 @@ type bucketKey struct {
 	shard int
 }
 
+// Use a fixed seed value when computing hashes so that a mutation for a
+// specific key winds up in the same bucket.
+var commonSeed = maphash.MakeSeed()
+
 // keyFor produces a bucketKey to group mutations together by key.
 // This function assumes that the encoding of the key is stable for
 // any given row.
@@ -31,6 +35,7 @@ func keyFor(table ident.Table, shardCount int, mut types.Mutation) bucketKey {
 	}
 
 	h := maphash.Hash{}
+	h.SetSeed(commonSeed)
 	_, _ = h.Write(mut.Key)
 	shard := int(h.Sum64() % uint64(shardCount))
 	return bucketKey{table, shard}

--- a/internal/target/apply/fan/key_test.go
+++ b/internal/target/apply/fan/key_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fan
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyStability(t *testing.T) {
+	tbl := ident.NewTable(ident.New("db"), ident.Public, ident.New("tbl"))
+	shardCount := 16
+	mut := types.Mutation{Key: []byte("some key")}
+
+	k1 := keyFor(tbl, shardCount, mut)
+	k2 := keyFor(tbl, shardCount, mut)
+	assert.Equal(t, k1, k2)
+}


### PR DESCRIPTION
This change tweaks how we map an incoming mutation onto a specific fan bucket
id by using the same maphash.Seed for each computation. This ensures that
mutations for the same key will be applied on the same underlying database
connection. This removes a potential source of contention in high-rate
scenarios.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/206)
<!-- Reviewable:end -->
