### PR TITLE
ident: Add pflag.Value adaptor

### DIFF
--- a/internal/util/ident/flag_var.go
+++ b/internal/util/ident/flag_var.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ident
+
+// Value allows Idents to be used with the spf13 flags package.
+type Value Ident
+
+// NewValue wraps the given Ident so that it can be used with the spf13
+// flags package.
+func NewValue(value string, id *Ident) *Value {
+	*id = New(value)
+	return (*Value)(id)
+}
+
+// Set implements Value.
+func (v *Value) Set(s string) error { *(*Ident)(v) = New(s); return nil }
+
+// String returns the raw value of the underlying Ident.
+func (v *Value) String() string { return (*Ident)(v).Raw() }
+
+// Type implements Value.
+func (v *Value) Type() string { return "ident" }

--- a/internal/util/ident/ident_test.go
+++ b/internal/util/ident/ident_test.go
@@ -17,6 +17,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFlagVar(t *testing.T) {
+	a := assert.New(t)
+
+	var id Ident
+	a.True(id.IsEmpty())
+
+	value := NewValue("default", &id)
+	a.Equal(New("default"), id)
+
+	a.NoError(value.Set("different"))
+	a.Equal(New("different"), id)
+}
+
 func TestIdent(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
This change allows an Ident to be used as the target of a CLI flag. It also simplifies the existing logical/config.go.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/215)
<!-- Reviewable:end -->
