### PR TITLE
workflow: Add CockroachDB v23.1b2 to test matrix

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -29,6 +29,10 @@ services:
     image: cockroachdb/cockroach:latest-v22.2
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
+  cockroachdb-v23.1:
+    image: cockroachdb/cockroach-unstable:v23.1.0-beta.2
+    network_mode: host
+    command: start-single-node --insecure --store type=mem,size=2G
   firestore:
     image: ghcr.io/cockroachdb/cdc-sink/firestore-emulator:latest
     # Expose the emulator on port 8181 to avoid conflict with CRDB admin UI.

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -156,6 +156,7 @@ jobs:
           - cockroachdb: v21.1
           - cockroachdb: v21.2
           - cockroachdb: v22.2
+          - cockroachdb: v23.1
     env:
       COVER_OUT: coverage-${{ matrix.cockroachdb }}-${{ matrix.integration }}.out
       FIRESTORE_EMULATOR_HOST: 127.0.0.1:8181


### PR DESCRIPTION
This change adds 23.1 to the test matrix, with the caveat that there's no "latest" tag in the unstable repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/305)
<!-- Reviewable:end -->
