### PR TITLE
mylogical: allow "Source Distribution" to map flavor to MySQL

### DIFF
--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -428,7 +428,7 @@ func getFlavor(config *Config) (string, error) {
 			}
 		}
 		return mysql.MariaDBFlavor, nil
-	} else if strings.Contains(version, "MySQL") {
+	} else if strings.Contains(version, "MySQL") || version == "Source distribution" {
 		for _, v := range mySQLSystemSettings {
 			err = checkSystemSetting(c, v[0], v[1])
 			if err != nil {


### PR DESCRIPTION
MySQL community editions do not have MySQL in the name - they use "Source Distribution" again apparently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/398)
<!-- Reviewable:end -->
