### PR TITLE
cdc: Make bufio.Scanner buffer configurable

### DIFF
--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -129,6 +129,8 @@ func (h *Handler) ndjson(ctx context.Context, req *request) error {
 
 	muts := make([]types.Mutation, 0, batches.Size())
 	scanner := bufio.NewScanner(req.body)
+	// Our config defaults to bufio.MaxScanTokenSize.
+	scanner.Buffer(make([]byte, 0, h.Config.NDJsonBuffer), h.Config.NDJsonBuffer)
 	for scanner.Scan() {
 		buf := scanner.Bytes()
 		if len(buf) == 0 {


### PR DESCRIPTION
The default Scanner buffer used for ndjson parsing is 64k. This per-line limit can be hit if the source cluster sends data with blobs. This change allows the buffer size to be set to arbitrary values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/273)
<!-- Reviewable:end -->
