### PR TITLE
sinktest: Separate source from target test schemas

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -24,6 +24,9 @@
 # as the values passed to sinktest.IntegrationMain.
 version: "3.9"
 services:
+  # These define the tested source databases. The network_mode is host
+  # so that outgoing changefeed network requests can connect to the test
+  # server.
   cockroachdb-v20.2:
     image: cockroachdb/cockroach:latest-v20.2
     network_mode: host
@@ -48,6 +51,24 @@ services:
     image: cockroachdb/cockroach:latest-v23.1
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
+
+  # These two services are used for testing split-mode operations. We
+  # need to bypass the usual entry-point script because it has a check
+  # to ensure that the process only listens on localhost and on the
+  # default port.
+  #
+  # https://github.com/cockroachdb/cockroach/issues/84166
+  source-cockroachdb-v23.1:
+    image: cockroachdb/cockroach:latest-v23.1
+    network_mode: host
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  target-cockroachdb-v23.1:
+    image: cockroachdb/cockroach:latest-v23.1
+    network_mode: host
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5401 --http-addr :8082
+
   firestore:
     image: ghcr.io/cockroachdb/cdc-sink/firestore-emulator:latest
     # Expose the emulator on port 8181 to avoid conflict with CRDB admin UI.

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -89,42 +89,49 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Refer to the CRDB support policy when determining how many
+      # older releases to support.
+      # https://www.cockroachlabs.com/docs/releases/release-support-policy.html
+      #
+      # This matrix is explicit, since we have a few axes (target vs
+      # integration) that can't be expressed with the automatic
+      # cross-product behavior provided by the matrix operator.
       matrix:
-        # Pick a primary version to test all of the integration sources
-        # against. The matrix component names should use the target
-        # names listed in the docker-compose.yml file in the parent
-        # directory.
-        cockroachdb: [ v23.1 ]
-        integration:
-          - "firestore"
-          - "mysql-v8"
-          - "mysql-mariadb-v10"
-          - "postgresql-v11"
-          - "postgresql-v12"
-          - "postgresql-v13"
-          - "postgresql-v14"
-          - "postgresql-v15"
-        # The cockroachdb value in this include block will collide with
-        # the value from the auto-expanded matrix. The net effect is
-        # that we'll skip integration tests against older versions of
-        # CRDB. These tests are kept around to ensure that the target
-        # package doesn't use any SQL that couldn't be run on older CRDB
-        # versions.
-        #
-        # Refer to the CRDB support policy when determining how many
-        # older releases to support.
-        # https://www.cockroachlabs.com/docs/releases/release-support-policy.html
         include:
           - cockroachdb: v21.1
           - cockroachdb: v21.2
           - cockroachdb: v22.1
           - cockroachdb: v22.2
           - cockroachdb: v23.1
+            integration: firestore
+          - cockroachdb: v23.1
+            integration: mysql-v8
+          - cockroachdb: v23.1
+            integration: mysql-mariadb-v10
+          - cockroachdb: v23.1
+            integration: postgresql-v11
+          - cockroachdb: v23.1
+            integration: postgresql-v12
+          - cockroachdb: v23.1
+            integration: postgresql-v13
+          - cockroachdb: v23.1
+            integration: postgresql-v14
+          - cockroachdb: v23.1
+            integration: postgresql-v15
+          # Run a test with a separate CockroachDB source and target
+          # instance to ensure there are no accidental dependencies
+          # between the source, staging, and target schemas.
+          - cockroachdb: v23.1
+            source: source-cockroachdb-v23.1
+            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
+            target: target-cockroachdb-v23.1
+            targetConn: "postgresql://root@127.0.0.1:5401/defaultdb?sslmode=disable"
     env:
-      COVER_OUT: coverage-${{ matrix.cockroachdb }}-${{ matrix.integration }}.out
+      COVER_OUT: coverage-${{ strategy.job-index }}.out
+      DOCKER_LOGS_OUT: docker-${{ strategy.job-index }}.log
       FIRESTORE_EMULATOR_HOST: 127.0.0.1:8181
-      JUNIT_OUT: junit-${{ matrix.cockroachdb }}-${{ matrix.integration }}.xml
-      TEST_OUT: go-test-${{ matrix.cockroachdb }}-${{ matrix.integration }}.json
+      JUNIT_OUT: junit-${{ strategy.job-index }}.xml
+      TEST_OUT: go-test-${{ strategy.job-index }}.json
     steps:
       - uses: actions/checkout@v3
 
@@ -147,14 +154,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Start CockroachDB
+      - name: Start Containers
         working-directory: .github
-        run: docker-compose up -d cockroachdb-${{ matrix.cockroachdb }}
-
-      - name: Start ${{ matrix.integration }}
-        if: ${{ matrix.integration }}
-        working-directory: .github
-        run: docker-compose up -d ${{ matrix.integration }}
+        run: >
+          docker-compose up -d
+          cockroachdb-${{ matrix.cockroachdb }}
+          ${{ matrix.integration }}
+          ${{ matrix.source }}
+          ${{ matrix.target }}
 
       # The go test json output will be written into a pipeline to
       # create a JUnit.xml file. The test reports are aggregated later
@@ -167,6 +174,8 @@ jobs:
         env:
           COCKROACH_DEV_LICENSE: ${{ secrets.COCKROACH_DEV_LICENSE }}
           CDC_INTEGRATION: ${{ matrix.integration }}
+          TEST_SOURCE_CONNECT: ${{ matrix.sourceConn }}
+          TEST_TARGET_CONNECT: ${{ matrix.targetConn }}
         run: >
           set -o pipefail;
           go test
@@ -185,16 +194,17 @@ jobs:
           -package-name ${{ matrix.cockroachdb }}-${{ matrix.integration }} |
           tee ${{ env.TEST_OUT }}
 
-      - name: Stop databases
-        if: ${{ always() }}
-        working-directory: .github
-        run: docker-compose down
-
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.COVER_OUT }}
+
+      # Capture container logs in case they're needed for diagnostics.
+      - name: Docker container logs
+        if: always()
+        working-directory: .github
+        run: docker-compose logs --no-color > ${{ env.DOCKER_LOGS_OUT }}
 
       # Upload all test reports to a common artifact name, to make them
       # available to the summarization step. The go test json is
@@ -206,6 +216,7 @@ jobs:
           name: integration-reports
           path: |
             ${{ env.COVER_OUT }}
+            ${{ env.DOCKER_LOGS_OUT }}
             ${{ env.JUNIT_OUT }}
             ${{ env.TEST_OUT }}
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ cdc-sink
 
 # CockroachDB data directory
 cockroach-data/
