### PR TITLE
workflow: Push status check to PR head sha

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -172,6 +172,7 @@ jobs:
       CONTEXT: Workflow Binaries
       GH_TOKEN: ${{ github.token }}
       MERGE_SHA: ${{ github.event.merge_group.head_sha }}
+      PR_SHA: ${{ github.event.pull_request.head.sha }}
       STATE: success
     steps:
       - name: Failure
@@ -181,10 +182,12 @@ jobs:
         run: |
           set -eo pipefail
 
-          gh api \
-             repos/${{ github.repository }}/statuses/${{ github.sha }} \
-             -f "state=$STATE" \
-             -f "context=$CONTEXT"
+          if [ ! -z "$PR_SHA" ]; then
+            gh api \
+               repos/${{ github.repository }}/statuses/$PR_SHA \
+               -f "state=$STATE" \
+               -f "context=$CONTEXT"
+          fi
           
           if [ ! -z "$MERGE_SHA" ]; then
             gh api \

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -224,6 +224,7 @@ jobs:
       CONTEXT: Workflow Golang
       GH_TOKEN: ${{ github.token }}
       MERGE_SHA: ${{ github.event.merge_group.head_sha }}
+      PR_SHA: ${{ github.event.pull_request.head.sha }}
       STATE: success
     steps:
       - name: Failure
@@ -233,10 +234,12 @@ jobs:
         run: |
           set -eo pipefail
 
-          gh api \
-             repos/${{ github.repository }}/statuses/${{ github.sha }} \
-             -f "state=$STATE" \
-             -f "context=$CONTEXT"
+          if [ ! -z "$PR_SHA" ]; then
+            gh api \
+               repos/${{ github.repository }}/statuses/$PR_SHA \
+               -f "state=$STATE" \
+               -f "context=$CONTEXT"
+          fi
 
           if [ ! -z "$MERGE_SHA" ]; then
             gh api \


### PR DESCRIPTION
The SHA under test is not always necessarily the same as the commit that the PR is attached to. This split seems to happen with PRs that come from forks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/384)
<!-- Reviewable:end -->
