### PR TITLE
workflow: Don't test on push

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -22,15 +22,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on:
+  # Since we use the merge queue to push and there are no observable
+  # side-effects of running a test-only workflow, we don't respond to
+  # push events.
   merge_group: # Enable merge queue
-  push:
-    branches: [ master ]
-    tags: [ 'v*.*.*' ]
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '**/*.go'
-      - '.github/workflows/golang.yaml'
   pull_request:
     paths:
       - 'go.mod'


### PR DESCRIPTION
We use the merge queue to admit changes, so there's no need to re-test once the commit hits a destination branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/385)
<!-- Reviewable:end -->
