### PR TITLE
workflows: Minor cleanups to push workflow

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -16,11 +16,7 @@ on:
       # Only upload on pull requests that modify this file, for testing.
       - '.github/workflows/binaries.yaml'
   workflow_dispatch:
-    inputs:
-      build_binaries:
-        description: 'Build distributable binaries'
-        type: boolean
-        required: false
+      # Make it easy to push other branches/tags.
 
 jobs:
   binaries:
@@ -47,21 +43,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - id: auth
+        name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.CDC_SINK_BINARIES_KEY }}
+
       # Pick up a symbolic name for the build (e.g. "v1.0.1") and a guaranteed SHA or tag value.
-      - name: Determine versions and names
+      - id: names
+        name: Determine versions and names
         run: |
-          BUILDNAME="cdc-sink-${{ matrix.os }}-${{ matrix.arch }}"
-          OUTPUT="$BUILDNAME${{ matrix.ext }}"
-          
-          # Tag name or SHA
-          VERSION=$(git describe --tags --always --dirty)
-          
-          # Print tag name, branch name, or just the SHA. 
-          SYMBOLIC_NAME=$(
+          BUILDNAME="cdc-sink-${{ matrix.os }}-${{ matrix.arch }}"   # cdc-sink-linux-amd64
+          OUTPUT="cdc-sink${{ matrix.ext }}"                         # cdc-sink(.exe)
+          VERSION=$(git describe --tags --always --dirty)            # Tag name or SHA 
+          SYMBOLIC_NAME=$(                                           # Tag, branch, or SHA.
             git describe --tags --exact-match HEAD 2> /dev/null ||
             git symbolic-ref -q --short HEAD ||
             echo "$VERSION")
           
+          # These are file globs to be included in the tarball.
           DISTRO_PATHS=$(cat << EOF
           $OUTPUT
           README.md
@@ -69,8 +69,10 @@ jobs:
           licenses/*.txt
           EOF)
           
+          # Write a build-marker file for convenience.
           echo "$VERSION" > VERSION.txt
-          
+
+          # Export values into next build steps.          
           echo "BUILDNAME=$BUILDNAME" >> $GITHUB_ENV
           echo "DISTRO_NAME=$BUILDNAME-$SYMBOLIC_NAME" >> $GITHUB_ENV          
           echo "OUTPUT=$OUTPUT" >> $GITHUB_ENV
@@ -84,17 +86,20 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       # Use separate build caches for each target platform.
-      - name: Write cache key
+      - id: cache_key
+        name: Write cache key
         run: echo '${{ github.job }} ${{ toJSON(matrix) }} ${{ hashFiles('go.sum') }}' > CACHE_KEY
 
-      - name: Set up Go
+      - id: setup_go
+        name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: CACHE_KEY
 
-      - name: Build
+      - id: build
+        name: Build
         run: >
           go
           build
@@ -110,30 +115,19 @@ jobs:
       - id: tarball
         name: Create distribution tarball
         run: |
+          # Expand globs with the find command. The output from find
+          # will have a ./ at the beginning.  We'll replace that when
+          # packing the archive with the distribution name.
           echo "${{ env.DISTRO_PATHS }}" |
-          tr '\n' '\0' |
-          xargs -0 -IQ find . -path ./Q | 
-          xargs tar zcvf ${{ env.DISTRO_NAME }}.tgz --transform 's|^|${{ env.DISTRO_NAME }}/|'
-
-      - id: local-upload
-        name: Upload zip contents
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.BUILDNAME }}
-          path: ${{ env.DISTRO_PATHS }}
-          if-no-files-found: error
-
-      - id: auth
-        name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.CDC_SINK_BINARIES_KEY }}
+          xargs -rIQ find . -path ./Q  -print0 |
+          xargs -r0 tar zcvf ${{ env.DISTRO_NAME }}.tgz --transform 's|^./|${{ env.DISTRO_NAME }}/|'
 
       - id: upload
         uses: google-github-actions/upload-cloud-storage@v1
         with:
           path: ${{ env.DISTRO_NAME }}.tgz
           destination: ${{ vars.CDC_SINK_BUCKET }}/
+          process_gcloudignore: false # Suppress warning about missing .gcloudignore file
 
       - id: link
         name: Summary link


### PR DESCRIPTION
Remove unnecessary now-unnecessary input from workflow_dispatch action.

Authenticate to GCP first, since this is likely the most fragile step.

Remove uploading artifacts to GitHub, since the summaries link directly to the
tarballs.

Use either "cdc-sink" or "cdc-sink.exe" as the executable name in the tarball.

Suppress warning about .gcloudignore file, since we're not globbing uploads.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/333)
<!-- Reviewable:end -->
