### PR TITLE
workflow: Use CockroachDB 23.1 public releases

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -24,13 +24,12 @@ services:
     image: cockroachdb/cockroach:latest-v22.1
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
-  # There is no latest-v22.2 tag available in the unstable repo.
   cockroachdb-v22.2:
     image: cockroachdb/cockroach:latest-v22.2
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
   cockroachdb-v23.1:
-    image: cockroachdb/cockroach-unstable:v23.1.0-beta.2
+    image: cockroachdb/cockroach:latest-v23.1
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
   firestore:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -63,7 +63,7 @@ jobs:
         # against. The matrix component names should use the target
         # names listed in the docker-compose.yml file in the parent
         # directory.
-        cockroachdb: [ v22.2 ]
+        cockroachdb: [ v23.1 ]
         integration:
           - "firestore"
           - "mysql-v8"
@@ -79,6 +79,10 @@ jobs:
         # CRDB. These tests are kept around to ensure that the target
         # package doesn't use any SQL that couldn't be run on older CRDB
         # versions.
+        #
+        # Refer to the CRDB support policy when determining how many
+        # older releases to support.
+        # https://www.cockroachlabs.com/docs/releases/release-support-policy.html
         include:
           - cockroachdb: v21.1
           - cockroachdb: v21.2


### PR DESCRIPTION
This change switches the 23.1 test image to the stable release tags in DockerHub. It also bumps the primary test version to 23.1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/334)
<!-- Reviewable:end -->
