### PR TITLE
workflow: Test 22.2 release, drop 20.2

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     command: start-single-node --insecure --store type=mem,size=2G
   # There is no latest-v22.2 tag available in the unstable repo.
   cockroachdb-v22.2:
-    image: cockroachdb/cockroach-unstable:v22.2.0-alpha.3
+    image: cockroachdb/cockroach:latest-v22.2
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
   firestore:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -10,11 +10,13 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '**/*.go'
+      - '.github/workflows/golang.yaml'
   pull_request:
     paths:
       - 'go.mod'
       - 'go.sum'
       - '**/*.go'
+      - '.github/workflows/golang.yaml'
   workflow_dispatch:
     inputs:
       build_binaries:
@@ -135,7 +137,7 @@ jobs:
         # against. The matrix component names should use the target
         # names listed in the docker-compose.yml file in the parent
         # directory.
-        cockroachdb: [ v22.1 ]
+        cockroachdb: [ v22.2 ]
         integration:
           - "firestore"
           - "mysql-v8"
@@ -151,10 +153,9 @@ jobs:
         # package doesn't use any SQL that couldn't be run on older CRDB
         # versions.
         include:
-          - cockroachdb: v20.2
           - cockroachdb: v21.1
           - cockroachdb: v21.2
-          - cockroachdb: v22.2 # Note this is currently pinned to alpha.3
+          - cockroachdb: v22.2
     env:
       COVER_OUT: coverage-${{ matrix.cockroachdb }}-${{ matrix.integration }}.out
       FIRESTORE_EMULATOR_HOST: 127.0.0.1:8181


### PR DESCRIPTION
This change adds v22.2 as the primary version to test all integration cases against, and drops 20.2 from the test matrix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/245)
<!-- Reviewable:end -->
