### PR TITLE
workflow: Enable final auto-merge behavior for gomod

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -25,8 +25,8 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+      - name: Enable auto-merge for Golang Dependabot PRs
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'gomod' }} # See ../dependabot.yaml
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
This change makes the last step in the auto-Dependabot workflow functional for Golang dependencies.  I verified the `gh` step with a previous PR to ensure that the dependencies changes will flow through.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/364)
<!-- Reviewable:end -->
