### PR TITLE
fslogical: Track received document ids

### DIFF
--- a/internal/source/fslogical/config.go
+++ b/internal/source/fslogical/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// Copies the document id from the doc metadata into the mutation
 	// using this property name.
 	DocumentIDProperty ident.Ident
+	// Enable extra tracking to allow selective re-processing of
+	// documents in a source collection.
+	Idempotent bool
 	// The Firebase project id. Usually inferred from the credentials.
 	ProjectID string
 	// The name of a collection that contains tombstones for documents
@@ -62,6 +65,8 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	// NB: Keep default value in sync with doc on tombstones.
 	f.Var(ident.NewValue("id", &c.DocumentIDProperty), "docID",
 		"the column name (likely the primary key) to populate with the document id")
+	f.BoolVar(&c.Idempotent, "idempotent", true,
+		"track received document ids and server times to prevent reprocessing")
 	f.StringVar(&c.LoopName, "loopName", "fslogical",
 		"identifies the logical replication loops in metrics")
 	f.StringVar(&c.ProjectID, "projectID", "",

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -155,6 +155,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 		},
 		BackfillBatchSize:           10,
 		DocumentIDProperty:          ident.New("id"), // Map doc id metadata to target column.
+		Idempotent:                  true,
 		ProjectID:                   projectID,
 		TombstoneCollection:         "Tombstones",
 		TombstoneCollectionProperty: ident.New("collection"),

--- a/internal/source/fslogical/provider.go
+++ b/internal/source/fslogical/provider.go
@@ -21,8 +21,10 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/golang/groupcache/lru"
+	"github.com/jackc/pgx/v5/pgxpool"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 )
@@ -46,8 +48,10 @@ var enableWipe bool
 func ProvideLoops(
 	ctx context.Context,
 	cfg *Config,
-	loops *logical.Factory,
 	fs *firestore.Client,
+	loops *logical.Factory,
+	memo types.Memo,
+	pool *pgxpool.Pool,
 	st *Tombstones,
 	userscript *script.UserScript,
 ) ([]*logical.Loop, func(), error) {
@@ -78,7 +82,10 @@ func ProvideLoops(
 			backfillBatchSize: cfg.BackfillBatchSize,
 			docIDProperty:     cfg.DocumentIDProperty.Raw(),
 			fs:                fs,
+			idempotent:        cfg.Idempotent,
 			loops:             loops,
+			memo:              memo,
+			pool:              pool,
 			query:             q,
 			tombstones:        st,
 			recurse:           source.Recurse,
@@ -99,7 +106,11 @@ func ProvideLoops(
 
 // ProvideFirestoreClient is called by wire. If a local emulator is in
 // use, the cleanup function will delete the test project data.
-func ProvideFirestoreClient(ctx context.Context, cfg *Config) (*firestore.Client, func(), error) {
+// The UserScript is added as a fake dependency to ensure that any
+// script-driven configuration is performed first.
+func ProvideFirestoreClient(
+	ctx context.Context, cfg *Config, _ *script.UserScript,
+) (*firestore.Client, func(), error) {
 	// Project ID is usually baked into the JSON key file.
 	projectID := firestore.DetectProjectID
 	if cfg.ProjectID != "" {


### PR DESCRIPTION
This change records document ids that have been successfully processed in order
to create idempotent behavior if a document collection must be re-processed by
clearing the collection's consistent point. It may be the case that, for large
document collections and as-yet-unknown reasons, some documents are not
received from Firestore.

The server-generated update-time for the document is recorded in the memo
table, and we ensure that incoming documents will advance the update-time. The
data for a specific document can be queried by executing `SELECT
(convert_from(value, 'utf8')::JSONB->>'u')::TIMESTAMP FROM memo WHERE key LIKE
'fs-doc-%__DOCUMENT_ID__';` in the _cdc_sink database.

This behavior can be disabled by setting `--idempotent=false`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/244)
<!-- Reviewable:end -->
