### PR TITLE
Resolve v23.1 test flakes

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -193,10 +193,10 @@ jobs:
         working-directory: .github
         run: docker-compose up -d ${{ matrix.integration }}
 
-      # The go test json output will be written into a file that's
-      # processed by a subsequent step into a JUnit.xml file. The test
-      # reports are aggregated later on to produce a nicer summary of
-      # the test output in the GitHub Actions UI.
+      # The go test json output will be written into a pipeline to
+      # create a JUnit.xml file. The test reports are aggregated later
+      # on to produce a nicer summary of the test output in the GitHub
+      # Actions UI.
       #
       # Inspired by
       # https://www.cloudwithchris.com/blog/githubactions-testsummary-go/
@@ -205,13 +205,22 @@ jobs:
           COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
           CDC_INTEGRATION: ${{ matrix.integration }}
         run: >
+          set -o pipefail;
           go test
+          -count 1
           -coverpkg=./internal/...
           -covermode=atomic
           -coverprofile=${{ env.COVER_OUT }}
-          -json
           -race
-          ./... > ${{ env.TEST_OUT }}
+          -v
+          ./... 2>&1 |
+          go run github.com/jstemmer/go-junit-report/v2
+          -iocopy
+          -out ${{ env.JUNIT_OUT }}
+          -p cockroachdb=${{ matrix.cockroachdb }}
+          -p integration=${{ matrix.integration }}
+          -package-name ${{ matrix.cockroachdb }}-${{ matrix.integration }} |
+          tee ${{ env.TEST_OUT }}
 
       - name: Stop databases
         if: ${{ always() }}
@@ -223,17 +232,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.COVER_OUT }}
-
-      - name: Convert test json to JUnit xml
-        if: always()
-        run: >
-          go run github.com/jstemmer/go-junit-report/v2
-          -parser gojson
-          -in ${{ env.TEST_OUT }}
-          -out ${{ env.JUNIT_OUT }}
-          -p cockroachdb=${{ matrix.cockroachdb }}
-          -p integration=${{ matrix.integration }}
-          -package-name ${{ matrix.cockroachdb }}-${{ matrix.integration }}
 
       # Upload all test reports to a common artifact name, to make them
       # available to the summarization step. The go test json is

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -334,19 +334,24 @@ func TestAllDataTypes(t *testing.T) {
 		"decimal_eng_50,2": "400000000000000000000000000000000000000000000000000.00",
 	}
 
-	a := assert.New(t)
-
-	fixture, cancel, err := sinktest.NewFixture()
-	if !a.NoError(err) {
-		return
-	}
-	defer cancel()
-
-	ctx := fixture.Context
-
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
+
+			// Creating a new database for each loop is, as of v22.2 and
+			// v23.1 faster than dropping the table between iterations.
+			// This is relevant because the fixture contains a test
+			// timeout which was getting tripped due to performance
+			// changes in v23.1.
+			//
+			// https://github.com/cockroachdb/cockroach/issues/102259
+			fixture, cancel, err := sinktest.NewFixture()
+			if !a.NoError(err) {
+				return
+			}
+			defer cancel()
+
+			ctx := fixture.Context
 
 			// Place the PK index on the data type under test, if allowable.
 			var create string


### PR DESCRIPTION
The flakiness in `apply_test.go` against v23.1 is caused by a performance regression in the table metadata queries.  This PR creates a fresh database for each loop of the test. There's a separate commit which tweaks how the go test logs are emitted to the GitHub Actions UI.

https://github.com/cockroachdb/cockroach/issues/102259

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/314)
<!-- Reviewable:end -->