+goroutine_dump/
+heap_profiler/

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -56,7 +56,7 @@ func TestScript(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	schema := fixture.TestDB.Schema()
+	schema := fixture.TargetSchema.Schema()
 
 	// Create tables that will be referenced by the user-script.
 	_, err = fixture.TargetPool.ExecContext(ctx,

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -41,13 +41,14 @@ type Fixture struct {
 	Watcher types.Watcher // A watcher for TestDB.
 }
 
-// CreateTable creates a test table within the TestDB and refreshes the
-// target database's Watcher. The schemaSpec parameter must have exactly
+// CreateTargetTable creates a test table within the TargetPool and
+// TargetSchema. If the table is successfully created, the schema
+// watcher will be refreshed. The schemaSpec parameter must have exactly
 // one %s substitution parameter for the database name and table name.
-func (f *Fixture) CreateTable(
+func (f *Fixture) CreateTargetTable(
 	ctx context.Context, schemaSpec string,
 ) (base.TableInfo[*types.TargetPool], error) {
-	ti, err := f.Fixture.CreateTable(ctx, schemaSpec)
+	ti, err := f.Fixture.CreateTargetTable(ctx, schemaSpec)
 	if err == nil {
 		err = f.Watcher.Refresh(ctx, f.TargetPool)
 	}

--- a/internal/sinktest/all/provider.go
+++ b/internal/sinktest/all/provider.go
@@ -20,6 +20,7 @@ package all
 import (
 	"context"
 
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
@@ -41,7 +42,7 @@ var TestSet = wire.NewSet(
 // ProvideWatcher is called by Wire to construct a Watcher
 // bound to the testing database.
 func ProvideWatcher(
-	ctx context.Context, testDB base.TestDB, watchers types.Watchers,
+	ctx context.Context, target sinktest.TargetSchema, watchers types.Watchers,
 ) (types.Watcher, error) {
-	return watchers.Get(ctx, testDB.Schema())
+	return watchers.Get(ctx, target.Schema())
 }

--- a/internal/sinktest/base/base_test.go
+++ b/internal/sinktest/base/base_test.go
@@ -29,6 +29,10 @@ func TestBaseSmoke(t *testing.T) {
 	r.NoError(err)
 	defer cleanup()
 
+	r.NotNil(fixture.SourcePool.DB)
+	r.NotEmpty(fixture.SourcePool.ConnectionString)
+	r.NotEmpty(fixture.SourcePool.Version)
+
 	r.NotNil(fixture.StagingPool.Pool)
 	r.NotEmpty(fixture.StagingPool.ConnectionString)
 	r.NotEmpty(fixture.StagingPool.Version)

--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
@@ -36,21 +37,55 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	connString = flag.String("testConnect",
-		"postgresql://root@localhost:26257/defaultdb?sslmode=disable",
-		"the connection string to use for testing")
+const (
+	defaultConnString = "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
 
-	targetString = flag.String("testTarget", "", "use an alternate connection string for the target database")
+	envSourceString  = "TEST_SOURCE_CONNECT"
+	envStagingString = "TEST_STAGING_CONNECT"
+	envTargetString  = "TEST_TARGET_CONNECT"
 )
+
+var (
+	sourceConn   *string
+	stagingConn  *string
+	targetString *string
+)
+
+func init() {
+	// We use os.Getenv and a length check so that defined, empty
+	// environment variables are ignored.
+
+	sourceConnect := defaultConnString
+	if found := os.Getenv(envSourceString); len(found) > 0 {
+		sourceConnect = found
+	}
+	sourceConn = flag.String("testSourceConnect", sourceConnect,
+		"the connection string to use for the source db")
+
+	stagingConnect := defaultConnString
+	if found := os.Getenv(envStagingString); len(found) > 0 {
+		stagingConnect = found
+	}
+	stagingConn = flag.String("testStagingConnect", stagingConnect,
+		"the connection string to use for the staging db")
+
+	targetConnect := defaultConnString
+	if found := os.Getenv(envTargetString); len(found) > 0 {
+		targetConnect = found
+	}
+	targetString = flag.String("testTargetConnect", targetConnect,
+		"the connection string to use for the target db")
+}
 
 // TestSet is used by wire.
 var TestSet = wire.NewSet(
 	ProvideContext,
-	ProvideStagingDB,
+	ProvideStagingSchema,
 	ProvideStagingPool,
+	ProvideSourcePool,
+	ProvideSourceSchema,
 	ProvideTargetPool,
-	ProvideTestDB,
+	ProvideTargetSchema,
 
 	wire.Struct(new(Fixture), "*"),
 )
@@ -59,30 +94,31 @@ var TestSet = wire.NewSet(
 // without the other services provided by the target package. One can be
 // constructed by calling NewFixture.
 type Fixture struct {
-	Context     context.Context    // The context for the test.
-	StagingPool *types.StagingPool // Access to __cdc_sink database.
-	TargetPool  *types.TargetPool  // Access to the destination.
-	StagingDB   ident.StagingDB    // The _cdc_sink SQL DATABASE.
-	TestDB      TestDB             // A unique SQL DATABASE identifier.
+	Context      context.Context       // The context for the test.
+	SourcePool   *types.SourcePool     // Access to user-data tables and changefeed creation.
+	SourceSchema sinktest.SourceSchema // A container for tables within SourcePool.
+	StagingPool  *types.StagingPool    // Access to __cdc_sink database.
+	StagingDB    ident.StagingSchema   // The _cdc_sink SQL DATABASE.
+	TargetPool   *types.TargetPool     // Access to the destination.
+	TargetSchema sinktest.TargetSchema // A container for tables within TargetPool.
 }
 
-// A global counter for allocating all temp tables in a test run. We
-// know that the enclosing database has a unique name, but it's
-// convenient for all test table names to be unique as well.
-var tempTable int32
+// CreateSourceTable creates a test table within the SourcePool and
+// SourceSchema. The schemaSpec parameter must have exactly one %s
+// substitution parameter for the database name and table name.
+func (f *Fixture) CreateSourceTable(
+	ctx context.Context, schemaSpec string,
+) (TableInfo[*types.SourcePool], error) {
+	return CreateTable(ctx, f.SourcePool, f.SourceSchema.Schema(), schemaSpec)
+}
 
-// CreateTable creates a test table within the TestDB. The
-// schemaSpec parameter must have exactly one %s substitution parameter
-// for the database name and table name.
-func (f *Fixture) CreateTable(
+// CreateTargetTable creates a test table within the TargetPool and
+// TargetSchema. The schemaSpec parameter must have exactly one %s
+// substitution parameter for the database name and table name.
+func (f *Fixture) CreateTargetTable(
 	ctx context.Context, schemaSpec string,
 ) (TableInfo[*types.TargetPool], error) {
-	tableNum := atomic.AddInt32(&tempTable, 1)
-	tableName := ident.New(fmt.Sprintf("tbl_%d", tableNum))
-	table := ident.NewTable(f.TestDB.Schema(), tableName)
-
-	err := retry.Execute(ctx, f.TargetPool, fmt.Sprintf(schemaSpec, table))
-	return TableInfo[*types.TargetPool]{f.TargetPool, table}, errors.WithStack(err)
+	return CreateTable(ctx, f.TargetPool, f.TargetSchema.Schema(), schemaSpec)
 }
 
 var caseTimout = flag.Duration(
@@ -98,23 +134,20 @@ func ProvideContext() (context.Context, func(), error) {
 	return ctx, cancel, nil
 }
 
-// ProvideStagingDB create a globally-unique SQL database. The cancel
-// function will drop the database.
-func ProvideStagingDB(
-	ctx context.Context, pool *types.StagingPool,
-) (ident.StagingDB, func(), error) {
-	ret, cancel, err := CreateSchema(ctx, pool, "_cdc_sink")
-	return ident.StagingDB(ret), cancel, err
-}
-
-// ProvideStagingPool opens a connection to the CockroachDB staging
-// cluster under test. This function will also configure the rangefeed
+// ProvideSourcePool connects to the source database. If the source is a
+// CockroachDB cluster, this function will also configure the rangefeed
 // and license cluster settings if they have not been previously
 // configured.
-func ProvideStagingPool(ctx context.Context) (*types.StagingPool, func(), error) {
-	ret, cancel, err := stdpool.OpenPgxAsStaging(ctx, *connString)
+func ProvideSourcePool(ctx context.Context) (*types.SourcePool, func(), error) {
+	tgt := *sourceConn
+	log.Infof("source connect string: %s", tgt)
+	ret, cancel, err := stdpool.OpenTarget(ctx, tgt)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if ret.Product != types.ProductCockroachDB {
+		return (*types.SourcePool)(ret), cancel, err
 	}
 
 	success := false
@@ -127,7 +160,7 @@ func ProvideStagingPool(ctx context.Context) (*types.StagingPool, func(), error)
 	// Set the cluster settings once, if we need to.
 	var enabled bool
 	if err := retry.Retry(ctx, func(ctx context.Context) error {
-		return ret.QueryRow(ctx, "SHOW CLUSTER SETTING kv.rangefeed.enabled").Scan(&enabled)
+		return ret.QueryRowContext(ctx, "SHOW CLUSTER SETTING kv.rangefeed.enabled").Scan(&enabled)
 	}); err != nil {
 		return nil, nil, errors.Wrap(err, "could not check cluster setting")
 	}
@@ -153,49 +186,91 @@ func ProvideStagingPool(ctx context.Context) (*types.StagingPool, func(), error)
 	}
 
 	success = true
-	return ret, cancel, nil
+	return (*types.SourcePool)(ret), cancel, nil
+}
+
+// ProvideStagingSchema create a globally-unique container for tables in the
+// staging database.
+func ProvideStagingSchema(
+	ctx context.Context, pool *types.StagingPool,
+) (ident.StagingSchema, func(), error) {
+	ret, cancel, err := provideSchema(ctx, pool, "cdc")
+	return ident.StagingSchema(ret), cancel, err
+}
+
+// ProvideStagingPool opens a connection to the CockroachDB staging
+// cluster under test.
+func ProvideStagingPool(ctx context.Context) (*types.StagingPool, func(), error) {
+	tgt := *stagingConn
+	log.Infof("staging connect string: %s", tgt)
+	return stdpool.OpenPgxAsStaging(ctx, tgt)
 }
 
 // ProvideTargetPool connects to the target database (which is most
-// often the same as the staging database).
-func ProvideTargetPool(ctx context.Context) (*types.TargetPool, func(), error) {
-	target := *targetString
-	if target == "" {
-		target = *connString
+// often the same as the source database).
+func ProvideTargetPool(
+	ctx context.Context, source *types.SourcePool,
+) (*types.TargetPool, func(), error) {
+	tgt := *targetString
+	if tgt == source.ConnectionString {
+		log.Info("reusing SourcePool as TargetPool")
+		return (*types.TargetPool)(source), func() {}, nil
 	}
-	return stdpool.OpenTarget(ctx, target)
+	log.Infof("target connect string: %s", tgt)
+	return stdpool.OpenTarget(ctx, *targetString)
 }
 
-// ProvideTestDB create a globally-unique SQL database. The cancel
-// function will drop the database.
-func ProvideTestDB(ctx context.Context, pool *types.TargetPool) (TestDB, func(), error) {
-	switch pool.Product {
+// ProvideSourceSchema create a globally-unique container for tables in
+// the source database.
+func ProvideSourceSchema(
+	ctx context.Context, pool *types.SourcePool,
+) (sinktest.SourceSchema, func(), error) {
+	sch, cancel, err := provideSchema(ctx, pool, "src")
+	log.Infof("source schema: %s", sch)
+	return sinktest.SourceSchema(sch), cancel, err
+}
+
+// ProvideTargetSchema create a globally-unique container for tables in
+// the target database.
+func ProvideTargetSchema(
+	ctx context.Context, pool *types.TargetPool,
+) (sinktest.TargetSchema, func(), error) {
+	sch, cancel, err := provideSchema(ctx, pool, "tgt")
+	log.Infof("target schema: %s", sch)
+	return sinktest.TargetSchema(sch), cancel, err
+}
+
+func provideSchema[P types.AnyPool](
+	ctx context.Context, pool P, prefix string,
+) (ident.Schema, func(), error) {
+	switch pool.Info().Product {
 	case types.ProductCockroachDB, types.ProductPostgreSQL:
-		ret, cancel, err := CreateSchema(ctx, pool, "_test_db")
-		return TestDB(ret), cancel, err
+		return CreateSchema(ctx, pool, prefix)
 
 	case types.ProductOracle:
 		// Each package tests run in a separate binary, so we need a
 		// "globally" unique ID.  While PIDs do recycle, they're highly
 		// unlikely to do so during a single run of the test suite.
-		name := ident.New(fmt.Sprintf("target_%d_%d", os.Getpid(), atomic.AddInt32(&dbIdentCounter, 1)))
+		name := ident.New(fmt.Sprintf(
+			"%s_%d_%d", prefix, os.Getpid(), atomic.AddInt32(&dbIdentCounter, 1)))
 
-		_, err := pool.ExecContext(ctx, fmt.Sprintf("CREATE USER %s", name))
+		err := retry.Execute(ctx, pool, fmt.Sprintf("CREATE USER %s", name))
 		if err != nil {
-			return TestDB{}, nil, errors.Wrapf(err, "could not create user %s", name)
+			return ident.Schema{}, nil, errors.Wrapf(err, "could not create user %s", name)
 		}
 
 		cancel := func() {
-			_, err := pool.ExecContext(ctx, fmt.Sprintf("DROP USER %s CASCADE", name))
+			err := retry.Execute(ctx, pool, fmt.Sprintf("DROP USER %s CASCADE", name))
 			if err != nil {
 				log.WithError(err).Warnf("could not clean up schema %s", name)
 			}
 		}
 
-		return TestDB(ident.MustSchema(name)), cancel, nil
+		return ident.MustSchema(name), cancel, nil
 
 	default:
-		return *new(TestDB), nil, errors.Errorf("cannot create test db for %s", pool.Product)
+		return ident.Schema{}, nil,
+			errors.Errorf("cannot create test db for %s", pool.Info().Product)
 	}
 }
 
@@ -246,9 +321,21 @@ func CreateSchema[P types.AnyPool](
 	return sch, cancel, nil
 }
 
-// TestDB is an injection point that holds the name of a unique database
-// schema in which to store user data.
-type TestDB ident.Schema
+// A global counter for allocating all temp tables in a test run. We
+// know that the enclosing database has a unique name, but it's
+// convenient for all test table names to be unique as well.
+var tempTable int32
 
-// Schema returns the underlying database identifier.
-func (t TestDB) Schema() ident.Schema { return ident.Schema(t) }
+// CreateTable creates a test table. The schemaSpec parameter must have
+// exactly one %s substitution parameter for the database name and table
+// name.
+func CreateTable[P types.AnyPool](
+	ctx context.Context, pool P, enclosing ident.Schema, schemaSpec string,
+) (TableInfo[P], error) {
+	tableNum := atomic.AddInt32(&tempTable, 1)
+	tableName := ident.New(fmt.Sprintf("tbl_%d", tableNum))
+	table := ident.NewTable(enclosing, tableName)
+
+	err := retry.Execute(ctx, pool, fmt.Sprintf(schemaSpec, table))
+	return TableInfo[P]{pool, table}, errors.WithStack(err)
+}

--- a/internal/sinktest/base/table_info.go
+++ b/internal/sinktest/base/table_info.go
@@ -69,6 +69,8 @@ func GetRowCount[P types.AnyPool](ctx context.Context, db P, name ident.Table) (
 	var count int
 	err := retry.Retry(ctx, func(ctx context.Context) error {
 		switch t := any(db).(type) {
+		case *types.SourcePool:
+			return t.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", name)).Scan(&count)
 		case *types.StagingPool:
 			return t.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", name)).Scan(&count)
 		case *types.TargetPool:

--- a/internal/sinktest/base/wire_gen.go
+++ b/internal/sinktest/base/wire_gen.go
@@ -14,25 +14,25 @@ func NewFixture() (*Fixture, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingPool, cleanup2, err := ProvideStagingPool(context)
+	sourcePool, cleanup2, err := ProvideSourcePool(context)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	targetPool, cleanup3, err := ProvideTargetPool(context)
+	sourceSchema, cleanup3, err := ProvideSourceSchema(context, sourcePool)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	stagingDB, cleanup4, err := ProvideStagingDB(context, stagingPool)
+	stagingPool, cleanup4, err := ProvideStagingPool(context)
 	if err != nil {
 		cleanup3()
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	testDB, cleanup5, err := ProvideTestDB(context, targetPool)
+	stagingSchema, cleanup5, err := ProvideStagingSchema(context, stagingPool)
 	if err != nil {
 		cleanup4()
 		cleanup3()
@@ -40,14 +40,37 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
+	targetPool, cleanup6, err := ProvideTargetPool(context, sourcePool)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	targetSchema, cleanup7, err := ProvideTargetSchema(context, targetPool)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	fixture := &Fixture{
-		Context:     context,
-		StagingPool: stagingPool,
-		TargetPool:  targetPool,
-		StagingDB:   stagingDB,
-		TestDB:      testDB,
+		Context:      context,
+		SourcePool:   sourcePool,
+		SourceSchema: sourceSchema,
+		StagingPool:  stagingPool,
+		StagingDB:    stagingSchema,
+		TargetPool:   targetPool,
+		TargetSchema: targetSchema,
 	}
 	return fixture, func() {
+		cleanup7()
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()

--- a/internal/sinktest/sinktest.go
+++ b/internal/sinktest/sinktest.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sinktest contains utility types for writing cdc-sink tests.
+package sinktest
+
+import "github.com/cockroachdb/cdc-sink/internal/util/ident"
+
+// SourceSchema is an injection point that holds the name of a unique
+// table schema in the source database in which to store user data.
+type SourceSchema ident.Schema
+
+// Schema returns the underlying database identifier.
+func (t SourceSchema) Schema() ident.Schema { return ident.Schema(t) }
+
+// TargetSchema is an injection point that holds the name of a unique
+// table schema in the source database in which to store user data.
+type TargetSchema ident.Schema
+
+// Schema returns the underlying database identifier.
+func (t TargetSchema) Schema() ident.Schema { return ident.Schema(t) }

--- a/internal/source/cdc/resolver_test.go
+++ b/internal/source/cdc/resolver_test.go
@@ -41,15 +41,16 @@ func TestResolverDeQueue(t *testing.T) {
 		MetaTableName: ident.New("resolved_timestamps"),
 		BaseConfig: logical.BaseConfig{
 			StagingDB:    baseFixture.StagingDB.Schema(),
+			StagingConn:  baseFixture.StagingPool.ConnectionString,
 			TargetConn:   baseFixture.TargetPool.ConnectionString,
-			TargetSchema: baseFixture.TestDB.Schema(),
+			TargetSchema: baseFixture.TargetSchema.Schema(),
 		},
 	})
 	r.NoError(err)
 	defer cancel()
 
 	ctx := fixture.Context
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		`CREATE TABLE %s (pk INT PRIMARY KEY, v INT NOT NULL)`)
 	r.NoError(err)
 

--- a/internal/source/cdc/url_test.go
+++ b/internal/source/cdc/url_test.go
@@ -149,7 +149,9 @@ func TestParseChangefeedURL(t *testing.T) {
 	}
 
 	h := &Handler{
-		TargetPool: &types.TargetPool{Product: types.ProductCockroachDB},
+		TargetPool: &types.TargetPool{
+			PoolInfo: types.PoolInfo{Product: types.ProductCockroachDB},
+		},
 	}
 	var leafDecision string
 	requestParsingTestCallback = func(decision string) { leafDecision = decision }

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -37,12 +37,12 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(),
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingDB, err := logical.ProvideStagingDB(baseConfig)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	typesLeases, err := leases.ProvideLeases(context, stagingPool, stagingDB)
+	typesLeases, err := leases.ProvideLeases(context, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup()
 		return nil, nil, err

--- a/internal/source/fslogical/wire_gen.go
+++ b/internal/source/fslogical/wire_gen.go
@@ -39,12 +39,12 @@ func Start(contextContext context.Context, config *Config) ([]*logical.Loop, fun
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingDB, err := logical.ProvideStagingDB(baseConfig)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(contextContext, stagingPool, stagingDB)
+	configs, cleanup2, err := applycfg.ProvideConfigs(contextContext, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -74,7 +74,7 @@ func Start(contextContext context.Context, config *Config) ([]*logical.Loop, fun
 		return nil, nil, err
 	}
 	appliers, cleanup6 := apply.ProvideFactory(configs, watchers)
-	memoMemo, err := memo.ProvideMemo(contextContext, stagingPool, stagingDB)
+	memoMemo, err := memo.ProvideMemo(contextContext, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -54,7 +54,7 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 	defer cancel()
 
 	ctx := fixture.Context
-	dbName := fixture.TestDB.Schema()
+	dbName := fixture.TargetSchema.Schema()
 	pool := fixture.TargetPool
 
 	// Create some tables.
@@ -86,6 +86,7 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 		LoopName:       "generator",
 		Immediate:      immediate,
 		RetryDelay:     time.Nanosecond,
+		StagingConn:    fixture.StagingPool.ConnectionString,
 		StagingDB:      fixture.StagingDB.Schema(),
 		StandbyTimeout: 5 * time.Millisecond,
 		TargetConn:     pool.ConnectionString,
@@ -179,7 +180,7 @@ func TestUserScript(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	dbName := fixture.TestDB.Schema()
+	dbName := fixture.TargetSchema.Schema()
 	pool := fixture.TargetPool
 
 	// Create some tables.
@@ -198,6 +199,7 @@ func TestUserScript(t *testing.T) {
 		ApplyTimeout:   2 * time.Minute, // Increase to make using the debugger easier.
 		LoopName:       "generator",
 		Immediate:      false,
+		StagingConn:    fixture.StagingPool.ConnectionString,
 		StagingDB:      fixture.StagingDB.Schema(),
 		StandbyTimeout: 5 * time.Millisecond,
 		TargetConn:     pool.ConnectionString,

--- a/internal/source/logical/provider.go
+++ b/internal/source/logical/provider.go
@@ -98,8 +98,8 @@ func ProvideLoop(ctx context.Context, factory *Factory, dialect Dialect) (*Loop,
 
 // ProvideStagingDB is called by Wire to retrieve the name of the
 // _cdc_sink SQL DATABASE.
-func ProvideStagingDB(config *BaseConfig) (ident.StagingDB, error) {
-	return ident.StagingDB(config.StagingDB), nil
+func ProvideStagingDB(config *BaseConfig) (ident.StagingSchema, error) {
+	return ident.StagingSchema(config.StagingDB), nil
 }
 
 // ProvideStagingPool is called by Wire to create a connection pool that
@@ -139,7 +139,7 @@ func ProvideTargetPool(ctx context.Context, config *BaseConfig) (*types.TargetPo
 	if txTimeout != 0 {
 		options = append(options, stdpool.WithTransactionTimeout(txTimeout))
 	}
-	ret, cancel, err := stdpool.OpenTarget(ctx, config.StagingConn, options...)
+	ret, cancel, err := stdpool.OpenTarget(ctx, config.TargetConn, options...)
 	if ret.Product != types.ProductCockroachDB {
 		cancel()
 		return nil, nil, errors.Errorf("only CockroachDB is a supported target at this time; have %s", ret.Product)

--- a/internal/source/logical/wire_gen.go
+++ b/internal/source/logical/wire_gen.go
@@ -35,12 +35,12 @@ func Start(ctx context.Context, config Config, dialect Dialect) (*Loop, func(), 
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingDB, err := ProvideStagingDB(baseConfig)
+	stagingSchema, err := ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingDB)
+	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -53,7 +53,7 @@ func Start(ctx context.Context, config Config, dialect Dialect) (*Loop, func(), 
 	}
 	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup5 := apply.ProvideFactory(configs, watchers)
-	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingDB)
+	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup5()
 		cleanup4()

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -68,7 +68,7 @@ func testMYLogical(t *testing.T, backfill, immediate bool) {
 	defer cancel()
 
 	ctx := fixture.Context
-	dbName := fixture.TestDB.Schema()
+	dbName := fixture.TargetSchema.Schema()
 	crdbPool := fixture.TargetPool
 
 	config := &Config{
@@ -334,7 +334,7 @@ func TestDataTypes(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	dbName := fixture.TestDB.Schema()
+	dbName := fixture.TargetSchema.Schema()
 	crdbPool := fixture.TargetPool
 
 	config := &Config{

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -38,12 +38,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingDB, err := logical.ProvideStagingDB(baseConfig)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingDB)
+	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -56,7 +56,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	}
 	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup5 := apply.ProvideFactory(configs, watchers)
-	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingDB)
+	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup5()
 		cleanup4()

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -73,7 +73,7 @@ func testPGLogical(t *testing.T, allowBackfill, immediate bool, withChaosProb fl
 	defer cancel()
 
 	ctx := fixture.Context
-	dbSchema := fixture.TestDB.Schema()
+	dbSchema := fixture.TargetSchema.Schema()
 	dbName := dbSchema.Idents(nil)[0] // Extract first name part.
 	crdbPool := fixture.TargetPool
 
@@ -292,7 +292,7 @@ func TestDataTypes(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	dbSchema := fixture.TestDB.Schema()
+	dbSchema := fixture.TargetSchema.Schema()
 	dbName := dbSchema.Idents(nil)[0] // Extract first name part.
 	crdbPool := fixture.TargetPool
 
@@ -308,7 +308,7 @@ func TestDataTypes(t *testing.T) {
 
 		// Create the schema in both locations.
 		var schema = fmt.Sprintf("CREATE TABLE %%s (k INT PRIMARY KEY, v %s)", tc.name)
-		ti, err := fixture.CreateTable(ctx, schema)
+		ti, err := fixture.CreateTargetTable(ctx, schema)
 		if !a.NoErrorf(err, "CRDB %s", tc.name) {
 			return
 		}

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -38,12 +38,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingDB, err := logical.ProvideStagingDB(baseConfig)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingDB)
+	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -56,7 +56,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	}
 	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup5 := apply.ProvideFactory(configs, watchers)
-	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingDB)
+	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup5()
 		cleanup4()

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -81,7 +81,7 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 	r.NoError(err)
 	defer cancel()
 
-	targetDB := destFixture.TestDB.Schema()
+	targetDB := destFixture.TargetSchema.Schema()
 	targetPool := destFixture.TargetPool
 
 	// The target fixture contains the cdc-sink server.
@@ -90,8 +90,9 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 			BaseConfig: logical.BaseConfig{
 				Immediate:    immediate,
 				LoopName:     "changefeed",
+				StagingConn:  destFixture.StagingPool.ConnectionString,
 				StagingDB:    destFixture.StagingDB.Schema(),
-				TargetSchema: destFixture.TestDB.Schema(),
+				TargetSchema: destFixture.TargetSchema.Schema(),
 				TargetConn:   destFixture.TargetPool.ConnectionString,
 			},
 			MetaTableName: ident.New("resolved_timestamps"),
@@ -103,7 +104,7 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 	defer cancel()
 
 	// Set up source and target tables.
-	source, err := sourceFixture.CreateTable(ctx, "CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")
+	source, err := sourceFixture.CreateSourceTable(ctx, "CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")
 	r.NoError(err)
 
 	// Since we're creating the target table without using the helper

--- a/internal/source/server/provider.go
+++ b/internal/source/server/provider.go
@@ -58,7 +58,7 @@ var Set = wire.NewSet(
 // authenticator, or a no-op authenticator if Config.DisableAuth has
 // been set.
 func ProvideAuthenticator(
-	ctx context.Context, pool *types.StagingPool, config *Config, stagingDB ident.StagingDB,
+	ctx context.Context, pool *types.StagingPool, config *Config, stagingDB ident.StagingSchema,
 ) (types.Authenticator, func(), error) {
 	if config.DisableAuth {
 		log.Info("authentication disabled, any caller may write to the target database")

--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -39,7 +39,7 @@ type testFixture struct {
 	Listener      net.Listener
 	StagingPool   *types.StagingPool
 	Server        *Server
-	StagingDB     ident.StagingDB
+	StagingDB     ident.StagingSchema
 	Watcher       types.Watchers
 }
 

--- a/internal/source/server/wire_gen.go
+++ b/internal/source/server/wire_gen.go
@@ -52,13 +52,13 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	stagingDB, err := logical.ProvideStagingDB(baseConfig)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingDB)
+	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup2()
 		cleanup()
@@ -73,7 +73,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 	}
 	watchers, cleanup5 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup6 := apply.ProvideFactory(configs, watchers)
-	authenticator, cleanup7, err := ProvideAuthenticator(ctx, stagingPool, config, stagingDB)
+	authenticator, cleanup7, err := ProvideAuthenticator(ctx, stagingPool, config, stagingSchema)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -84,7 +84,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 		return nil, nil, err
 	}
 	cdcConfig := &config.CDC
-	typesLeases, err := leases.ProvideLeases(ctx, stagingPool, stagingDB)
+	typesLeases, err := leases.ProvideLeases(ctx, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -96,7 +96,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 		return nil, nil, err
 	}
 	metaTable := cdc.ProvideMetaTable(cdcConfig)
-	stagers := stage.ProvideFactory(stagingPool, stagingDB)
+	stagers := stage.ProvideFactory(stagingPool, stagingSchema)
 	resolvers, cleanup8, err := cdc.ProvideResolvers(ctx, cdcConfig, typesLeases, metaTable, stagingPool, stagers, watchers)
 	if err != nil {
 		cleanup7()
@@ -165,12 +165,12 @@ func newTestFixture(contextContext context.Context, config *Config) (*testFixtur
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingDB, err := logical.ProvideStagingDB(baseConfig)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	authenticator, cleanup2, err := ProvideAuthenticator(contextContext, stagingPool, config, stagingDB)
+	authenticator, cleanup2, err := ProvideAuthenticator(contextContext, stagingPool, config, stagingSchema)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -181,7 +181,7 @@ func newTestFixture(contextContext context.Context, config *Config) (*testFixtur
 		cleanup()
 		return nil, nil, err
 	}
-	configs, cleanup4, err := applycfg.ProvideConfigs(contextContext, stagingPool, stagingDB)
+	configs, cleanup4, err := applycfg.ProvideConfigs(contextContext, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup3()
 		cleanup2()
@@ -199,7 +199,7 @@ func newTestFixture(contextContext context.Context, config *Config) (*testFixtur
 	watchers, cleanup6 := schemawatch.ProvideFactory(targetPool)
 	appliers, cleanup7 := apply.ProvideFactory(configs, watchers)
 	cdcConfig := &config.CDC
-	typesLeases, err := leases.ProvideLeases(contextContext, stagingPool, stagingDB)
+	typesLeases, err := leases.ProvideLeases(contextContext, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -211,7 +211,7 @@ func newTestFixture(contextContext context.Context, config *Config) (*testFixtur
 		return nil, nil, err
 	}
 	metaTable := cdc.ProvideMetaTable(cdcConfig)
-	stagers := stage.ProvideFactory(stagingPool, stagingDB)
+	stagers := stage.ProvideFactory(stagingPool, stagingSchema)
 	resolvers, cleanup8, err := cdc.ProvideResolvers(contextContext, cdcConfig, typesLeases, metaTable, stagingPool, stagers, watchers)
 	if err != nil {
 		cleanup7()
@@ -252,7 +252,7 @@ func newTestFixture(contextContext context.Context, config *Config) (*testFixtur
 		Listener:      listener,
 		StagingPool:   stagingPool,
 		Server:        server,
-		StagingDB:     stagingDB,
+		StagingDB:     stagingSchema,
 		Watcher:       watchers,
 	}
 	return serverTestFixture, func() {
@@ -276,6 +276,6 @@ type testFixture struct {
 	Listener      net.Listener
 	StagingPool   *types.StagingPool
 	Server        *Server
-	StagingDB     ident.StagingDB
+	StagingDB     ident.StagingSchema
 	Watcher       types.Watchers
 }

--- a/internal/staging/applycfg/provider.go
+++ b/internal/staging/applycfg/provider.go
@@ -34,7 +34,7 @@ var Set = wire.NewSet(
 // ProvideConfigs constructs a Configs instance, starting a new
 // background goroutine to keep it refreshed.
 func ProvideConfigs(
-	ctx context.Context, pool *types.StagingPool, targetDB ident.StagingDB,
+	ctx context.Context, pool *types.StagingPool, targetDB ident.StagingSchema,
 ) (*Configs, func(), error) {
 	target := ident.NewTable(targetDB.Schema(), ident.New("apply_config"))
 

--- a/internal/staging/auth/jwt/provider.go
+++ b/internal/staging/auth/jwt/provider.go
@@ -38,7 +38,7 @@ var Set = wire.NewSet(ProvideAuth)
 // This provider will also start a background goroutine to look for
 // configuration changes in the database.
 func ProvideAuth(
-	ctx context.Context, db types.StagingQuerier, stagingDB ident.StagingDB,
+	ctx context.Context, db types.StagingQuerier, stagingDB ident.StagingSchema,
 ) (auth types.Authenticator, cancel func(), err error) {
 	cancel = func() {}
 

--- a/internal/staging/auth/jwt/testing.go
+++ b/internal/staging/auth/jwt/testing.go
@@ -35,7 +35,10 @@ import (
 // InsertTestingKey generates a new private key and updates the existing
 // Authenticator with the associated public key.
 func InsertTestingKey(
-	ctx context.Context, tx types.StagingQuerier, auth types.Authenticator, stagingDB ident.StagingDB,
+	ctx context.Context,
+	tx types.StagingQuerier,
+	auth types.Authenticator,
+	stagingDB ident.StagingSchema,
 ) (method jwt.SigningMethod, signer crypto.PrivateKey, err error) {
 	impl, ok := auth.(*authenticator)
 	if !ok {
@@ -91,7 +94,7 @@ func InsertRevokedToken(
 	ctx context.Context,
 	tx types.StagingQuerier,
 	auth types.Authenticator,
-	stagingDB ident.StagingDB,
+	stagingDB ident.StagingSchema,
 	id string,
 ) error {
 	impl, ok := auth.(*authenticator)

--- a/internal/staging/leases/leases_test.go
+++ b/internal/staging/leases/leases_test.go
@@ -28,33 +28,32 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
 func TestLeases(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	fixture, cancel, err := base.NewFixture()
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 	defer cancel()
 
 	ctx := fixture.Context
 
-	tbl, err := fixture.CreateTable(ctx, schema)
-	if !a.NoError(err) {
-		return
-	}
+	enclosing, cancel, err := base.CreateSchema(ctx, fixture.StagingPool, "leases_")
+	r.NoError(err)
+	defer cancel()
+
+	tbl, err := base.CreateTable(ctx, fixture.StagingPool, enclosing, schema)
+	r.NoError(err)
 
 	intf, err := New(ctx, Config{
 		Pool:   fixture.StagingPool,
 		Target: tbl.Name(),
 	})
+	r.NoError(err)
 	l := intf.(*leases)
-	if !a.NoError(err) {
-		return
-	}
 
 	now := time.Now().UTC()
 

--- a/internal/staging/leases/provider.go
+++ b/internal/staging/leases/provider.go
@@ -37,7 +37,7 @@ var Set = wire.NewSet(
 //
 // https://github.com/cockroachdb/cockroach/issues/100194
 func ProvideLeases(
-	ctx context.Context, pool *types.StagingPool, stagingDB ident.StagingDB,
+	ctx context.Context, pool *types.StagingPool, stagingDB ident.StagingSchema,
 ) (types.Leases, error) {
 	return New(ctx, Config{
 		Guard:      time.Second,

--- a/internal/staging/memo/provider.go
+++ b/internal/staging/memo/provider.go
@@ -34,7 +34,7 @@ var Set = wire.NewSet(
 
 // ProvideMemo is called by Wire to construct the KV wrapper.
 func ProvideMemo(
-	ctx context.Context, db *types.StagingPool, staging ident.StagingDB,
+	ctx context.Context, db *types.StagingPool, staging ident.StagingSchema,
 ) (*Memo, error) {
 	target := ident.NewTable(staging.Schema(), ident.New("memo"))
 	if err := retry.Execute(ctx, db, fmt.Sprintf(schema, target)); err != nil {

--- a/internal/staging/stage/provider.go
+++ b/internal/staging/stage/provider.go
@@ -28,7 +28,7 @@ var Set = wire.NewSet(
 )
 
 // ProvideFactory is called by Wire to construct the Stagers factory.
-func ProvideFactory(db *types.StagingPool, stagingDB ident.StagingDB) types.Stagers {
+func ProvideFactory(db *types.StagingPool, stagingDB ident.StagingSchema) types.Stagers {
 	f := &factory{
 		db:        db,
 		stagingDB: stagingDB.Schema(),

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -48,7 +48,7 @@ func TestPutAndDrain(t *testing.T) {
 	ctx := fixture.Context
 	a.NotEmpty(fixture.StagingPool.Version)
 	pool := fixture.StagingPool
-	targetDB := fixture.TestDB.Schema()
+	targetDB := fixture.StagingDB.Schema()
 
 	dummyTarget := ident.NewTable(targetDB, ident.New("target"))
 
@@ -214,7 +214,7 @@ func TestSelectMany(t *testing.T) {
 	a.NotEmpty(fixture.StagingPool.Version)
 
 	// Create some fake table names.
-	targetDB := fixture.TestDB.Schema()
+	targetDB := fixture.TargetSchema.Schema()
 	tables := make([]ident.Table, tableCount)
 	for idx := range tables {
 		tables[idx] = ident.NewTable(targetDB, ident.New(fmt.Sprintf("target_%d", idx)))
@@ -451,7 +451,7 @@ func benchmarkStage(b *testing.B, batchSize int) {
 	defer cancel()
 
 	ctx := fixture.Context
-	targetDB := fixture.TestDB.Schema()
+	targetDB := fixture.TargetSchema.Schema()
 
 	dummyTarget := ident.NewTable(targetDB, ident.New("target"))
 

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -54,7 +54,7 @@ func TestApply(t *testing.T) {
 		Pk0 int    `json:"pk0"`
 		Pk1 string `json:"pk1"`
 	}
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk0 INT, pk1 STRING, extras JSONB, PRIMARY KEY (pk0,pk1))")
 	if !a.NoError(err) {
 		return
@@ -364,7 +364,7 @@ func TestAllDataTypes(t *testing.T) {
 				create = fmt.Sprintf("CREATE TABLE %%s (k int primary key, val %s)", tc.columnType)
 			}
 
-			tbl, err := fixture.CreateTable(ctx, create)
+			tbl, err := fixture.CreateTargetTable(ctx, create)
 			if !a.NoError(err) {
 				return
 			}
@@ -430,7 +430,7 @@ func testConditions(t *testing.T, cas, deadline bool) {
 		TS  time.Time `json:"ts"`
 	}
 
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk INT PRIMARY KEY, ver INT, ts TIMESTAMP)")
 	if !a.NoError(err) {
 		return
@@ -580,7 +580,7 @@ func TestExpressionColumns(t *testing.T) {
 		Fixed string `json:"fixed"`
 	}
 
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk INT PRIMARY KEY, val STRING, fixed STRING)")
 	if !a.NoError(err) {
 		return
@@ -654,7 +654,7 @@ func TestIgnoredColumns(t *testing.T) {
 		ValIgnored string `json:"val_ignored"`
 	}
 
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk0 INT, pk1 INT, val0 STRING, not_required STRING, PRIMARY KEY (pk0, pk1))")
 	if !a.NoError(err) {
 		return
@@ -708,7 +708,7 @@ func TestRenamedColumns(t *testing.T) {
 		Val string `json:"val_source"`
 	}
 
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")
 	if !a.NoError(err) {
 		return
@@ -761,7 +761,7 @@ func TestRepeatedKeysWithIgnoredColumns(t *testing.T) {
 		Pk0 int    `json:"pk0"`
 		Val string `json:"val"`
 	}
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk0 INT PRIMARY KEY, ignored INT AS (1) STORED, val STRING)")
 	if !a.NoError(err) {
 		return
@@ -825,12 +825,12 @@ func TestUTDEnum(t *testing.T) {
 
 	_, err = fixture.TargetPool.ExecContext(ctx, fmt.Sprintf(
 		`CREATE TYPE %s."MyEnum" AS ENUM ('foo', 'bar')`,
-		fixture.TestDB.Schema()))
+		fixture.TargetSchema.Schema()))
 	r.NoError(err)
 
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		fmt.Sprintf(`CREATE TABLE %%s (pk INT PRIMARY KEY, val %s."MyEnum")`,
-			fixture.TestDB.Schema()))
+			fixture.TargetSchema.Schema()))
 	r.NoError(err)
 
 	app, err := fixture.Appliers.Get(ctx, tbl.Name())
@@ -867,7 +867,7 @@ func TestVirtualColumns(t *testing.T) {
 		CK int `json:"ck"`
 		X  int `json:"x,omitempty"`
 	}
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s ("+
 			"a INT, "+
 			"ck INT AS (a + b) STORED, "+
@@ -966,7 +966,7 @@ func benchConditions(b *testing.B, cfg benchConfig) {
 
 	ctx := fixture.Context
 
-	tbl, err := fixture.CreateTable(ctx,
+	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk UUID PRIMARY KEY, ver INT, ts TIMESTAMP)")
 	if !a.NoError(err) {
 		return

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -154,14 +154,14 @@ func TestGetColumns(t *testing.T) {
 		},
 		{
 			products:    []types.Product{types.ProductCockroachDB, types.ProductPostgreSQL},
-			tableSchema: fmt.Sprintf(`a %s."MyEnum" PRIMARY KEY`, fixture.TestDB.Schema()),
+			tableSchema: fmt.Sprintf(`a %s."MyEnum" PRIMARY KEY`, fixture.TargetSchema.Schema()),
 			primaryKeys: []string{"a"},
 			check: func(t *testing.T, data []types.ColData) {
 				a := assert.New(t)
 				if a.Len(data, 1) {
 					col := data[0]
 					a.Equal(
-						ident.NewUDT(fixture.TestDB.Schema(), ident.New("MyEnum")),
+						ident.NewUDT(fixture.TargetSchema.Schema(), ident.New("MyEnum")),
 						col.Type)
 				}
 			},
@@ -171,7 +171,7 @@ func TestGetColumns(t *testing.T) {
 	// Verify user-defined types with mixed-case name.
 	if _, err := fixture.TargetPool.ExecContext(ctx, fmt.Sprintf(
 		`CREATE TYPE %s."MyEnum" AS ENUM ('foo', 'bar')`,
-		fixture.TestDB.Schema()),
+		fixture.TargetSchema.Schema()),
 	); !a.NoError(err) {
 		return
 	}
@@ -204,7 +204,7 @@ func TestGetColumns(t *testing.T) {
 				cmd = "SET experimental_enable_hash_sharded_indexes='true';" + cmd
 			}
 
-			ti, err := fixture.CreateTable(ctx, cmd)
+			ti, err := fixture.CreateTargetTable(ctx, cmd)
 			if !a.NoError(err) {
 				return
 			}
@@ -255,13 +255,14 @@ func TestColDataIgnoresViews(t *testing.T) {
 
 	ctx := fixture.Context
 
-	ti, err := fixture.CreateTable(ctx, `CREATE TABLE %s ( pk INT PRIMARY KEY )`)
+	ti, err := fixture.CreateTargetTable(ctx, `CREATE TABLE %s ( pk INT PRIMARY KEY )`)
 	if !a.NoError(err) {
 		return
 	}
 	tableName := ti.Name()
 
-	vi, err := fixture.CreateTable(ctx, fmt.Sprintf(`CREATE VIEW %%s AS SELECT pk FROM %s`, tableName))
+	vi, err := fixture.CreateTargetTable(ctx, fmt.Sprintf(
+		`CREATE VIEW %%s AS SELECT pk FROM %s`, tableName))
 	if !a.NoError(err) {
 		return
 	}

--- a/internal/target/schemawatch/dependencies_test.go
+++ b/internal/target/schemawatch/dependencies_test.go
@@ -121,7 +121,7 @@ func TestGetDependencyOrder(t *testing.T) {
 	pool := fixture.TargetPool
 
 	for idx, tc := range tcs {
-		sql := fmt.Sprintf(tc.schema, fixture.TestDB.Schema())
+		sql := fmt.Sprintf(tc.schema, fixture.TargetSchema.Schema())
 		_, err := pool.ExecContext(ctx, sql)
 		r.NoError(err, idx)
 	}
@@ -148,21 +148,21 @@ func TestGetDependencyOrder(t *testing.T) {
 CREATE TABLE %[1]s.cycle_a (pk int primary key);
 CREATE TABLE %[1]s.cycle_b (pk int primary key, ref int references %[1]s.cycle_a);
 ALTER TABLE %[1]s.cycle_a ADD COLUMN ref int references %[1]s.cycle_b;
-`, fixture.TestDB.Schema()))
+`, fixture.TargetSchema.Schema()))
 		r.NoError(err)
 
 	case types.ProductOracle:
 		_, err = pool.ExecContext(ctx, fmt.Sprintf(
-			`CREATE TABLE %[1]s.cycle_a (pk int primary key)`, fixture.TestDB.Schema()))
+			`CREATE TABLE %[1]s.cycle_a (pk int primary key)`, fixture.TargetSchema.Schema()))
 		r.NoError(err)
 
 		_, err = pool.ExecContext(ctx, fmt.Sprintf(
 			`CREATE TABLE %[1]s.cycle_b (pk int primary key, ref int references %[1]s.cycle_a)`,
-			fixture.TestDB.Schema()))
+			fixture.TargetSchema.Schema()))
 		r.NoError(err)
 
 		_, err = pool.ExecContext(ctx, fmt.Sprintf(
-			`ALTER TABLE %[1]s.cycle_a ADD (ref int references %[1]s.cycle_b)`, fixture.TestDB.Schema()))
+			`ALTER TABLE %[1]s.cycle_a ADD (ref int references %[1]s.cycle_b)`, fixture.TargetSchema.Schema()))
 		r.NoError(err)
 
 	default:

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -44,11 +44,11 @@ func TestWatch(t *testing.T) {
 	defer cancel()
 
 	ctx := fixture.Context
-	dbName := fixture.TestDB.Schema()
+	dbName := fixture.TargetSchema.Schema()
 	w := fixture.Watcher
 
 	// Bootstrap column.
-	tblInfo, err := fixture.CreateTable(ctx, "CREATE TABLE %s (pk INT PRIMARY KEY)")
+	tblInfo, err := fixture.CreateTargetTable(ctx, "CREATE TABLE %s (pk INT PRIMARY KEY)")
 	if !a.NoError(err) {
 		return
 	}

--- a/internal/util/ident/staging.go
+++ b/internal/util/ident/staging.go
@@ -16,10 +16,10 @@
 
 package ident
 
-// StagingDB is a type alias for the name of the "_cdc_sink" database.
-// It serves as an injection point for uniquely naming the staging
-// database in test cases.
-type StagingDB Schema
+// StagingSchema is a type alias for the name of the "_cdc_sink.public"
+// table schema. It serves as an injection point for uniquely naming the
+// staging database in test cases.
+type StagingSchema Schema
 
 // Schema returns the underying database identifier.
-func (s StagingDB) Schema() Schema { return Schema(s) }
+func (s StagingSchema) Schema() Schema { return Schema(s) }

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -43,6 +43,8 @@ func Execute[P types.AnyPool](ctx context.Context, db P, query string, args ...a
 	return Retry(ctx, func(ctx context.Context) error {
 		var err error
 		switch t := any(db).(type) {
+		case *types.SourcePool:
+			_, err = t.ExecContext(ctx, query, args...)
 		case *types.StagingPool:
 			_, err = t.Exec(ctx, query, args...)
 		case *types.TargetPool:

--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -48,9 +48,11 @@ func OpenOracleAsTarget(
 		}
 
 		ret := &types.TargetPool{
-			ConnectionString: connectString,
-			DB:               sql.OpenDB(connector),
-			Product:          types.ProductOracle,
+			DB: sql.OpenDB(connector),
+			PoolInfo: types.PoolInfo{
+				ConnectionString: connectString,
+				Product:          types.ProductOracle,
+			},
 		}
 
 		ctx.Go(func() error {

--- a/internal/util/stdpool/pgx.go
+++ b/internal/util/stdpool/pgx.go
@@ -75,9 +75,11 @@ func OpenPgxAsStaging(
 	}()
 
 	ret := &types.StagingPool{
-		Pool:             db,
-		ConnectionString: connectString,
-		Product:          types.ProductCockroachDB,
+		Pool: db,
+		PoolInfo: types.PoolInfo{
+			ConnectionString: connectString,
+			Product:          types.ProductCockroachDB,
+		},
 	}
 
 	if err := retry.Retry(ctx, func(ctx context.Context) error {
@@ -117,8 +119,10 @@ func OpenPgxAsTarget(
 	}()
 
 	ret := &types.TargetPool{
-		ConnectionString: connectString,
-		DB:               db,
+		DB: db,
+		PoolInfo: types.PoolInfo{
+			ConnectionString: connectString,
+		},
 	}
 
 	if err := retry.Retry(ctx, func(ctx context.Context) error {


### PR DESCRIPTION
This PR separates test code that depends on a "source" database from the
existing target database. In the past, the source, staging, and target database
were all the same CockroachDB instance, so there was never a need to make this
distinction in the test code. This change enables non-CockroachDB targets to be
tested.

The source, staging, and target setup in this PR would also allow us to move
cdc-sink in a direction where we test against older versions of CockroachDB as
a source, but we only verify that the staging and target behaviors work on more
recent versions.

Summary of changes:
- `sinktest.base` looks for three environment variables to determine what
  database(s) to connect to.
- Each of source, staging, and test have distinct table schemas for each test.
  These are available through new injection types, `sinktest.SourceSchema` and
  `sinktest.TargetSchema`. The `TestDB` injection point is removed.
- `types.StagingDB` is renamed to `StagingSchema` for consistency.
- `types.SourcePool` is added for tests, but it could be used if we add the
  proposed S4 (stupid, simple SELECT *) frontend.
- The Fixture.CreateTable method is bifurcated into CreateSourceTable and
  CreateTargetTable. These return types that are parameterized with their
  pool-ness, so the typesystem gives us a hand in avoiding cases where we might
  cross the streams.
- The Golang workflow adds a test-matrix entry to test completely separated
  source, staging, and target databases. The docker container logs are also
  captured, as this was necessary to troubleshoot some startup issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/404)
<!-- Reviewable:end -->
