### PR TITLE
apply: Extract config persistence code

### DIFF
--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
@@ -114,7 +114,7 @@ func ProvideLoader(cfg *Config) (*Loader, error) {
 // target database.
 func ProvideUserScript(
 	ctx context.Context,
-	applyConfigs *apply.Configs,
+	applyConfigs *applycfg.Configs,
 	boot *Loader,
 	stagingPool types.StagingPool,
 	target TargetSchema,

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/dop251/goja"
@@ -73,7 +73,7 @@ type Source struct {
 // A Target holds user-provided configuration options
 // for a target table.
 type Target struct {
-	apply.Config
+	applycfg.Config
 	// A user-provided function to modify or filter mutations bound for
 	// the target table.
 	Map Map
@@ -135,7 +135,7 @@ func (s *UserScript) bind(loader *Loader) error {
 		if err != nil {
 			return errors.Wrapf(err, "configureTable(%q)", tableName)
 		}
-		tgt := &Target{Config: *apply.NewConfig()}
+		tgt := &Target{Config: *applycfg.NewConfig()}
 		s.Targets[table] = tgt
 
 		for _, cas := range bag.CASColumns {

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/stretchr/testify/assert"
@@ -126,24 +126,24 @@ func TestScript(t *testing.T) {
 
 	tbl := ident.NewTable(fixture.TestDB.Ident(), ident.Public, ident.New("all_features"))
 	if cfg := s.Targets[tbl]; a.NotNil(cfg) {
-		expectedApply := apply.Config{
+		expectedApply := applycfg.Config{
 			CASColumns: []ident.Ident{ident.New("cas0"), ident.New("cas1")},
-			Deadlines: map[apply.TargetColumn]time.Duration{
+			Deadlines: map[applycfg.TargetColumn]time.Duration{
 				ident.New("dl0"): time.Hour,
 				ident.New("dl1"): time.Minute,
 			},
-			Exprs: map[apply.TargetColumn]string{
+			Exprs: map[applycfg.TargetColumn]string{
 				ident.New("expr0"): "fnv32($0::BYTES)",
 				ident.New("expr1"): "Hello Library!",
 			},
 			Extras: ident.New("overflow_column"),
-			Ignore: map[apply.TargetColumn]bool{
+			Ignore: map[applycfg.TargetColumn]bool{
 				ident.New("ign0"): true,
 				ident.New("ign1"): true,
 				// The false value is dropped.
 			},
 			// SourceName not used; that can be handled by the function.
-			SourceNames: map[apply.TargetColumn]apply.SourceColumn{},
+			SourceNames: map[applycfg.TargetColumn]applycfg.SourceColumn{},
 		}
 		a.Equal(expectedApply, cfg.Config)
 

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 )
 
@@ -31,7 +31,7 @@ type Fixture struct {
 	*base.Fixture
 
 	Appliers types.Appliers
-	Configs  *apply.Configs
+	Configs  *applycfg.Configs
 	Memo     types.Memo
 	Stagers  types.Stagers
 	Watchers types.Watchers

--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -8,6 +8,7 @@ package all
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
 	"github.com/cockroachdb/cdc-sink/internal/staging/stage"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
@@ -49,7 +50,7 @@ func NewFixture() (*Fixture, func(), error) {
 		StagingDB:   stagingDB,
 		TestDB:      testDB,
 	}
-	configs, cleanup4, err := apply.ProvideConfigs(context, targetPool, stagingDB)
+	configs, cleanup4, err := applycfg.ProvideConfigs(context, stagingPool, stagingDB)
 	if err != nil {
 		cleanup3()
 		cleanup2()

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
@@ -36,19 +37,19 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	stagingPool := logical.ProvideStagingPool(targetPool)
 	stagingDB, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := apply.ProvideConfigs(ctx, targetPool, stagingDB)
+	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingDB)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
 	watchers, cleanup3 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup4 := apply.ProvideFactory(configs, watchers)
-	stagingPool := logical.ProvideStagingPool(targetPool)
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingDB)
 	if err != nil {
 		cleanup4()

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
@@ -36,19 +37,19 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	stagingPool := logical.ProvideStagingPool(targetPool)
 	stagingDB, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := apply.ProvideConfigs(ctx, targetPool, stagingDB)
+	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingDB)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
 	watchers, cleanup3 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup4 := apply.ProvideFactory(configs, watchers)
-	stagingPool := logical.ProvideStagingPool(targetPool)
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingDB)
 	if err != nil {
 		cleanup4()

--- a/internal/source/server/provider.go
+++ b/internal/source/server/provider.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/jwt"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
@@ -82,7 +83,7 @@ func ProvideListener(config *Config) (net.Listener, func(), error) {
 // routes requests.
 func ProvideMux(
 	handler *cdc.Handler,
-	applyConf *apply.Configs,
+	applyConf *applycfg.Configs,
 	stagingPool types.StagingPool,
 	targetPool types.TargetPool,
 ) *http.ServeMux {

--- a/internal/staging/applycfg/conf.go
+++ b/internal/staging/applycfg/conf.go
@@ -1,0 +1,89 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package applycfg
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// SubstitutionToken contains the string that we'll use to substitute in
+// the actual parameter index into the generated SQL.
+const SubstitutionToken = "$0"
+
+// Type aliases to improve readability.
+type (
+	// SourceColumn is the name of a column found in incoming data.
+	SourceColumn = ident.Ident
+	// TargetColumn is the name of a column found in the target database.
+	TargetColumn = ident.Ident
+)
+
+// A Config contains per-target-table configuration.
+type Config struct {
+	CASColumns  []TargetColumn                 // The columns for compare-and-set operations.
+	Deadlines   map[TargetColumn]time.Duration // Deadline-based operation.
+	Exprs       map[TargetColumn]string        // Synthetic or replacement SQL expressions.
+	Extras      TargetColumn                   // JSONB column to store unmapped values in.
+	Ignore      map[TargetColumn]bool          // Source column names to ignore.
+	SourceNames map[TargetColumn]SourceColumn  // Look for alternate name in the incoming data.
+}
+
+// NewConfig constructs a Config with all map fields populated.
+func NewConfig() *Config {
+	return &Config{
+		Deadlines:   make(types.Deadlines),
+		Exprs:       make(map[TargetColumn]string),
+		Ignore:      make(map[TargetColumn]bool),
+		SourceNames: make(map[TargetColumn]SourceColumn),
+	}
+}
+
+// Copy returns a copy of the Config.
+func (t *Config) Copy() *Config {
+	ret := NewConfig()
+
+	ret.CASColumns = append(ret.CASColumns, t.CASColumns...)
+	for k, v := range t.Deadlines {
+		ret.Deadlines[k] = v
+	}
+	for k, v := range t.Exprs {
+		ret.Exprs[k] = v
+	}
+	ret.Extras = t.Extras
+	for k, v := range t.Ignore {
+		ret.Ignore[k] = v
+	}
+	for k, v := range t.SourceNames {
+		ret.SourceNames[k] = v
+	}
+
+	return ret
+}
+
+// IsZero returns true if the Config represents the absence of a
+// configuration.
+func (t *Config) IsZero() bool {
+	return len(t.CASColumns) == 0 &&
+		len(t.Deadlines) == 0 &&
+		len(t.Exprs) == 0 &&
+		t.Extras.IsEmpty() &&
+		len(t.Ignore) == 0 &&
+		len(t.SourceNames) == 0
+}

--- a/internal/staging/applycfg/conf_test.go
+++ b/internal/staging/applycfg/conf_test.go
@@ -14,23 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package staging contains all services which interact with the staging
-// database.
-package staging
+package applycfg_test
 
 import (
+	"testing"
+
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
-	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
-	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
-	"github.com/cockroachdb/cdc-sink/internal/staging/stage"
-	"github.com/google/wire"
+	"github.com/stretchr/testify/assert"
 )
 
-// Set is used by Wire and contains providers for all target
-// sub-packages.
-var Set = wire.NewSet(
-	applycfg.Set,
-	leases.Set,
-	memo.Set,
-	stage.Set,
-)
+func TestZero(t *testing.T) {
+	a := assert.New(t)
+
+	a.True(applycfg.NewConfig().IsZero())
+}

--- a/internal/staging/applycfg/configs.go
+++ b/internal/staging/applycfg/configs.go
@@ -14,7 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+// Package applycfg contains code for persisting applier configurations.
+// This is separate from apply since we use the staging database as the
+// storage location.
+package applycfg
 
 import (
 	"context"
@@ -31,78 +34,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// substitutionToken contains the string that we'll use to substitute in
-// the actual parameter index into the generated SQL.
-const substitutionToken = "$0"
-
-// Type aliases to improve readability.
-type (
-	// SourceColumn is the name of a column found in incoming data.
-	SourceColumn = ident.Ident
-	// TargetColumn is the name of a column found in the target database.
-	TargetColumn = ident.Ident
-)
-
-// A Config contains per-target-table configuration.
-type Config struct {
-	CASColumns  []TargetColumn                 // The columns for compare-and-set operations.
-	Deadlines   map[TargetColumn]time.Duration // Deadline-based operation.
-	Exprs       map[TargetColumn]string        // Synthetic or replacement SQL expressions.
-	Extras      TargetColumn                   // JSONB column to store unmapped values in.
-	Ignore      map[TargetColumn]bool          // Source column names to ignore.
-	SourceNames map[TargetColumn]SourceColumn  // Look for alternate name in the incoming data.
-}
-
 // configZero is a sentinel value for "no configuration".
 var configZero = NewConfig()
-
-// NewConfig constructs a Config with all map fields populated.
-func NewConfig() *Config {
-	return &Config{
-		Deadlines:   make(types.Deadlines),
-		Exprs:       make(map[TargetColumn]string),
-		Ignore:      make(map[TargetColumn]bool),
-		SourceNames: make(map[TargetColumn]SourceColumn),
-	}
-}
-
-// Copy returns a copy of the Config.
-func (t *Config) Copy() *Config {
-	ret := NewConfig()
-
-	ret.CASColumns = append(ret.CASColumns, t.CASColumns...)
-	for k, v := range t.Deadlines {
-		ret.Deadlines[k] = v
-	}
-	for k, v := range t.Exprs {
-		ret.Exprs[k] = v
-	}
-	ret.Extras = t.Extras
-	for k, v := range t.Ignore {
-		ret.Ignore[k] = v
-	}
-	for k, v := range t.SourceNames {
-		ret.SourceNames[k] = v
-	}
-
-	return ret
-}
-
-// IsZero returns true if the Config represents the absence of a
-// configuration.
-func (t *Config) IsZero() bool {
-	return len(t.CASColumns) == 0 &&
-		len(t.Deadlines) == 0 &&
-		len(t.Exprs) == 0 &&
-		t.Extras.IsEmpty() &&
-		len(t.Ignore) == 0 &&
-		len(t.SourceNames) == 0
-}
 
 // Configs provides a lookup service for per-destination-table
 // configurations.
 type Configs struct {
-	pool types.Querier
+	pool types.StagingPool
 
 	// Parent context of all watch behaviors. When the background
 	// refresh loop is stopped, we can cancel all watches as there will

--- a/internal/staging/applycfg/provider.go
+++ b/internal/staging/applycfg/provider.go
@@ -1,0 +1,64 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package applycfg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/google/wire"
+	"github.com/pkg/errors"
+)
+
+// Set is used by Wire.
+var Set = wire.NewSet(
+	ProvideConfigs,
+)
+
+// ProvideConfigs constructs a Configs instance, starting a new
+// background goroutine to keep it refreshed.
+func ProvideConfigs(
+	ctx context.Context, pool types.StagingPool, targetDB ident.StagingDB,
+) (*Configs, func(), error) {
+	target := ident.NewTable(targetDB.Ident(), ident.Public, ident.New("apply_config"))
+
+	if _, err := pool.Exec(ctx, fmt.Sprintf(confSchema, target)); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	cfg := &Configs{pool: pool}
+	cfg.mu.data = make(map[ident.Table]*Config)
+	cfg.mu.updated = make(chan struct{})
+	cfg.sql.delete = fmt.Sprintf(deleteConfTemplate, target)
+	cfg.sql.loadAll = fmt.Sprintf(loadConfTemplate, target)
+	cfg.sql.upsert = fmt.Sprintf(upsertConfTemplate, target)
+
+	// Ensure initial data load is good.
+	if _, err := cfg.Refresh(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	// Start a background goroutine to refresh data.
+	refreshCtx, cancel := context.WithCancel(context.Background())
+	go cfg.refreshLoop(refreshCtx)
+	// Once the refresh context has stopped, watches won't fire.
+	cfg.watchCtx = refreshCtx
+
+	return cfg, cancel, nil
+}

--- a/internal/target/apply/debug.go
+++ b/internal/target/apply/debug.go
@@ -19,11 +19,13 @@ package apply
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 )
 
 // DebugHandler returns a trivial http Handler that will dump the
 // current configuration as a JSON document.
-func DebugHandler(cfgs *Configs) http.Handler {
+func DebugHandler(cfgs *applycfg.Configs) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/target/apply/factory.go
+++ b/internal/target/apply/factory.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 )
 
 // factory vends singleton instance of apply.
 type factory struct {
-	configs  *Configs
+	configs  *applycfg.Configs
 	watchers types.Watchers
 	mu       struct {
 		sync.RWMutex

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -17,57 +17,21 @@
 package apply
 
 import (
-	"context"
-	"fmt"
-
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
-	"github.com/pkg/errors"
 )
 
 // Set is used by Wire.
 var Set = wire.NewSet(
-	ProvideConfigs,
 	ProvideFactory,
 )
-
-// ProvideConfigs constructs a Configs instance, starting a new
-// background goroutine to keep it refreshed.
-func ProvideConfigs(
-	ctx context.Context, pool types.TargetPool, targetDB ident.StagingDB,
-) (*Configs, func(), error) {
-	target := ident.NewTable(targetDB.Ident(), ident.Public, ident.New("apply_config"))
-
-	if _, err := pool.Exec(ctx, fmt.Sprintf(confSchema, target)); err != nil {
-		return nil, nil, errors.WithStack(err)
-	}
-
-	cfg := &Configs{pool: pool}
-	cfg.mu.data = make(map[ident.Table]*Config)
-	cfg.mu.updated = make(chan struct{})
-	cfg.sql.delete = fmt.Sprintf(deleteConfTemplate, target)
-	cfg.sql.loadAll = fmt.Sprintf(loadConfTemplate, target)
-	cfg.sql.upsert = fmt.Sprintf(upsertConfTemplate, target)
-
-	// Ensure initial data load is good.
-	if _, err := cfg.Refresh(ctx); err != nil {
-		return nil, nil, err
-	}
-
-	// Start a background goroutine to refresh data.
-	refreshCtx, cancel := context.WithCancel(context.Background())
-	go cfg.refreshLoop(refreshCtx)
-	// Once the refresh context has stopped, watches won't fire.
-	cfg.watchCtx = refreshCtx
-
-	return cfg, cancel, nil
-}
 
 // ProvideFactory is called by Wire to construct the factory. The cancel
 // function will, in turn, destroy the per-schema types.Applier
 // instances.
-func ProvideFactory(configs *Configs, watchers types.Watchers) (types.Appliers, func()) {
+func ProvideFactory(configs *applycfg.Configs, watchers types.Watchers) (types.Appliers, func()) {
 	f := &factory{
 		configs:  configs,
 		watchers: watchers,

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -101,7 +102,9 @@ type templates struct {
 // newTemplates constructs a new templates instance, performing some
 // pre-computations to identify primary keys and to filter out ignored
 // columns.
-func newTemplates(target ident.Table, cfgData *Config, colData []types.ColData) *templates {
+func newTemplates(
+	target ident.Table, cfgData *applycfg.Config, colData []types.ColData,
+) *templates {
 	// Map cas column names to their order in the comparison tuple.
 	casMap := make(map[ident.Ident]int, len(cfgData.CASColumns))
 	for idx, name := range cfgData.CASColumns {
@@ -175,7 +178,7 @@ func (t *templates) Vars() [][]varPair {
 
 			if pattern, ok := t.Exprs[col.Name]; ok {
 				vp.Expr = strings.ReplaceAll(
-					pattern, substitutionToken, fmt.Sprintf("$%d", vp.Index))
+					pattern, applycfg.SubstitutionToken, fmt.Sprintf("$%d", vp.Index))
 				// A constant expression doesn't occupy an index slot.
 				if vp.Expr == pattern {
 					vp.Index = 0


### PR DESCRIPTION
This change moves the persistence code for apply.Config under the staging package, since we're making the command-and-control tables separate from the target tables.

There are no functional changes in this commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/374)
<!-- Reviewable:end -->
