### PR TITLE
Split types for staging and target db connections

### DIFF
--- a/internal/script/injector.go
+++ b/internal/script/injector.go
@@ -23,6 +23,6 @@ func newScriptFromFixture(*all.Fixture, *Config, TargetSchema) (*UserScript, err
 	panic(wire.Build(
 		Set,
 		wire.FieldsOf(new(*all.Fixture), "Fixture", "Configs", "Watchers"),
-		wire.FieldsOf(new(*base.Fixture), "Context", "Pool"),
+		wire.FieldsOf(new(*base.Fixture), "Context", "StagingPool"),
 	))
 }

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/google/uuid"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 )
 
@@ -111,7 +110,7 @@ func ProvideUserScript(
 	ctx context.Context,
 	applyConfigs *apply.Configs,
 	boot *Loader,
-	pool *pgxpool.Pool,
+	stagingPool types.StagingPool,
 	target TargetSchema,
 	watchers types.Watchers,
 ) (*UserScript, error) {
@@ -141,7 +140,7 @@ func ProvideUserScript(
 	}
 
 	err = retry.Retry(ctx, func(ctx context.Context) error {
-		tx, err := pool.Begin(ctx)
+		tx, err := stagingPool.Begin(ctx)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -52,17 +52,17 @@ func TestScript(t *testing.T) {
 	ctx := fixture.Context
 
 	// Create tables that will be referenced by the user-script.
-	_, err = fixture.Pool.Exec(ctx,
+	_, err = fixture.TargetPool.Exec(ctx,
 		fmt.Sprintf("CREATE TABLE %s.table1(msg TEXT PRIMARY KEY)", fixture.TestDB.Ident()))
 	r.NoError(err)
-	_, err = fixture.Pool.Exec(ctx,
+	_, err = fixture.TargetPool.Exec(ctx,
 		fmt.Sprintf("CREATE TABLE %s.table2(idx INT PRIMARY KEY)", fixture.TestDB.Ident()))
 	r.NoError(err)
-	_, err = fixture.Pool.Exec(ctx,
+	_, err = fixture.TargetPool.Exec(ctx,
 		fmt.Sprintf("CREATE TABLE %s.all_features(msg TEXT PRIMARY KEY)", fixture.TestDB.Ident()))
 	r.NoError(err)
 
-	r.NoError(fixture.Watcher.Refresh(ctx, fixture.Pool))
+	r.NoError(fixture.Watcher.Refresh(ctx, fixture.TargetPool))
 
 	var opts mapOptions
 

--- a/internal/script/wire_gen.go
+++ b/internal/script/wire_gen.go
@@ -24,9 +24,9 @@ func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema Tar
 	if err != nil {
 		return nil, err
 	}
-	pool := baseFixture.Pool
+	stagingPool := baseFixture.StagingPool
 	watchers := fixture.Watchers
-	userScript, err := ProvideUserScript(context, configs, loader, pool, targetSchema, watchers)
+	userScript, err := ProvideUserScript(context, configs, loader, stagingPool, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -39,7 +39,7 @@ type Fixture struct {
 func (f *Fixture) CreateTable(ctx context.Context, schemaSpec string) (base.TableInfo, error) {
 	ti, err := f.Fixture.CreateTable(ctx, schemaSpec)
 	if err == nil {
-		err = f.Watcher.Refresh(ctx, f.Pool)
+		err = f.Watcher.Refresh(ctx, f.TargetPool)
 	}
 	return ti, err
 }

--- a/internal/sinktest/base/wire_gen.go
+++ b/internal/sinktest/base/wire_gen.go
@@ -19,24 +19,26 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	pool := ProvidePool(dbInfo)
-	stagingDB, cleanup2, err := ProvideStagingDB(context, pool)
+	stagingPool := ProvideStagingPool(dbInfo)
+	targetPool := ProvideTargetPool(dbInfo)
+	stagingDB, cleanup2, err := ProvideStagingDB(context, stagingPool)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	testDB, cleanup3, err := ProvideTestDB(context, pool)
+	testDB, cleanup3, err := ProvideTestDB(context, targetPool)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
 	fixture := &Fixture{
-		Context:   context,
-		DBInfo:    dbInfo,
-		Pool:      pool,
-		StagingDB: stagingDB,
-		TestDB:    testDB,
+		Context:     context,
+		DBInfo:      dbInfo,
+		StagingPool: stagingPool,
+		TargetPool:  targetPool,
+		StagingDB:   stagingDB,
+		TestDB:      testDB,
 	}
 	return fixture, func() {
 		cleanup3()

--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -34,9 +33,10 @@ type Handler struct {
 	Appliers      types.Appliers      // Update tables within TargetDb.
 	Authenticator types.Authenticator // Access checks.
 	Config        *Config             // Runtime options.
-	Pool          *pgxpool.Pool       // Access to the target cluster.
 	Resolvers     *Resolvers          // Process resolved timestamps.
+	StagingPool   types.StagingPool   // Access to the staging cluster.
 	Stores        types.Stagers       // Record incoming json blobs.
+	TargetPool    types.TargetPool    // Access to the target cluster.
 }
 
 // A request is configured by the various parseURL methods in Handler.

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -51,7 +51,7 @@ func testHandler(t *testing.T, immediate bool) {
 			Immediate:  immediate,
 			LoopName:   "changefeed",
 			StagingDB:  baseFixture.StagingDB.Ident(),
-			TargetConn: baseFixture.Pool.Config().ConnString(),
+			TargetConn: baseFixture.TargetPool.Config().ConnString(),
 			TargetDB:   baseFixture.TestDB.Ident(),
 		},
 	})
@@ -287,7 +287,7 @@ func testMassBackfillWithForeignKeys(
 				LoopName:           "changefeed",
 				StagingDB:          baseFixture.StagingDB.Ident(),
 				RetryDelay:         time.Nanosecond,
-				TargetConn:         baseFixture.Pool.Config().ConnString(),
+				TargetConn:         baseFixture.TargetPool.Config().ConnString(),
 				TargetDB:           baseFixture.TestDB.Ident(),
 			},
 		})
@@ -358,7 +358,7 @@ func testMassBackfillWithForeignKeys(
 	// Wait for rows to appear.
 	for _, tbl := range []ident.Table{parent.Name(), child.Name(), grand.Name()} {
 		for {
-			count, err := base.GetRowCount(ctx, baseFixture.Pool, tbl)
+			count, err := base.GetRowCount(ctx, baseFixture.TargetPool, tbl)
 			r.NoError(err)
 			log.Infof("saw %d of %d rows in %s", count, rowCount, tbl)
 			if count == rowCount {

--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -115,7 +115,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request) error {
 			return err
 		}
 		flush = func(muts []types.Mutation) {
-			eg.Go(func() error { return applier.Apply(egCtx, h.Pool, muts) })
+			eg.Go(func() error { return applier.Apply(egCtx, h.TargetPool, muts) })
 		}
 	} else {
 		store, err := h.Stores.Get(ctx, target)
@@ -123,7 +123,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request) error {
 			return err
 		}
 		flush = func(muts []types.Mutation) {
-			eg.Go(func() error { return store.Store(ctx, h.Pool, muts) })
+			eg.Go(func() error { return store.Store(ctx, h.StagingPool, muts) })
 		}
 	}
 

--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 )
 
@@ -46,7 +45,7 @@ func ProvideResolvers(
 	cfg *Config,
 	leases types.Leases,
 	metaTable MetaTable,
-	pool *pgxpool.Pool,
+	pool types.StagingPool,
 	stagers types.Stagers,
 	watchers types.Watchers,
 ) (*Resolvers, func(), error) {

--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -54,7 +53,7 @@ type resolver struct {
 	fastWakeup  chan struct{}
 	leases      types.Leases
 	loop        *logical.Loop // Reference to driving loop, for testing.
-	pool        *pgxpool.Pool
+	pool        types.StagingPool
 	retirements chan hlc.Time // Drives a goroutine to remove applied mutations.
 	stagers     types.Stagers
 	target      ident.Schema
@@ -78,7 +77,7 @@ func newResolver(
 	ctx context.Context,
 	cfg *Config,
 	leases types.Leases,
-	pool *pgxpool.Pool,
+	pool types.StagingPool,
 	metaTable ident.Table,
 	stagers types.Stagers,
 	target ident.Schema,
@@ -570,7 +569,7 @@ type Resolvers struct {
 	leases    types.Leases
 	noStart   bool // Set by test code to disable call to loop.Start()
 	metaTable ident.Table
-	pool      *pgxpool.Pool
+	pool      types.StagingPool
 	stagers   types.Stagers
 	watchers  types.Watchers
 

--- a/internal/source/cdc/resolver_test.go
+++ b/internal/source/cdc/resolver_test.go
@@ -35,7 +35,7 @@ func TestResolverDeQueue(t *testing.T) {
 		MetaTableName: ident.New("resolved_timestamps"),
 		BaseConfig: logical.BaseConfig{
 			StagingDB:  baseFixture.StagingDB.Ident(),
-			TargetConn: baseFixture.Pool.Config().ConnString(),
+			TargetConn: baseFixture.TargetPool.Config().ConnString(),
 			TargetDB:   baseFixture.TestDB.Ident(),
 		},
 	})

--- a/internal/source/fslogical/fslogical.go
+++ b/internal/source/fslogical/fslogical.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
@@ -40,7 +39,7 @@ type Dialect struct {
 	idempotent        bool                     // Detect reprocessing the same document.
 	loops             *logical.Factory         // Support dynamic nested collections.
 	memo              types.Memo               // Durable logging of processed doc ids.
-	pool              *pgxpool.Pool            // Database access.
+	pool              types.StagingPool        // Database access.
 	query             firestore.Query          // The base query build from.
 	recurse           bool                     // Scan for dynamic, nested collections.
 	recurseFilter     map[ident.Ident]struct{} // Ignore nested collections with these names.

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -131,7 +131,7 @@ func testSmoke(t *testing.T, chaosProb float32) {
 			RetryDelay:         time.Nanosecond,
 			StandbyTimeout:     10 * time.Millisecond,
 			StagingDB:          fixture.StagingDB.Ident(),
-			TargetConn:         fixture.Pool.Config().ConnString(),
+			TargetConn:         fixture.TargetPool.Config().ConnString(),
 			TargetDB:           fixture.TestDB.Ident(),
 
 			ScriptConfig: script.Config{
@@ -235,7 +235,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 	// Wait for updated values.
 	for {
 		var ct int
-		r.NoError(fixture.Pool.QueryRow(ctx,
+		r.NoError(fixture.TargetPool.QueryRow(ctx,
 			fmt.Sprintf("SELECT count(*) FROM %s WHERE v LIKE 'updated%%'",
 				destTable.Name())).Scan(&ct))
 		if ct == docCount {
@@ -281,7 +281,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 	// Wait for documents to be deleted.
 	for {
 		var ct int
-		r.NoError(fixture.Pool.QueryRow(ctx,
+		r.NoError(fixture.TargetPool.QueryRow(ctx,
 			fmt.Sprintf("SELECT count(*) FROM %s WHERE v LIKE 'updated%%'",
 				destTable.Name())).Scan(&ct))
 		if ct == 0 {

--- a/internal/source/fslogical/provider.go
+++ b/internal/source/fslogical/provider.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/golang/groupcache/lru"
-	"github.com/jackc/pgx/v5/pgxpool"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 )
@@ -51,7 +50,7 @@ func ProvideLoops(
 	fs *firestore.Client,
 	loops *logical.Factory,
 	memo types.Memo,
-	pool *pgxpool.Pool,
+	pool types.StagingPool,
 	st *Tombstones,
 	userscript *script.UserScript,
 ) ([]*logical.Loop, func(), error) {

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -49,7 +49,7 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 
 	ctx := fixture.Context
 	dbName := fixture.TestDB.Ident()
-	pool := fixture.Pool
+	pool := fixture.TargetPool
 
 	// Create some tables.
 	tgts := []ident.Table{
@@ -172,7 +172,7 @@ func TestUserScript(t *testing.T) {
 
 	ctx := fixture.Context
 	dbName := fixture.TestDB.Ident()
-	pool := fixture.Pool
+	pool := fixture.TargetPool
 
 	// Create some tables.
 	tgts := []ident.Table{
@@ -258,7 +258,7 @@ api.configureTable("t_2", {
 	r.NoError(err)
 
 	for {
-		count, err := base.GetRowCount(ctx, fixture.Pool, tgts[0])
+		count, err := base.GetRowCount(ctx, fixture.TargetPool, tgts[0])
 		r.NoError(err)
 		if count == 0 {
 			break
@@ -267,7 +267,7 @@ api.configureTable("t_2", {
 	}
 
 	// Verify that t_2 was unchanged.
-	count, err := base.GetRowCount(ctx, fixture.Pool, tgts[1])
+	count, err := base.GetRowCount(ctx, fixture.TargetPool, tgts[1])
 	r.NoError(err)
 	a.Equal(100, count)
 

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -63,7 +63,7 @@ func testMYLogical(t *testing.T, backfill, immediate bool) {
 
 	ctx := fixture.Context
 	dbName := fixture.TestDB.Ident()
-	crdbPool := fixture.Pool
+	crdbPool := fixture.TargetPool
 
 	config := &Config{
 		BaseConfig: logical.BaseConfig{
@@ -329,7 +329,7 @@ func TestDataTypes(t *testing.T) {
 
 	ctx := fixture.Context
 	dbName := fixture.TestDB.Ident()
-	crdbPool := fixture.Pool
+	crdbPool := fixture.TargetPool
 
 	config := &Config{
 		BaseConfig: logical.BaseConfig{

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -68,7 +68,7 @@ func testPGLogical(t *testing.T, enableBackfill, immediate bool, withChaosProb f
 
 	ctx := fixture.Context
 	dbName := fixture.TestDB.Ident()
-	crdbPool := fixture.Pool
+	crdbPool := fixture.TargetPool
 
 	pgPool, cancel, err := setupPGPool(dbName)
 	if !a.NoError(err) {
@@ -283,7 +283,7 @@ func TestDataTypes(t *testing.T) {
 
 	ctx := fixture.Context
 	dbName := fixture.TestDB.Ident()
-	crdbPool := fixture.Pool
+	crdbPool := fixture.TargetPool
 
 	pgPool, cancel, err := setupPGPool(dbName)
 	if !a.NoError(err) {

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -32,7 +32,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	pool, cleanup, err := logical.ProvidePool(ctx, baseConfig)
+	targetPool, cleanup, err := logical.ProvideTargetPool(ctx, baseConfig)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -41,14 +41,15 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := apply.ProvideConfigs(ctx, pool, stagingDB)
+	configs, cleanup2, err := apply.ProvideConfigs(ctx, targetPool, stagingDB)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	watchers, cleanup3 := schemawatch.ProvideFactory(pool)
+	watchers, cleanup3 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup4 := apply.ProvideFactory(configs, watchers)
-	memoMemo, err := memo.ProvideMemo(ctx, pool, stagingDB)
+	stagingPool := logical.ProvideStagingPool(targetPool)
+	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingDB)
 	if err != nil {
 		cleanup4()
 		cleanup3()
@@ -57,7 +58,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		return nil, nil, err
 	}
 	targetSchema := logical.ProvideUserScriptTarget(baseConfig)
-	userScript, err := script.ProvideUserScript(ctx, configs, loader, pool, targetSchema, watchers)
+	userScript, err := script.ProvideUserScript(ctx, configs, loader, stagingPool, targetSchema, watchers)
 	if err != nil {
 		cleanup4()
 		cleanup3()
@@ -65,7 +66,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	factory, cleanup5 := logical.ProvideFactory(appliers, config, memoMemo, pool, watchers, userScript)
+	factory, cleanup5 := logical.ProvideFactory(appliers, config, memoMemo, stagingPool, targetPool, watchers, userScript)
 	dialect, err := ProvideDialect(ctx, config)
 	if err != nil {
 		cleanup5()

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -77,7 +77,7 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 	defer cancel()
 
 	targetDB := destFixture.TestDB.Ident()
-	targetPool := destFixture.Pool
+	targetPool := destFixture.TargetPool
 
 	// The target fixture contains the cdc-sink server.
 	targetFixture, cancel, err := newTestFixture(ctx, &Config{
@@ -87,7 +87,7 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 				LoopName:   "changefeed",
 				StagingDB:  destFixture.StagingDB.Ident(),
 				TargetDB:   destFixture.TestDB.Ident(),
-				TargetConn: destFixture.Pool.Config().ConnString(),
+				TargetConn: destFixture.TargetPool.Config().ConnString(),
 			},
 			MetaTableName: ident.New("resolved_timestamps"),
 		},

--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -25,14 +25,13 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type testFixture struct {
 	Authenticator types.Authenticator
 	Config        *Config
 	Listener      net.Listener
-	Pool          *pgxpool.Pool
+	StagingPool   types.StagingPool
 	Server        *Server
 	StagingDB     ident.StagingDB
 	Watcher       types.Watchers

--- a/internal/staging/auth/jwt/jwt_test.go
+++ b/internal/staging/auth/jwt/jwt_test.go
@@ -30,7 +30,7 @@ func TestJWT(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	pool := fixture.Pool
+	pool := fixture.StagingPool
 	stagingDB := fixture.StagingDB
 
 	auth, cancel, err := ProvideAuth(ctx, pool, stagingDB)

--- a/internal/staging/leases/leases_test.go
+++ b/internal/staging/leases/leases_test.go
@@ -42,7 +42,7 @@ func TestLeases(t *testing.T) {
 	}
 
 	intf, err := New(ctx, Config{
-		Pool:   fixture.Pool,
+		Pool:   fixture.StagingPool,
 		Target: tbl.Name(),
 	})
 	l := intf.(*leases)

--- a/internal/staging/leases/provider.go
+++ b/internal/staging/leases/provider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Set is used by Wire.
@@ -32,7 +31,7 @@ var Set = wire.NewSet(
 //
 // https://github.com/cockroachdb/cockroach/issues/100194
 func ProvideLeases(
-	ctx context.Context, pool *pgxpool.Pool, stagingDB ident.StagingDB,
+	ctx context.Context, pool types.StagingPool, stagingDB ident.StagingDB,
 ) (types.Leases, error) {
 	return New(ctx, Config{
 		Guard:      time.Second,

--- a/internal/staging/memo/memo_test.go
+++ b/internal/staging/memo/memo_test.go
@@ -26,7 +26,7 @@ func TestRoundtrip(t *testing.T) {
 
 	ctx := fixture.Context
 	memo := fixture.Memo
-	pool := fixture.Pool
+	pool := fixture.StagingPool
 
 	tests := []struct {
 		name     string

--- a/internal/staging/memo/provider.go
+++ b/internal/staging/memo/provider.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Set is used by Wire.
@@ -28,7 +27,9 @@ var Set = wire.NewSet(
 )
 
 // ProvideMemo is called by Wire to construct the KV wrapper.
-func ProvideMemo(ctx context.Context, db *pgxpool.Pool, staging ident.StagingDB) (*Memo, error) {
+func ProvideMemo(
+	ctx context.Context, db types.StagingPool, staging ident.StagingDB,
+) (*Memo, error) {
 	target := ident.NewTable(staging.Ident(), ident.Public, ident.New("memo"))
 	if err := retry.Execute(ctx, db, fmt.Sprintf(schema, target)); err != nil {
 		return nil, err

--- a/internal/staging/stage/factory.go
+++ b/internal/staging/stage/factory.go
@@ -24,13 +24,12 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 type factory struct {
-	db        *pgxpool.Pool
+	db        types.StagingPool
 	stagingDB ident.Ident
 
 	mu struct {

--- a/internal/staging/stage/provider.go
+++ b/internal/staging/stage/provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Set is used by Wire.
@@ -23,7 +22,7 @@ var Set = wire.NewSet(
 )
 
 // ProvideFactory is called by Wire to construct the Stagers factory.
-func ProvideFactory(db *pgxpool.Pool, stagingDB ident.StagingDB) types.Stagers {
+func ProvideFactory(db types.StagingPool, stagingDB ident.StagingDB) types.Stagers {
 	f := &factory{
 		db:        db,
 		stagingDB: stagingDB.Ident(),

--- a/internal/staging/stage/stage.go
+++ b/internal/staging/stage/stage.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -294,7 +293,7 @@ func (s *stage) Store(ctx context.Context, db types.Querier, mutations []types.M
 	// If we're working with a pool, and not a transaction, we'll stage
 	// the data in a concurrent manner.
 	var err error
-	if _, isPool := db.(*pgxpool.Pool); isPool {
+	if _, isPool := db.(types.StagingPool); isPool {
 		eg, errCtx := errgroup.WithContext(ctx)
 		err = batches.Batch(len(mutations), func(begin, end int) error {
 			eg.Go(func() error {

--- a/internal/target/apply/conf_test.go
+++ b/internal/target/apply/conf_test.go
@@ -82,7 +82,7 @@ func TestPersistenceRoundTrip(t *testing.T) {
 	a.True(cfgs.Get(tbl).IsZero())
 
 	// Verify that we can store the data.
-	tx, err := fixture.Pool.Begin(ctx)
+	tx, err := fixture.StagingPool.Begin(ctx)
 	a.NoError(err)
 	a.NoError(cfgs.Store(ctx, tx, tbl, cfg))
 	a.NoError(tx.Commit(ctx))
@@ -111,7 +111,7 @@ func TestPersistenceRoundTrip(t *testing.T) {
 
 	// Replace the data with an empty configuration, this will wind
 	// up deleting the config rows.
-	a.NoError(cfgs.Store(ctx, fixture.Pool, tbl, &apply.Config{}))
+	a.NoError(cfgs.Store(ctx, fixture.StagingPool, tbl, &apply.Config{}))
 	changed, err = fixture.Configs.Refresh(ctx)
 	a.True(changed)
 	a.NoError(err)

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 )
 
@@ -30,7 +29,7 @@ var Set = wire.NewSet(
 // ProvideConfigs constructs a Configs instance, starting a new
 // background goroutine to keep it refreshed.
 func ProvideConfigs(
-	ctx context.Context, pool *pgxpool.Pool, targetDB ident.StagingDB,
+	ctx context.Context, pool types.TargetPool, targetDB ident.StagingDB,
 ) (*Configs, func(), error) {
 	target := ident.NewTable(targetDB.Ident(), ident.Public, ident.New("apply_config"))
 

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -180,7 +180,7 @@ func TestGetColumns(t *testing.T) {
 	}
 
 	// Verify user-defined types with mixed-case name.
-	if _, err := fixture.Pool.Exec(ctx, fmt.Sprintf(
+	if _, err := fixture.TargetPool.Exec(ctx, fmt.Sprintf(
 		`CREATE TYPE %s."MyEnum" AS ENUM ('foo', 'bar')`,
 		fixture.TestDB.Ident()),
 	); !a.NoError(err) {

--- a/internal/target/schemawatch/dependencies_test.go
+++ b/internal/target/schemawatch/dependencies_test.go
@@ -112,7 +112,7 @@ func TestGetDependencyOrder(t *testing.T) {
 	}
 
 	ctx := fixture.Context
-	pool := fixture.Pool
+	pool := fixture.TargetPool
 
 	for idx, tc := range tcs {
 		sql := fmt.Sprintf(tc.schema, fixture.TestDB.Ident())
@@ -161,7 +161,7 @@ func TestNoDeferrableConstraints(t *testing.T) {
 
 	ctx := fixture.Context
 
-	_, err = fixture.Pool.Exec(ctx,
+	_, err = fixture.TargetPool.Exec(ctx,
 		"create table x (pk uuid primary key, ref uuid references x deferrable initially deferred)")
 	a.ErrorContains(err, "deferrable")
 	a.ErrorContains(err, "42601")

--- a/internal/target/schemawatch/factory.go
+++ b/internal/target/schemawatch/factory.go
@@ -16,12 +16,11 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // factory is a memoizing factory for watcher instances.
 type factory struct {
-	pool *pgxpool.Pool
+	pool types.TargetPool
 	mu   struct {
 		sync.RWMutex
 		cancels []func()

--- a/internal/target/schemawatch/provider.go
+++ b/internal/target/schemawatch/provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Set is used by Wire.
@@ -23,7 +22,7 @@ var Set = wire.NewSet(
 )
 
 // ProvideFactory is called by Wire to construct the Watchers factory.
-func ProvideFactory(pool *pgxpool.Pool) (types.Watchers, func()) {
+func ProvideFactory(pool types.TargetPool) (types.Watchers, func()) {
 	w := &factory{pool: pool}
 	w.mu.data = make(map[ident.Ident]*watcher)
 	return w, w.close

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -62,7 +62,7 @@ func TestWatch(t *testing.T) {
 	}
 
 	// Add a column and expect to see it.
-	if !a.NoError(retry.Execute(ctx, fixture.Pool,
+	if !a.NoError(retry.Execute(ctx, fixture.TargetPool,
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN v STRING", tblInfo.Name()))) {
 		return
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 )
 
@@ -218,6 +219,16 @@ type SchemaData struct {
 	// for deferrable foreign-key constraints:
 	// https://github.com/cockroachdb/cockroach/issues/31632
 	Order [][]ident.Table
+}
+
+// StagingPool is an injection point for a connection to the staging database.
+type StagingPool struct {
+	*pgxpool.Pool
+}
+
+// TargetPool is an injection point for a connection to the target database.
+type TargetPool struct {
+	*pgxpool.Pool
 }
 
 // Watcher allows table metadata to be observed.

--- a/internal/util/serial/serial_test.go
+++ b/internal/util/serial/serial_test.go
@@ -72,7 +72,7 @@ func TestPool(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	p := &Pool{Pool: fixture.Pool}
+	p := &Pool{Pool: fixture.TargetPool.Pool}
 
 	t.Run("begin commit rollback", func(t *testing.T) {
 		a := assert.New(t)

--- a/internal/util/stdpool/metrics_test.go
+++ b/internal/util/stdpool/metrics_test.go
@@ -27,9 +27,9 @@ func TestConcurrentRegistration(t *testing.T) {
 	r.NoError(err)
 	defer cancel()
 
-	c1 := stdpool.PublishMetrics(fixture.Pool)
+	c1 := stdpool.PublishMetrics(fixture.TargetPool.Pool)
 	defer c1()
 
-	c2 := stdpool.PublishMetrics(fixture.Pool)
+	c2 := stdpool.PublishMetrics(fixture.TargetPool.Pool)
 	defer c2()
 }

--- a/internal/util/txguard/guard_test.go
+++ b/internal/util/txguard/guard_test.go
@@ -30,7 +30,7 @@ func TestGuard(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	db := fixture.Pool
+	db := fixture.TargetPool
 
 	const testPeriod = 10 * time.Millisecond
 


### PR DESCRIPTION
This change replaces the use of the pgxpool.Pool type with either of types.StagingPool or types.TargetPool. This is a follow-on to PR #336 which separates the staging-specific and target-specific packages.

At the moment, the staging and target pools are the same. Support for actually operating in a split mode will be added in a follow-on PR.