### PR TITLE
cdc: Split resolver.readInto()

### DIFF
--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -269,6 +269,9 @@ func testMassBackfillWithForeignKeys(t *testing.T, backfill bool, chaosProb floa
 	ctx := fixture.Context
 	h := fixture.Handler
 
+	loadStart := time.Now()
+	log.Info("starting data load")
+
 	parent, err := fixture.CreateTable(ctx,
 		`CREATE TABLE %s (pk INT PRIMARY KEY, v INT NOT NULL)`)
 	r.NoError(err)
@@ -303,7 +306,7 @@ func testMassBackfillWithForeignKeys(t *testing.T, backfill bool, chaosProb floa
 			}))
 		}
 	}
-	log.Info("finished filling data")
+	log.Info("finished filling data in ", time.Since(loadStart).String())
 
 	// Send a resolved timestamp that needs to dequeue many rows.
 	r.NoError(h.resolved(ctx, &request{


### PR DESCRIPTION
This change reorganizes the code in the readInto() method into an outer method that loops and an inner method which implements a single pass of the loop. This change is motivated by a desire to clarify the lifetime of the next-timestamp transaction associated with an iteration of the resolver loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/289)
<!-- Reviewable:end -->
