### PR TITLE
fan: Add sanity-check for semaphore over-relase

### DIFF
--- a/internal/target/apply/fan/stamped_batch.go
+++ b/internal/target/apply/fan/stamped_batch.go
@@ -11,12 +11,16 @@
 package fan
 
 import (
+	"os"
 	"sync"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/pkg/errors"
 )
+
+var _, stampedBackSanityCheck = os.LookupEnv("STAMPED_BATCH_CHECKS")
 
 // A stampedBatch of mutations.
 type stampedBatch struct {
@@ -25,6 +29,7 @@ type stampedBatch struct {
 		sync.Mutex
 		immutable bool // If true, prevents coalescing.
 		muts      []types.Mutation
+		weight    int64
 	}
 }
 
@@ -33,22 +38,23 @@ var _ stamp.Coalescing = (*stampedBatch)(nil)
 func newBatch(stamp stamp.Stamp, mut types.Mutation) *stampedBatch {
 	ret := &stampedBatch{stamp: stamp}
 	ret.mu.muts = []types.Mutation{mut}
+	ret.mu.weight = mutationWeight(mut)
 	return ret
 }
 
 // Coalesce allows a tail element to be merged if it has the same Stamp.
 func (b *stampedBatch) Coalesce(tail stamp.Stamped) stamp.Stamped {
+	other := tail.(*stampedBatch)
+	if stamp.Compare(b.stamp, other.stamp) != 0 {
+		return tail
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	// If this stampedBatch is in the process of being flushed, we don't
 	// want it to allow coalescing.
 	if b.mu.immutable {
-		return tail
-	}
-
-	other := tail.(*stampedBatch)
-	if stamp.Compare(b.stamp, other.stamp) != 0 {
 		return tail
 	}
 
@@ -66,30 +72,68 @@ func (b *stampedBatch) Coalesce(tail stamp.Stamped) stamp.Stamped {
 
 	// Append as many elements as will bring us up to the configured
 	// batching size.
-	toAppend := other.mu.muts
 	maxCount := batches.Size() - len(b.mu.muts)
-	if maxCount > len(toAppend) {
-		maxCount = len(toAppend)
+	toTransfer := other.mu.muts
+	if maxCount >= len(toTransfer) {
+		b.mu.muts = append(b.mu.muts, toTransfer...)
+		b.mu.weight += other.mu.weight
+		other.mu.muts = nil
+		other.mu.weight = 0
+		return nil
 	}
-	b.mu.muts = append(b.mu.muts, toAppend[:maxCount]...)
 
-	// Return the remainder, or nil if we've consumed all elements.
-	toAppend = toAppend[maxCount:]
-	if len(toAppend) > 0 {
-		other.mu.muts = toAppend
-		return other
+	// For sanity check later.
+	origWeight := b.mu.weight + other.mu.weight
+
+	// Push the elements around.
+	other.mu.muts = toTransfer[maxCount:]
+	toTransfer = toTransfer[:maxCount]
+	b.mu.muts = append(b.mu.muts, toTransfer...)
+
+	for _, mut := range toTransfer {
+		weight := mutationWeight(mut)
+		b.mu.weight += weight
+		other.mu.weight -= weight
 	}
-	return nil
+
+	// Sanity check the math and/or concurrent mutation.
+	if stampedBackSanityCheck && origWeight != b.mu.weight+other.mu.weight {
+		panic(errors.Errorf("unexpected weight %d vs %d", origWeight, b.mu.weight+other.mu.weight))
+	}
+	return other
 }
 
 // Pick marks the batch as immutable, to prevent coalescing, and returns
 // the enclosed mutations.
-func (b *stampedBatch) Pick() []types.Mutation {
+func (b *stampedBatch) Pick() (muts []types.Mutation, weight int64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.mu.immutable = true
-	return b.mu.muts
+
+	if stampedBackSanityCheck {
+		var check int64
+		for _, mut := range b.mu.muts {
+			check += mutationWeight(mut)
+		}
+		if check != b.mu.weight {
+			panic(errors.Errorf("mismatch in picked weight: %d vs %d", check, b.mu.weight))
+		}
+	}
+
+	return b.mu.muts, b.mu.weight
 }
 
 // Stamp implements stamp.Stamped.
 func (b *stampedBatch) Stamp() stamp.Stamp { return b.stamp }
+
+// Weight returns the backpressure weight of the batch.
+func (b *stampedBatch) Weight() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.mu.weight
+}
+
+// mutationWeight computes a weight to use for generating backpressure.
+func mutationWeight(mut types.Mutation) int64 {
+	return int64(len(mut.Data)) + int64(len(mut.Key))
+}

--- a/internal/target/apply/fan/stamped_batch_test.go
+++ b/internal/target/apply/fan/stamped_batch_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/batches"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchCoalesce(t *testing.T) {
+	stampedBackSanityCheck = true
+
+	m := types.Mutation{
+		Data: []byte("SOME DATA"),
+		Key:  []byte("SOME KEY"),
+		Time: hlc.From(time.Now()),
+		Meta: nil,
+	}
+
+	t.Run("append-until-full", func(t *testing.T) {
+		a := assert.New(t)
+
+		batch := newBatch(nil, m)
+		for {
+			tail := newBatch(nil, m)
+
+			leftover := batch.Coalesce(tail)
+			if leftover != nil {
+				break
+			}
+		}
+
+		muts, weight := batch.Pick()
+
+		a.Len(muts, batches.Size())
+		a.Equal(int64(batches.Size()*(len(m.Data)+len(m.Key))), weight)
+	})
+
+	// Verify that a picked batch cannot coalesce or be coalesced.
+	t.Run("coalesce-picked", func(t *testing.T) {
+		a := assert.New(t)
+
+		b1 := newBatch(nil, m)
+		b2 := newBatch(nil, m)
+
+		b1.Pick()
+		a.Same(b2, b1.Coalesce(b2))
+		a.Same(b1, b2.Coalesce(b1))
+	})
+
+	t.Run("partial-coalesce", func(t *testing.T) {
+		r := require.New(t)
+
+		max := 3 * batches.Size() / 4
+
+		b1 := newBatch(nil, m)
+		b2 := newBatch(nil, m)
+		for i := 0; i < max-1; i++ {
+			r.Nil(b1.Coalesce(newBatch(nil, m)))
+			r.Nil(b2.Coalesce(newBatch(nil, m)))
+		}
+
+		r.Len(b1.mu.muts, max)
+		r.Len(b2.mu.muts, max)
+
+		rem := b1.Coalesce(b2)
+		r.Len(b1.mu.muts, batches.Size())
+		r.Equal(int64(batches.Size()*(len(m.Data)+len(m.Key))), b1.Weight())
+
+		r.Same(b2, rem)
+		r.Len(b2.mu.muts, batches.Size()/2)
+		r.Equal(int64(batches.Size()/2*(len(m.Data)+len(m.Key))), b2.Weight())
+	})
+}


### PR DESCRIPTION
This change calculates the mutation weight of a stampedBatch once and updates it as any batch coalescing occurs. An environment variable, STAMPED_BATCH_CHECKS, is added for temporary testing purposes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/298)
<!-- Reviewable:end -->
