### PR TITLE
Remove unnecessary locking code from resolver

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -155,6 +155,7 @@ jobs:
         include:
           - cockroachdb: v21.1
           - cockroachdb: v21.2
+          - cockroachdb: v22.1
           - cockroachdb: v22.2
           - cockroachdb: v23.1
     env:

--- a/internal/util/stamp/queue.go
+++ b/internal/util/stamp/queue.go
@@ -252,7 +252,7 @@ func (s *Queue) validate() error {
 	// Invariant 4: consistent < markers[0]
 	if mark := s.PeekMarker(); mark != nil {
 		if Compare(s.consistent, mark) >= 0 {
-			return errors.Errorf("consistent stamp %s > markers stamp %s", s.consistent, mark)
+			return errors.Errorf("consistent stamp %s >= markers stamp %s", s.consistent, mark)
 		}
 	}
 


### PR DESCRIPTION
These changes remove the remnants of the `SELECT FOR UPDATE` approach to locking. They also add a test for concurrent instances of the resolver loop. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/315)
<!-- Reviewable:end -->
