### PR TITLE
workflow: Changes for merge queue

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -3,6 +3,7 @@ name: Binaries
 permissions:
   contents: read
 on:
+  merge_group: # Build, but don't push
   push:
     branches: [ master ]
     tags: [ 'v*.*.*' ]
@@ -11,12 +12,8 @@ on:
       - 'go.sum'
       - '**/*.go'
       - '.github/workflows/binaries.yaml'
-  pull_request:
-    paths:
-      # Only upload on pull requests that modify this file, for testing.
-      - '.github/workflows/binaries.yaml'
-  workflow_dispatch:
-      # Make it easy to push other branches/tags.
+  pull_request: # Build, but don't push
+  workflow_dispatch:  # Make it easy to push other branches/tags.
 
 jobs:
   binaries:
@@ -124,6 +121,7 @@ jobs:
 
       - id: upload
         uses: google-github-actions/upload-cloud-storage@v1
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           path: ${{ env.DISTRO_NAME }}.tgz
           destination: ${{ vars.CDC_SINK_BUCKET }}/
@@ -131,4 +129,5 @@ jobs:
 
       - id: link
         name: Summary link
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         run: echo "[${{ env.BUILDNAME }}](https://storage.googleapis.com/${{ vars.CDC_SINK_BUCKET }}/${{ env.DISTRO_NAME }}.tgz)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -3,6 +3,7 @@ permissions:
   contents: read
   packages: read
 on:
+  merge_group: # Enable merge queue
   push:
     branches: [ master ]
     tags: [ 'v*.*.*' ]


### PR DESCRIPTION
This change triggers the golang and binary workflows for merge queue actions. The binary-build workflow is tweaked to only copy files out to the storage bucket for push or manual-run events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/356)
<!-- Reviewable:end -->
