### PR TITLE
Replace use of sync.Cond with channel

### DIFF
--- a/internal/source/logical/factory.go
+++ b/internal/source/logical/factory.go
@@ -104,7 +104,7 @@ func (f *Factory) newLoop(ctx context.Context, config *BaseConfig, dialect Diale
 		running:    stopper.WithContext(ctx),
 		targetPool: f.pool,
 	}
-	loop.consistentPoint.Cond = sync.NewCond(&sync.Mutex{})
+	loop.consistentPoint.updated = make(chan struct{})
 	initialPoint, err := loop.loadConsistentPoint(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -13,7 +13,6 @@ package apply
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -39,11 +38,9 @@ func ProvideConfigs(
 		return nil, nil, errors.WithStack(err)
 	}
 
-	cfg := &Configs{
-		dataChanged: sync.NewCond(&sync.Mutex{}),
-		pool:        pool,
-	}
+	cfg := &Configs{pool: pool}
 	cfg.mu.data = make(map[ident.Table]*Config)
+	cfg.mu.updated = make(chan struct{})
 	cfg.sql.delete = fmt.Sprintf(deleteConfTemplate, target)
 	cfg.sql.loadAll = fmt.Sprintf(loadConfTemplate, target)
 	cfg.sql.upsert = fmt.Sprintf(upsertConfTemplate, target)

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -53,7 +53,7 @@ func TestWatch(t *testing.T) {
 	defer cancel()
 
 	select {
-	case <-time.After(2 * delay):
+	case <-ctx.Done():
 		a.FailNow("timed out waiting for channel data")
 	case data := <-ch:
 		if a.Len(data, 1) {
@@ -68,7 +68,7 @@ func TestWatch(t *testing.T) {
 	}
 
 	select {
-	case <-time.After(2 * delay):
+	case <-ctx.Done():
 		a.FailNow("timed out waiting for channel data")
 	case data := <-ch:
 		if a.Len(data, 2) {
@@ -82,7 +82,7 @@ func TestWatch(t *testing.T) {
 		return
 	}
 	select {
-	case <-time.After(2 * delay):
+	case <-ctx.Done():
 		a.FailNow("timed out waiting for channel close")
 	case _, open := <-ch:
 		a.False(open)


### PR DESCRIPTION
Condition variables are hard to use well in non-trivial locking and flow control. This change replaces the uses of sync.Cond with channels that are closed to indicate that some state has been invalidated and needs to be refreshed. This pattern plays nicely with RWMutex as long as the data and its associated channel are read from the locked data within the same critical region.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/329)
<!-- Reviewable:end -->
