### PR TITLE
schemawatch: only return actual tables, not views, when querying table names

### DIFF
--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -195,7 +195,7 @@ func (w *watcher) Watch(table ident.Table) (_ <-chan []types.ColData, cancel fun
 	return ch, cancel, nil
 }
 
-const tableTemplate = `SELECT schema_name, table_name FROM [SHOW TABLES FROM %s]`
+const tableTemplate = `SELECT schema_name, table_name FROM [SHOW TABLES FROM %s] WHERE type = 'table'`
 
 func (w *watcher) getTables(ctx context.Context, tx pgxtype.Querier) (*types.SchemaData, error) {
 	ret := &types.SchemaData{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/306)
<!-- Reviewable:end -->
