### PR TITLE
logical: Improve graceful draining

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.20
 
 require (
 	cloud.google.com/go/firestore v1.9.0
+	github.com/bobvawter/latch v1.0.1
 	github.com/cockroachdb/apd v1.1.0
-	github.com/cockroachdb/crlfmt v0.0.0-20220610162206-024b567ce87b
+	github.com/cockroachdb/crlfmt v0.0.0-20221214225007-b2fc5c302548
 	github.com/dop251/goja v0.0.0-20220915101355-d79e1b125a30
 	github.com/evanw/esbuild v0.17.17
 	github.com/go-mysql-org/go-mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bobvawter/latch v1.0.1 h1:pSQUCMKlucP4V2OOzSKpMoGdTQ0CucSc+PpH04qub+I=
+github.com/bobvawter/latch v1.0.1/go.mod h1:Y2y27j+pGSfiJVvw+xF8YDFV7cjq5vUS0Vmp40eSupk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -72,12 +74,10 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/cockroachdb/crlfmt v0.0.0-20220610162206-024b567ce87b h1:kGrgvdN+SBR+DsZIf51EguT29Y7Am1/v9DYoDvhzeyU=
-github.com/cockroachdb/crlfmt v0.0.0-20220610162206-024b567ce87b/go.mod h1:EOI6rrXIdP+4EXwM8837kmmb6IJesf7k7W6bUu8BDOg=
-github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqid9LAzWz/l5OgA=
+github.com/cockroachdb/crlfmt v0.0.0-20221214225007-b2fc5c302548 h1:i0bnjanlWAvM50wHMT7EFyxlt5HQusznWrkwl+HBIsU=
+github.com/cockroachdb/crlfmt v0.0.0-20221214225007-b2fc5c302548/go.mod h1:qtkxNlt5i3rrdirfJE/bQeW/IeLajKexErv7jEIV+Uc=
 github.com/cockroachdb/gostdlib v1.19.0 h1:cSISxkVnTlWhTkyple/T6NXzOi5659FkhxvUgZv+Eb0=
 github.com/cockroachdb/gostdlib v1.19.0/go.mod h1:+dqqpARXbE/gRDEhCak6dm0l14AaTymPZUKMfURjBtY=
-github.com/cockroachdb/ttycolor v0.0.0-20180709150743-a1d5aaeb377d/go.mod h1:NltwFG0VBANi1jHKpn5KL9AbsHTE+8fPaAHT0TzL20k=
 github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8 h1:Hli+oX84dKq44sLVCcsGKqifm5Lg9J8VoJ2P3h9iPdI=
 github.com/cockroachdb/ttycolor v0.0.0-20210902133924-c7d7dcdde4e8/go.mod h1:75wnig8+TF6vst9hChkpcFO7YrRLddouJ5is8uqpfv0=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -336,7 +336,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -574,7 +573,6 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200923014426-f5e916c686e1/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201125231158-b5590deeca9b/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=

--- a/internal/source/fslogical/config.go
+++ b/internal/source/fslogical/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// Copies the document id from the doc metadata into the mutation
 	// using this property name.
 	DocumentIDProperty ident.Ident
+	// Enable extra tracking to allow selective re-processing of
+	// documents in a source collection.
+	Idempotent bool
 	// The Firebase project id. Usually inferred from the credentials.
 	ProjectID string
 	// The name of a collection that contains tombstones for documents
@@ -62,6 +65,8 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	// NB: Keep default value in sync with doc on tombstones.
 	f.Var(ident.NewValue("id", &c.DocumentIDProperty), "docID",
 		"the column name (likely the primary key) to populate with the document id")
+	f.BoolVar(&c.Idempotent, "idempotent", true,
+		"track received document ids and server times to prevent reprocessing")
 	f.StringVar(&c.LoopName, "loopName", "fslogical",
 		"identifies the logical replication loops in metrics")
 	f.StringVar(&c.ProjectID, "projectID", "",

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -155,6 +155,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 		},
 		BackfillBatchSize:           10,
 		DocumentIDProperty:          ident.New("id"), // Map doc id metadata to target column.
+		Idempotent:                  true,
 		ProjectID:                   projectID,
 		TombstoneCollection:         "Tombstones",
 		TombstoneCollectionProperty: ident.New("collection"),
@@ -175,7 +176,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 			break
 		}
 		log.Infof("saw only %d documents in top level", ct)
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	log.Info("waiting for child-table backfill")
@@ -186,7 +187,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 			break
 		}
 		log.Infof("saw only %d documents in child table", ct)
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	log.Info("waiting for collection-group backfill")
@@ -199,7 +200,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 			break
 		}
 		log.Infof("saw only %d documents in sub-collection", ct)
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	log.Info("backfill done, sending document updates")
@@ -240,7 +241,8 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 		if ct == docCount {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		log.Infof("saw only %d updated documents", ct)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	log.Info("saw updates, writing tombstones")
@@ -285,7 +287,8 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 		if ct == 0 {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		log.Infof("still have %d documents to delete", ct)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	log.Info("all deletes done")

--- a/internal/source/fslogical/provider.go
+++ b/internal/source/fslogical/provider.go
@@ -21,8 +21,10 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/golang/groupcache/lru"
+	"github.com/jackc/pgx/v5/pgxpool"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 )
@@ -46,8 +48,10 @@ var enableWipe bool
 func ProvideLoops(
 	ctx context.Context,
 	cfg *Config,
-	loops *logical.Factory,
 	fs *firestore.Client,
+	loops *logical.Factory,
+	memo types.Memo,
+	pool *pgxpool.Pool,
 	st *Tombstones,
 	userscript *script.UserScript,
 ) ([]*logical.Loop, func(), error) {
@@ -78,7 +82,10 @@ func ProvideLoops(
 			backfillBatchSize: cfg.BackfillBatchSize,
 			docIDProperty:     cfg.DocumentIDProperty.Raw(),
 			fs:                fs,
+			idempotent:        cfg.Idempotent,
 			loops:             loops,
+			memo:              memo,
+			pool:              pool,
 			query:             q,
 			tombstones:        st,
 			recurse:           source.Recurse,
@@ -99,7 +106,11 @@ func ProvideLoops(
 
 // ProvideFirestoreClient is called by wire. If a local emulator is in
 // use, the cleanup function will delete the test project data.
-func ProvideFirestoreClient(ctx context.Context, cfg *Config) (*firestore.Client, func(), error) {
+// The UserScript is added as a fake dependency to ensure that any
+// script-driven configuration is performed first.
+func ProvideFirestoreClient(
+	ctx context.Context, cfg *Config, _ *script.UserScript,
+) (*firestore.Client, func(), error) {
 	// Project ID is usually baked into the JSON key file.
 	projectID := firestore.DetectProjectID
 	if cfg.ProjectID != "" {

--- a/internal/source/logical/generator_test.go
+++ b/internal/source/logical/generator_test.go
@@ -125,6 +125,10 @@ func (g *generatorDialect) ReadInto(
 				g.readIntoMu.lastBatchSent = nextBatchNumber
 				g.readIntoMu.Unlock()
 
+			case <-state.Stopping():
+				// Graceful shutdown requested.
+				return nil
+
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -135,6 +139,8 @@ func (g *generatorDialect) ReadInto(
 		// Wait for more work or to be shut down
 		select {
 		case <-g.workRequested:
+		case <-state.Stopping():
+			return nil
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/internal/source/logical/provider.go
+++ b/internal/source/logical/provider.go
@@ -64,7 +64,7 @@ func ProvideFactory(
 		watchers:   watchers,
 		userscript: userscript,
 	}
-	f.mu.loops = make(map[string]*loopCancel)
+	f.mu.loops = make(map[string]*Loop)
 	return f, f.Close
 }
 

--- a/internal/util/stopper/stopper.go
+++ b/internal/util/stopper/stopper.go
@@ -1,0 +1,267 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package stopper contains a utility class for gracefully terminating
+// long-running processes.
+package stopper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// contextKey is a [context.Context.Value] key.
+type contextKey struct{}
+
+// background is a Context that never stops.
+var background = &Context{
+	delegate: context.Background(),
+	stopping: make(chan struct{}),
+}
+
+// ErrStopped will be returned from [context.Cause] when the Context has
+// been stopped.
+var ErrStopped = errors.New("stopped")
+
+// ErrGracePeriodExpired will be returned from [context.Cause] when the
+// Context has been stopped, but the goroutines have not exited.
+var ErrGracePeriodExpired = errors.New("grace period expired")
+
+// A Context is conceptually similar to an [errgroup.Group] in that it
+// manages a [context.Context] whose lifecycle is associated with some
+// number of goroutines. Rather than canceling the associated context
+// when a goroutine returns an error, it cancels the context after the
+// Stop method is called and all associated goroutines have all exited.
+//
+// As an API convenience, the Context type implements [context.Context]
+// so that it fits into idiomatic context-plumbing.  The [From]
+// function can be used to retrieve a Context from any
+// [context.Context].
+type Context struct {
+	cancel   func(error)
+	delegate context.Context
+	stopping chan struct{}
+	parent   *Context
+
+	mu struct {
+		sync.RWMutex
+		count    int
+		err      error
+		stopping bool
+	}
+}
+
+var _ context.Context = (*Context)(nil)
+
+// Background is analogous to [context.Background]. It returns a Context
+// which cannot be stopped or canceled, but which is otherwise
+// functional.
+func Background() *Context { return background }
+
+// From returns a pre-existing Context from the Context chain. Use
+// [WithContext] to construct a new Context.
+//
+// If the chain is not associated with a Context, the [Background]
+// instance will be returned.
+func From(ctx context.Context) *Context {
+	if s, ok := ctx.(*Context); ok {
+		return s
+	}
+	if s := ctx.Value(contextKey{}); s != nil {
+		return s.(*Context)
+	}
+	return Background()
+}
+
+// IsStopping is a convenience method to determine if a stopper is
+// associated with a Context and if work should be stopped.
+func IsStopping(ctx context.Context) bool {
+	return From(ctx).IsStopping()
+}
+
+// WithContext creates a new Context whose work will be immediately
+// canceled when the parent context is canceled. If the provided context
+// is already managed by a Context, a call to the enclosing
+// [Context.Stop] method will also trigger a call to Stop in the
+// newly-constructed Context.
+func WithContext(ctx context.Context) *Context {
+	// Might be background, which never stops.
+	parent := From(ctx)
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	s := &Context{
+		cancel:   cancel,
+		delegate: ctx,
+		parent:   parent,
+		stopping: make(chan struct{}),
+	}
+
+	// Propagate a parent stop or context cancellation into a Stop call
+	// to ensure that all notification channels are closed.
+	go func() {
+		select {
+		case <-parent.Stopping():
+		case <-s.Done():
+		}
+		s.Stop(0)
+	}()
+	return s
+}
+
+// Deadline implements [context.Context].
+func (s *Context) Deadline() (deadline time.Time, ok bool) { return s.delegate.Deadline() }
+
+// Done implements [context.Context]. The channel that is returned will
+// be closed when Stop has been called and all associated goroutines
+// have exited. The returned channel will be closed immediately if the
+// parent context (passed to [WithContext]) is canceled.
+func (s *Context) Done() <-chan struct{} { return s.delegate.Done() }
+
+// Err implements context.Context. When the return value for this is
+// [context.ErrCanceled], [context.Cause] will return [ErrStopped] if
+// the context cancellation resulted from a call to Stop.
+func (s *Context) Err() error { return s.delegate.Err() }
+
+// Go spawns a new goroutine to execute the given function and monitors
+// its lifecycle. This method will not execute the function and return
+// false if Stop has already been called. If the function returns an
+// error, the Stop method will be called. The returned error will be
+// available from Wait once the remaining goroutines have exited.
+func (s *Context) Go(fn func() error) (accepted bool) {
+	if !s.apply(1) {
+		return false
+	}
+
+	go func() {
+		defer s.apply(-1)
+		if err := fn(); err != nil {
+			s.Stop(0)
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if s.mu.err == nil {
+				s.mu.err = err
+			}
+		}
+	}()
+	return true
+}
+
+// IsStopping returns true once [Stop] has been called.  See also
+// [Stopping] for a notification-based API.
+func (s *Context) IsStopping() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.stopping
+}
+
+// Stop begins a graceful shutdown of the Context. When this method is
+// called, the Stopping channel will be closed.  Once all goroutines
+// started by Go have exited, the associated Context will be cancelled,
+// thus closing the Done channel. If the gracePeriod is non-zero, the
+// context will be forcefully cancelled if the goroutines have not
+// exited within the given timeframe.
+func (s *Context) Stop(gracePeriod time.Duration) {
+	if s == background {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.mu.stopping {
+		return
+	}
+	s.mu.stopping = true
+	close(s.stopping)
+
+	// Cancel the context if nothing's currently running.
+	if s.mu.count == 0 {
+		s.cancel(ErrStopped)
+	} else if gracePeriod > 0 {
+		go func() {
+			select {
+			case <-time.After(gracePeriod):
+				// Cancel after the grace period has expired. This
+				// should immediately terminate any well-behaved
+				// goroutines driven by Go().
+				s.cancel(ErrGracePeriodExpired)
+			case <-s.Done():
+				// We'll hit this path in a clean-exit, where apply()
+				// cancels the context after the last goroutine has
+				// exited.
+			}
+		}()
+	}
+}
+
+// Stopping returns a channel that is closed when a graceful shutdown
+// has been requested or when the parent context has been canceled.
+func (s *Context) Stopping() <-chan struct{} {
+	return s.stopping
+}
+
+// Value implements context.Context.
+func (s *Context) Value(key any) any {
+	if _, ok := key.(contextKey); ok {
+		return s
+	}
+	return s.delegate.Value(key)
+}
+
+// Wait will block until Stop has been called and all associated
+// goroutines have exited or the parent context has been cancelled. This
+// method will return the first, non-nil error from any of the callbacks
+// passed to Go. If Wait is called on the [Background] instance, it will
+// immediately return nil.
+func (s *Context) Wait() error {
+	if s == background {
+		return nil
+	}
+	<-s.Done()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.err
+}
+
+// apply is used to maintain the count of started goroutines. It returns
+// true if the delta was applied.
+func (s *Context) apply(delta int) bool {
+	if s == background {
+		return true
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Don't allow new goroutines to be added when stopping.
+	if s.mu.stopping && delta >= 0 {
+		return false
+	}
+
+	// Ensure that nested jobs prolong the lifetime of the parent
+	// context to prevent premature cancellation. Verify that the parent
+	// accepted the delta in case it was just stopped, but our helper
+	// goroutine hasn't yet called Stop on this instance.
+	if !s.parent.apply(delta) {
+		return false
+	}
+
+	s.mu.count += delta
+	if s.mu.count < 0 {
+		// Implementation error, not user problem.
+		panic("over-released")
+	}
+	if s.mu.count == 0 && s.mu.stopping {
+		s.cancel(ErrStopped)
+	}
+	return true
+}

--- a/internal/util/stopper/stopper_test.go
+++ b/internal/util/stopper/stopper_test.go
@@ -1,0 +1,208 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stopper
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAmbient(t *testing.T) {
+	a := assert.New(t)
+
+	s := From(context.Background())
+	a.Same(s, background)
+
+	a.False(IsStopping(context.Background()))
+	s.Go(func() error { return nil })
+
+	// Should be a no-op.
+	s.Stop(0)
+	a.False(s.mu.stopping)
+	a.Nil(s.Err())
+	a.Nil(s.Wait())
+}
+
+func TestCancelOuter(t *testing.T) {
+	a := assert.New(t)
+
+	top, cancelTop := context.WithCancel(context.Background())
+
+	s := WithContext(top)
+
+	s.Go(func() error { <-s.Done(); return nil })
+
+	cancelTop()
+	select {
+	case <-s.Stopping():
+	// Verify that canceling the top-level also closes the Stopping channel.
+	case <-time.After(time.Second):
+		a.Fail("timed out waiting for Stopping to close")
+	}
+	a.True(IsStopping(s))
+	a.ErrorIs(s.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(s), context.Canceled)
+	a.Nil(s.Wait())
+}
+
+func TestCallbackErrorStops(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	err := errors.New("BOOM")
+	s.Go(func() error { return err })
+	a.ErrorIs(s.Wait(), err)
+	a.Error(context.Cause(s), ErrStopped)
+}
+
+func TestChainStopper(t *testing.T) {
+	a := assert.New(t)
+
+	parent := WithContext(context.Background())
+	mid := context.WithValue(parent, parent, parent) // Demonstrate unwrapping.
+	child := WithContext(mid)
+	a.Same(parent, child.parent)
+
+	waitFor := make(chan struct{})
+	child.Go(func() error { <-waitFor; return nil })
+
+	// Verify that stopping the parent propagates to the child.
+	parent.Stop(0)
+	select {
+	case <-child.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("call to stop did not propagate")
+	}
+
+	// However, the contexts should not cancel until the work is done.
+	a.Nil(parent.Err())
+	a.Nil(child.Err())
+
+	// Allow the work to finish, and verify cancellation.
+	close(waitFor)
+
+	select {
+	case <-child.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for child to finish")
+	}
+
+	select {
+	case <-mid.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for mid to finish")
+	}
+
+	select {
+	case <-parent.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for parent to finish")
+	}
+
+	a.ErrorIs(child.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(child), ErrStopped)
+	a.Nil(child.Wait())
+
+	a.ErrorIs(mid.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(mid), ErrStopped)
+
+	a.ErrorIs(parent.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(parent), ErrStopped)
+	a.Nil(child.Wait())
+}
+
+func TestGracePeriod(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+
+	// This goroutine waits on Done, which is not correct.
+	s.Go(func() error { <-s.Done(); return nil })
+
+	s.Stop(time.Nanosecond)
+
+	<-s.Done()
+	a.ErrorIs(s.Err(), context.Canceled)
+	a.ErrorIs(context.Cause(s), ErrGracePeriodExpired)
+}
+
+func TestStopper(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	a.Same(s, From(s))                          // Direct cast
+	a.Same(s, From(context.WithValue(s, s, s))) // Unwrapping
+	select {
+	case <-s.Stopping():
+		a.Fail("should not be stopping yet")
+	default:
+		// OK
+	}
+	a.False(IsStopping(s))
+
+	waitFor := make(chan struct{})
+	a.True(s.Go(func() error { <-waitFor; return nil }))
+	a.True(s.Go(func() error { return nil }))
+
+	s.Stop(0)
+	select {
+	case <-s.Stopping():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for stopped")
+	}
+
+	// Verify that the context is stopping, but not cancelled.
+	a.True(IsStopping(s))
+	a.Nil(s.Err())
+
+	// It's a no-op to run new routines after stopping.
+	a.False(s.Go(func() error { return nil }))
+
+	// Stop the waiting goroutines.
+	close(waitFor)
+
+	// Once all workers have stopped, the context should cancel.
+	select {
+	case <-s.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for Context.Done()")
+	}
+	a.True(IsStopping(s))
+	a.NotNil(s.Err())
+	a.ErrorIs(context.Cause(s), ErrStopped)
+	a.Nil(s.Wait())
+}
+
+// Verify that a never-used Stopper behaves correctly.
+func TestUnused(t *testing.T) {
+	a := assert.New(t)
+
+	s := WithContext(context.Background())
+	s.Stop(0)
+	select {
+	case <-s.Done():
+	// OK
+	case <-time.After(time.Second):
+		a.Fail("timeout waiting for Context.Done()")
+	}
+	a.ErrorIs(context.Cause(s), ErrStopped)
+	a.Nil(s.Wait())
+}


### PR DESCRIPTION
This change adds a stopper utility package to assist with gracefully
transitioning a Dialect from backfill to transactional modes. The API is very
much like an errgroup, in that it starts some number of goroutines, however the
associated context is canceled after the Stop() method is called and the
goroutines have exited. The existing logical-loop code uses normal context
cancellation to signal a need to change modes, but this winds up being too
coarse-grained, we want the dialect's message producer to exit and for the
message consumer to drain the channel.

The logical.Event interface gains an explicit Flush() method to allow all
in-flight mutations passed to OnData() to be written to the backing store. This
further simplifies FK-preserving backfill mode, since we no longer attempt to
synthesize fake transaction boundary markers between FK levels. Instead, the
orderedEvents facade just calls Flush() between FK levels.

The logical.State interface switches to a channel-driven api when awaiting
changes to the consistent point. This allows callers to compose behavior with
select statements, instead of relying on various forms of context cancellation.
The graceful-stopping signal is also made available through the State
interface.

The private logical.Events.stop() method was renamed to drain() to avoid
confusion.

The various logical Dialects are updated to look for the stopping signal.  This
PR additionally includes the previously-reviewed, but unmerged, changes from PR #244 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/325)
<!-- Reviewable:end -->
