### PR TITLE
workflow: Cancel outdated workflow runs

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -2,6 +2,9 @@
 name: Binaries
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   merge_group: # Build, but don't push
   push:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,9 @@
 name: Docker
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -2,6 +2,9 @@ name: Golang
 permissions:
   contents: read
   packages: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   merge_group: # Enable merge queue
   push:


### PR DESCRIPTION
If a branch is pushed several times in quick succession, this change will ensure that outdated workflow runs are canceled immediately.

https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/359)
<!-- Reviewable:end -->
