### PR TITLE
leases: Report blocked-until time

### DIFF
--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -71,7 +71,7 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 
 	var dialect logical.Dialect = gen
 	if withChaos {
-		dialect = logical.WithChaos(gen, 0.01)
+		dialect = logical.WithChaos(gen, 0.05)
 	}
 
 	cfg := &logical.BaseConfig{

--- a/internal/source/logical/loop.go
+++ b/internal/source/logical/loop.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding"
 	"encoding/json"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -242,12 +243,33 @@ func (l *loop) run(ctx context.Context) {
 // runOnce is called by run.
 func (l *loop) runOnce(ctx context.Context) error {
 	if lessor, ok := l.dialect.(Lessor); ok {
-		lease, err := lessor.Acquire(ctx)
-		if err != nil {
-			// Mask lease-busy error.  We'll just try again later.
-			if errors.As(err, (*types.LeaseBusyError)(nil)) {
-				return nil
+		// Loop until we can acquire a lease.
+		var lease types.Lease
+		for {
+			var err error
+			lease, err = lessor.Acquire(ctx)
+			// Lease acquired.
+			if err == nil {
+				log.Tracef("lease %s acquired", l.config.LoopName)
+				break
 			}
+			// If busy, wait until the expiration.
+			if busy, ok := types.IsLeaseBusy(err); ok {
+				log.WithField("until", busy.Expiration).Tracef(
+					"lease %s was busy, waiting", l.config.LoopName)
+
+				// Add some jitter to the expiration.
+				duration := time.Until(busy.Expiration) +
+					time.Duration(rand.Intn(10))*time.Millisecond
+
+				select {
+				case <-time.After(duration):
+					continue
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			// General err, defer to the loop's retry delay.
 			return err
 		}
 		defer lease.Release()

--- a/internal/target/leases/leases.go
+++ b/internal/target/leases/leases.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/google/uuid"
 	"github.com/jackc/pgtype/pgxtype"
-	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -138,23 +137,23 @@ func New(ctx context.Context, cfg Config) (types.Leases, error) {
 
 // Acquire the named lease, keep it alive, and return a facade.
 func (l *leases) Acquire(ctx context.Context, name string) (types.Lease, error) {
-	acquired, ok, err := l.acquire(ctx, name)
+	leaseRow, ok, err := l.acquire(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return nil, &types.LeaseBusyError{}
+		return nil, &types.LeaseBusyError{Expiration: leaseRow.expires}
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
-		l.keepRenewed(ctx, acquired)
+		l.keepRenewed(ctx, leaseRow)
 		cancel()
 	}()
 
 	ret := &leaseFacade{
 		cancel: func() {
-			_, _ = l.release(ctx, acquired)
+			_, _ = l.release(ctx, leaseRow)
 			cancel()
 		},
 		ctx: ctx,
@@ -318,10 +317,12 @@ func (l *leases) keepRenewed(ctx context.Context, tgt lease) lease {
 }
 
 // acquire returns a non-nil lease if it was able to acquire the named lease.
-func (l *leases) acquire(ctx context.Context, name string) (acquired lease, ok bool, err error) {
+func (l *leases) acquire(
+	ctx context.Context, name string,
+) (leaseRow lease, acquired bool, err error) {
 	err = retry.Retry(ctx, func(ctx context.Context) error {
 		var err error
-		acquired, ok, err = l.tryAcquire(ctx, name, time.Now())
+		leaseRow, acquired, err = l.tryAcquire(ctx, name, time.Now())
 		return err
 	})
 	return
@@ -341,35 +342,44 @@ const acquireTemplate = `
 WITH
   proposed (name, expires, nonce) AS (VALUES ($1::STRING, $2::TIMESTAMP, gen_random_uuid())),
   blocking AS (
-    SELECT 1
+    SELECT x.expires
     FROM %[1]s x
     JOIN proposed USING (name)
     WHERE x.expires > $3::TIMESTAMP
-    LIMIT 1)
-UPSERT INTO %[1]s 
-  SELECT name, expires, nonce
-  FROM proposed
-  WHERE (SELECT count(*) FROM blocking) = 0
-  RETURNING nonce
+    FOR UPDATE
+    LIMIT 1),
+  acquired AS (
+    UPSERT INTO %[1]s
+    SELECT name, expires, nonce
+    FROM proposed
+    WHERE (SELECT count(*) FROM blocking) = 0
+    RETURNING nonce)
+SELECT (SELECT expires FROM blocking), (SELECT nonce FROM acquired)
 `
 
-// tryAcquire returns a non-nil lease if it was able to acquire the named lease.
+// tryAcquire returns the current state of the named lease in the
+// database. The ok value will be true if this call acquired the lease.
 func (l *leases) tryAcquire(
 	ctx context.Context, name string, now time.Time,
-) (acquired lease, ok bool, err error) {
-	now = now.UTC()
+) (leaseRow lease, acquired bool, err error) {
+	// We only have millisecond-level resolution in the db.
+	now = now.UTC().Truncate(time.Millisecond)
 	expires := now.Add(l.cfg.Lifetime)
+	var blockedUntil *time.Time
 	var nonce uuid.UUID
 
 	// Explicit call to Format needed for compatibility with CRDB 20.2.
-	row := l.cfg.Pool.QueryRow(ctx, l.sql.acquire, name,
-		expires.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
-	if err := row.Scan(&nonce); errors.Is(err, pgx.ErrNoRows) {
-		return lease{}, false, nil
-	} else if err != nil {
+	if err := l.cfg.Pool.QueryRow(ctx,
+		l.sql.acquire,
+		name,
+		expires.Format(time.RFC3339Nano),
+		now.Format(time.RFC3339Nano),
+	).Scan(&blockedUntil, &nonce); err != nil {
 		return lease{}, false, errors.WithStack(err)
 	}
-
+	if blockedUntil != nil {
+		return lease{*blockedUntil, name, uuid.UUID{}}, false, nil
+	}
 	return lease{expires, name, nonce}, true, nil
 }
 

--- a/internal/target/leases/leases_test.go
+++ b/internal/target/leases/leases_test.go
@@ -252,7 +252,7 @@ func TestLeases(t *testing.T) {
 
 		eg, egCtx := errgroup.WithContext(ctx)
 		var running int32
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 10; i++ {
 			eg.Go(func() error {
 				// Each callback verifies that it's the only instance
 				// running, then requests to be shut down.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -65,9 +65,16 @@ type Lease interface {
 
 // LeaseBusyError is returned by [Leases.Acquire] if another caller
 // holds the lease.
-type LeaseBusyError struct{}
+type LeaseBusyError struct {
+	Expiration time.Time
+}
 
 func (e *LeaseBusyError) Error() string { return "lease is held by another caller" }
+
+// IsLeaseBusy returns the error if it represents a busy lease.
+func IsLeaseBusy(err error) (busy *LeaseBusyError, ok bool) {
+	return busy, errors.As(err, &busy)
+}
 
 // Leases coordinates behavior across multiple instances of cdc-sink.
 type Leases interface {


### PR DESCRIPTION
This change allows the lease package to report when a blocking lease will expire.  The logical loop code will now use that to optimize its waiting behaviors. The chaos dialect also now simulates busy-lease and error conditions when acquiring a lease.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/304)
<!-- Reviewable:end -->
