### PR TITLE
cdc: Fix timestamp parsing

### DIFF
--- a/internal/source/cdc/resolved.go
+++ b/internal/source/cdc/resolved.go
@@ -83,7 +83,7 @@ func parseResolvedTimestamp(timestamp string, logical string) (hlc.Time, error) 
 	if err != nil {
 		return hlc.Time{}, err
 	}
-	timestampParsed.Add(nanos)
+	timestampParsed = timestampParsed.Add(nanos)
 
 	// Parse out the logical timestamp
 	logicalParsed, err := strconv.Atoi(logical)

--- a/internal/source/cdc/url_test.go
+++ b/internal/source/cdc/url_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/stretchr/testify/assert"
 )
@@ -68,10 +69,12 @@ func TestResolvedURL(t *testing.T) {
 		u         string
 		expect    string
 		expectErr bool
+		time      hlc.Time
 	}{
 		{
-			u:      "/db/public/2020-04-04/202004042351304139680000000000456.RESOLVED",
+			u:      "/db/public/2020-04-04/202011221122335555555556666666666.RESOLVED",
 			expect: "db.public",
+			time:   hlc.New(1606044153_555555555, 6666666666),
 		},
 		{
 			u:         "/db/2020-04-04/202004042351304139680000000000456.RESOLVED",
@@ -97,6 +100,7 @@ func TestResolvedURL(t *testing.T) {
 			}
 			if a.NoError(err) {
 				a.Equal(tc.expect, req.target.AsSchema().Raw())
+				a.Equal(tc.time, req.timestamp)
 			}
 		})
 	}


### PR DESCRIPTION
The timestamp parsing code has always thrown away the nanos values. A test is added to check for correct parsing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/319)
<!-- Reviewable:end -->
