### PR TITLE
schemawatch: Initial Oracle implementation

### DIFF
--- a/internal/sinktest/base/table_info.go
+++ b/internal/sinktest/base/table_info.go
@@ -43,9 +43,9 @@ func (ti TableInfo[P]) DeleteAll(ctx context.Context) error {
 	return retry.Execute(ctx, ti.db, fmt.Sprintf("DELETE FROM %s WHERE true", ti.name))
 }
 
-// DropTable drops the table if it exists.
+// DropTable drops the table.
 func (ti TableInfo[P]) DropTable(ctx context.Context) error {
-	return retry.Execute(ctx, ti.db, fmt.Sprintf("DROP TABLE IF EXISTS %s", ti.name))
+	return retry.Execute(ctx, ti.db, fmt.Sprintf("DROP TABLE %s", ti.name))
 }
 
 // Exec executes a single SQL statement. The sql string must include

--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -20,6 +20,7 @@ package schemawatch
 
 import (
 	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 	"sync"
@@ -52,7 +53,8 @@ type watcher struct {
 	}
 
 	sql struct {
-		tables string
+		tables     string
+		tablesArgs []any
 	}
 }
 
@@ -72,7 +74,16 @@ func newWatcher(
 		schema:     schema,
 	}
 	w.mu.updated = make(chan struct{})
-	w.sql.tables = fmt.Sprintf(tableTemplate, schema)
+	switch tx.Product {
+	case types.ProductCockroachDB:
+		w.sql.tables = fmt.Sprintf(tableTemplateCrdb, schema)
+	case types.ProductOracle:
+		w.sql.tables = tableTemplateOracle
+		w.sql.tablesArgs = []any{sql.Named("owner", schema.Raw())}
+	default:
+		cancel()
+		return nil, nil, errors.Errorf("unimplemented %s", tx.Product)
+	}
 
 	// Initial data load to sanity-check and make ready.
 	data, err := w.getTables(ctx, tx)
@@ -215,14 +226,18 @@ func (w *watcher) Watch(table ident.Table) (_ <-chan []types.ColData, cancel fun
 	return ch, cancel, nil
 }
 
-const tableTemplate = `SELECT table_name FROM [SHOW TABLES FROM %s] WHERE type = 'table'`
+const (
+	tableTemplateCrdb   = `SELECT table_name FROM [SHOW TABLES FROM %s] WHERE type = 'table'`
+	tableTemplateOracle = `SELECT TABLE_NAME FROM ALL_TABLES WHERE OWNER = :owner`
+)
 
 func (w *watcher) getTables(ctx context.Context, tx *types.TargetPool) (*types.SchemaData, error) {
 	ret := &types.SchemaData{
 		Columns: make(map[ident.Table][]types.ColData),
 	}
+
 	err := retry.Retry(ctx, func(ctx context.Context) error {
-		rows, err := tx.QueryContext(ctx, w.sql.tables)
+		rows, err := tx.QueryContext(ctx, w.sql.tables, w.sql.tablesArgs...)
 		if err != nil {
 			return errors.Wrap(err, w.sql.tables)
 		}


### PR DESCRIPTION
This change updates the schemawatch package to support Oracle as the target database.

The tests in the schemawatch package will pass if given the flag `-testTarget oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1`. These tests won't be enabled in the CI system until the apply package has been ported.

The base.ProvideTestDB() function has been updated to create a new SQL user, thereby creating a new schema for creating tables into. The names of testing tables have changed to support both PG and Oracle naming conventions.

The delta is coldata_test.go is driven by wanting to keep the same test code running for multiple products. Similarly, the table-dependency test uses such trivial tables, it happens to work for both databases with a trivial change.

h/t: @BramGruneir for initial research into the introspection queries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/403)
<!-- Reviewable:end -->
