### PR TITLE
cdc: Use lease package when retrieving work

### DIFF
--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -44,6 +44,7 @@ func ProvideMetaTable(cfg *Config) MetaTable {
 func ProvideResolvers(
 	ctx context.Context,
 	cfg *Config,
+	leases types.Leases,
 	metaTable MetaTable,
 	pool *pgxpool.Pool,
 	stagers types.Stagers,
@@ -55,6 +56,7 @@ func ProvideResolvers(
 
 	ret := &Resolvers{
 		cfg:       cfg,
+		leases:    leases,
 		metaTable: metaTable.Table(),
 		pool:      pool,
 		stagers:   stagers,

--- a/internal/source/cdc/resolver_test.go
+++ b/internal/source/cdc/resolver_test.go
@@ -56,6 +56,7 @@ func TestResolverDeQueue(t *testing.T) {
 
 	for i := int64(0); i < rowCount; i++ {
 		r.NoError(resolver.Mark(ctx, hlc.New(i+1, 0)))
+		r.NoError(resolver.Mark(ctx, hlc.New(i, 0)))
 	}
 
 	log.Info("marked")

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/target/auth/trust"
+	"github.com/cockroachdb/cdc-sink/internal/target/leases"
 	"github.com/cockroachdb/cdc-sink/internal/target/sinktest"
 	"github.com/google/wire"
 )
@@ -33,6 +34,7 @@ func newTestFixture(*sinktest.Fixture, *Config) (*testFixture, func(), error) {
 		wire.FieldsOf(new(*sinktest.BaseFixture), "Context"),
 		wire.FieldsOf(new(*sinktest.Fixture),
 			"Appliers", "BaseFixture", "Stagers", "Watchers"),
+		leases.Set,
 		logical.Set,
 		script.Set,
 		trust.New, // Is valid to use as a provider.

--- a/internal/source/server/injector.go
+++ b/internal/source/server/injector.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/target/leases"
 	"github.com/google/wire"
 )
 
@@ -27,6 +28,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
+		leases.Set,
 		logical.Set,
 		script.Set,
 		target.Set,

--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/target/leases"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
@@ -43,6 +44,7 @@ func newTestFixture(context.Context, *Config) (*testFixture, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
+		leases.Set,
 		logical.Set,
 		script.Set,
 		target.Set,

--- a/internal/target/leases/provider.go
+++ b/internal/target/leases/provider.go
@@ -1,0 +1,45 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package leases
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/google/wire"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// Set is used by Wire.
+var Set = wire.NewSet(
+	ProvideLeases,
+)
+
+// ProvideLeases is called by Wire to configure the work-leasing strategy.
+//
+// This can be removed once stagingDB once SELECT FOR UPDATE uses
+// replicated locks.
+//
+// https://github.com/cockroachdb/cockroach/issues/100194
+func ProvideLeases(
+	ctx context.Context, pool *pgxpool.Pool, stagingDB ident.StagingDB,
+) (types.Leases, error) {
+	return New(ctx, Config{
+		Guard:      time.Second,
+		Lifetime:   5 * time.Second,
+		RetryDelay: time.Second,
+		Poll:       time.Second,
+		Pool:       pool,
+		Target:     ident.NewTable(stagingDB.Ident(), ident.Public, ident.New("leases")),
+	})
+}


### PR DESCRIPTION
The locks created by a SELECT FOR UPDATE command are unreplicated and fragile if the leaseholder for the associated range is moved. This change creates an explicit lease for the destination schema to work around the limitation.

https://github.com/cockroachdb/cockroach/issues/100194

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/297)
<!-- Reviewable:end -->
