### PR TITLE
version: Detect incompatible metadata schema changes

### DIFF
--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
+	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 )
 
@@ -30,11 +31,12 @@ import (
 type Fixture struct {
 	*base.Fixture
 
-	Appliers types.Appliers
-	Configs  *applycfg.Configs
-	Memo     types.Memo
-	Stagers  types.Stagers
-	Watchers types.Watchers
+	Appliers       types.Appliers
+	Configs        *applycfg.Configs
+	Memo           types.Memo
+	Stagers        types.Stagers
+	VersionChecker *version.Checker
+	Watchers       types.Watchers
 
 	Watcher types.Watcher // A watcher for TestDB.
 }

--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
 	"github.com/cockroachdb/cdc-sink/internal/staging/stage"
+	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 )
@@ -81,6 +82,7 @@ func NewFixture() (*Fixture, func(), error) {
 		return nil, nil, err
 	}
 	stagers := stage.ProvideFactory(stagingPool, stagingDB)
+	checker := version.ProvideChecker(stagingPool, memoMemo)
 	watcher, err := ProvideWatcher(context, testDB, watchers)
 	if err != nil {
 		cleanup8()
@@ -94,13 +96,14 @@ func NewFixture() (*Fixture, func(), error) {
 		return nil, nil, err
 	}
 	allFixture := &Fixture{
-		Fixture:  fixture,
-		Appliers: appliers,
-		Configs:  configs,
-		Memo:     memoMemo,
-		Stagers:  stagers,
-		Watchers: watchers,
-		Watcher:  watcher,
+		Fixture:        fixture,
+		Appliers:       appliers,
+		Configs:        configs,
+		Memo:           memoMemo,
+		Stagers:        stagers,
+		VersionChecker: checker,
+		Watchers:       watchers,
+		Watcher:        watcher,
 	}
 	return allFixture, func() {
 		cleanup8()

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -52,7 +52,7 @@ func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, func(), erro
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
-			"Appliers", "Fixture", "Configs", "Memo", "Watchers"),
+			"Appliers", "Fixture", "Configs", "Memo", "VersionChecker", "Watchers"),
 		ProvideFirestoreClient,
 		ProvideLoops,
 		ProvideTombstones,

--- a/internal/source/logical/wire_gen.go
+++ b/internal/source/logical/wire_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
+	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 )
@@ -71,7 +72,16 @@ func Start(ctx context.Context, config Config, dialect Dialect) (*Loop, func(), 
 		cleanup()
 		return nil, nil, err
 	}
-	factory, cleanup6 := ProvideFactory(appliers, config, memoMemo, stagingPool, targetPool, watchers, userScript)
+	checker := version.ProvideChecker(stagingPool, memoMemo)
+	factory, cleanup6, err := ProvideFactory(ctx, appliers, config, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	logicalLoop, err := ProvideLoop(ctx, factory, dialect)
 	if err != nil {
 		cleanup6()

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
+	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 )
@@ -74,7 +75,16 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	factory, cleanup6 := logical.ProvideFactory(appliers, config, memoMemo, stagingPool, targetPool, watchers, userScript)
+	checker := version.ProvideChecker(stagingPool, memoMemo)
+	factory, cleanup6, err := logical.ProvideFactory(ctx, appliers, config, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	dialect, err := ProvideDialect(config)
 	if err != nil {
 		cleanup6()

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
+	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 )
@@ -74,7 +75,16 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	factory, cleanup6 := logical.ProvideFactory(appliers, config, memoMemo, stagingPool, targetPool, watchers, userScript)
+	checker := version.ProvideChecker(stagingPool, memoMemo)
+	factory, cleanup6, err := logical.ProvideFactory(ctx, appliers, config, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	dialect, err := ProvideDialect(ctx, config)
 	if err != nil {
 		cleanup6()

--- a/internal/staging/version/provider.go
+++ b/internal/staging/version/provider.go
@@ -14,25 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package staging contains all services which interact with the staging
-// database.
-package staging
+package version
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
-	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
-	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
-	"github.com/cockroachdb/cdc-sink/internal/staging/stage"
-	"github.com/cockroachdb/cdc-sink/internal/staging/version"
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/google/wire"
 )
 
-// Set is used by Wire and contains providers for all target
-// sub-packages.
-var Set = wire.NewSet(
-	applycfg.Set,
-	leases.Set,
-	memo.Set,
-	stage.Set,
-	version.Set,
-)
+// Set is used by Wire.
+var Set = wire.NewSet(ProvideChecker)
+
+// ProvideChecker is called by Wire.
+func ProvideChecker(db *types.StagingPool, memo types.Memo) *Checker {
+	return &Checker{
+		Memo:        memo,
+		StagingPool: db,
+	}
+}

--- a/internal/staging/version/version_test.go
+++ b/internal/staging/version/version_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package version_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
+	"github.com/cockroachdb/cdc-sink/internal/staging/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecker(t *testing.T) {
+	r := require.New(t)
+
+	fixture, cancel, err := all.NewFixture()
+	r.NoError(err)
+	defer cancel()
+
+	checker := fixture.VersionChecker
+	ctx := fixture.Context
+
+	// Verify bootstrap.
+	warnings, err := checker.Check(ctx)
+	r.NoError(err)
+	r.Empty(warnings)
+
+	// Introduce a new version.
+	version.Versions = append(version.Versions, version.Version{
+		Info: "testing",
+		PR:   1234,
+	})
+
+	warnings, err = checker.Check(ctx)
+	r.NoError(err)
+	r.Len(warnings, 1)
+
+	// Perform schema change out of band.
+	r.NoError(fixture.Memo.Put(ctx,
+		fixture.StagingPool,
+		"version-1234",
+		[]byte(`{"state":"applied"}`)))
+
+	warnings, err = checker.Check(ctx)
+	r.NoError(err)
+	r.Empty(warnings)
+}

--- a/internal/staging/version/versions.go
+++ b/internal/staging/version/versions.go
@@ -1,0 +1,138 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package version is used to track incompatible schema changes within
+// the staging tables. This package does not assume that breaking
+// changes are necessarily linear.
+//
+// In the future, new versions  could trigger a lease acquisition and an
+// automated migration. For the moment, we'll print a list of PR numbers
+// that will contain information about the breaking change.
+//
+// To introduce a new version, add an entry to the tail of the
+// [Versions] array, create a PR, and then update the entry with the new
+// PR number.
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/retry"
+	"github.com/pkg/errors"
+)
+
+// Versions contains breaking changes to the cdc-sink metadata tables.
+var Versions = []Version{
+	{"Add versions table", 400},
+}
+
+// A Version describes a breaking change in the cdc-sink metadata
+// tables.
+type Version struct {
+	Info string // A short string for human consumption.
+	PR   int    // The pull request number which introduces the incompatible change.
+}
+
+// String is for debugging use only. Use [Version.Warning] for a
+// user-friendly message.
+func (v *Version) String() string {
+	return fmt.Sprintf("%d: %s", v.PR, v.Info)
+}
+
+// Warning returns a user-facing warning message to describe the Version.
+func (v *Version) Warning() string {
+	return fmt.Sprintf(warningTemplate, v.Info, v.PR)
+}
+
+const (
+	appliedState    = "applied"
+	versionKey      = "version-%d"
+	warningTemplate = `Manual schema change required to upgrade to this version of cdc-sink.
+%s
+See https://github.com/cockroachdb/cdc-sink/pull/%d for additional details.`
+)
+
+// Checker ensures that a set of version entries exists in the memo
+// table so that we can provide useful messages to users on how to
+// perform cdc-sink metadata schema fixups.
+type Checker struct {
+	Memo        types.Memo
+	StagingPool *types.StagingPool
+}
+
+// Check will produce a report of PRs that have not been applied to the
+func (c *Checker) Check(ctx context.Context) ([]string, error) {
+	type payload struct {
+		State string `json:"state,omitempty"`
+	}
+
+	var warnings []string
+	err := retry.Retry(ctx, func(ctx context.Context) error {
+		warnings = nil
+
+		tx, err := c.StagingPool.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback(ctx)
+
+		bootstrap := false
+		for idx, v := range Versions {
+			var p payload
+			key := fmt.Sprintf(versionKey, v.PR)
+			data, err := c.Memo.Get(ctx, tx, key)
+			if err != nil {
+				return errors.Wrapf(err, "could not retrieve %s", key)
+			}
+
+			// If we have data, make sure it's marked as being applied.
+			if len(data) != 0 {
+				if err := json.Unmarshal(data, &p); err != nil {
+					return errors.Wrapf(err, "could not decode version-check payload %s", key)
+				}
+				// Future-proof against automatic migrations.
+				if p.State != appliedState {
+					warnings = append(warnings,
+						fmt.Sprintf("unexpected state %s: %s", p.State, v.Warning()))
+				}
+				continue
+			}
+
+			// If there's no marker for the first version, we'll assume
+			// that we're booting for the first time and apply markers.
+			if idx == 0 || bootstrap {
+				bootstrap = true
+				p = payload{State: appliedState}
+				data, err := json.Marshal(p)
+				if err != nil {
+					return errors.Wrapf(err, "could not marshal payload for %s", key)
+				}
+				if err := c.Memo.Put(ctx, tx, key, data); err != nil {
+					return errors.Wrapf(err, "could not put %s", key)
+				}
+				continue
+			}
+
+			warnings = append(warnings, v.Warning())
+		}
+
+		return tx.Commit(ctx)
+	})
+	return warnings, err
+}


### PR DESCRIPTION
This change introduces a utility class that provides useful warning messages when making breaking changes to the cdc-sink schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/400)
<!-- Reviewable:end -->
