### PR TITLE
cmap: Add utility for canonicalized mappings

### DIFF
--- a/internal/util/cmap/cmap.go
+++ b/internal/util/cmap/cmap.go
@@ -1,0 +1,160 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cmap contains an implementation of a canonicalizing map.
+package cmap
+
+// An Entry in a Map. Note that the Key type is not necessarily
+// comparable.
+type Entry[K, V any] struct {
+	Key   K
+	Value V
+}
+
+// A Mapper provider a canonical mapping from an arbitrary type to a
+// comparable value.
+type Mapper[K, C any] func(K) C
+
+// The Map type uses a canonical representation of a key when storing or
+// retrieving values. This allows key types which are not comparable
+// to be used.
+//
+// A Map is not internally synchronized.
+type Map[K any, V any] interface {
+	// CopyInto populates the destination with the contents of the map.
+	CopyInto(dest Map[K, V])
+
+	// Delete removes a key from the map.
+	Delete(key K)
+
+	// Entries returns the entries of the map as a slice. Note that
+	// the iteration order is not stable.
+	Entries() []Entry[K, V]
+
+	// Get returns the value associated with the canonical form of the
+	// key.
+	Get(key K) (_ V, ok bool)
+
+	// GetZero returns the value associated with the canonical form of
+	// the key or returns a zero value.
+	GetZero(key K) V
+
+	// Len returns the number of entries in the Map.
+	Len() int
+
+	// Match is similar to Get, except that it returns the original key
+	// used to insert the entry. This can be used by callers to
+	// determine if the requested and original keys are an exact match.
+	Match(key K) (_ K, _ V, ok bool)
+
+	// Put adds a new mapping. Any error returned by the Mapper will be
+	// returned.
+	Put(key K, value V)
+
+	// Range invokes the callback for each entry in the Map. Range will
+	// stop at the first error returned by the callback. If the callback
+	// never returns an error, neither will Range.
+	Range(func(k K, v V) error) error
+}
+
+// New constructs a canonicalizing Map. The K type must implement
+// TextKey if the MarshalJSON or UnmarshalJSON methods are to be called.
+func New[K any, C comparable, V any](mapper Mapper[K, C]) Map[K, V] {
+	return &impl[K, C, V]{
+		data:   make(map[C]*Entry[K, V]),
+		mapper: mapper,
+	}
+}
+
+// NewOf is a helper for testing. It requires an even number of varargs
+// of alternating key and value types. This function will panic, so it
+// is not suitable for production code.
+func NewOf[K any, C comparable, V any](mapper Mapper[K, C], args ...any) Map[K, V] {
+	if len(args)%2 != 0 {
+		panic("expecting an even number of arguments")
+	}
+	ret := New[K, C, V](mapper)
+	for i := 0; i < len(args); i += 2 {
+		ret.Put(args[i].(K), args[i+1].(V))
+	}
+	return ret
+}
+
+// impl is not exported, since the C type isn't relevant to callers.
+type impl[K any, C comparable, V any] struct {
+	data   map[C]*Entry[K, V]
+	mapper Mapper[K, C]
+}
+
+func (m *impl[K, C, V]) CopyInto(dest Map[K, V]) {
+	_ = m.Range(func(k K, v V) error {
+		dest.Put(k, v)
+		return nil
+	})
+}
+
+func (m *impl[K, C, V]) Delete(key K) {
+	c := m.mapper(key)
+	delete(m.data, c)
+}
+
+func (m *impl[K, C, V]) Entries() []Entry[K, V] {
+	ret := make([]Entry[K, V], 0, len(m.data))
+	for _, entry := range m.data {
+		ret = append(ret, *entry)
+	}
+	return ret
+}
+
+func (m *impl[K, C, V]) Get(key K) (_ V, ok bool) {
+	_, v, ok := m.Match(key)
+	return v, ok
+}
+
+func (m *impl[K, C, V]) GetZero(key K) V {
+	v, _ := m.Get(key)
+	return v
+}
+
+func (m *impl[K, C, V]) Match(key K) (_ K, _ V, ok bool) {
+	c := m.mapper(key)
+	entry, ok := m.data[c]
+	if !ok {
+		return *new(K), *new(V), false
+	}
+	return entry.Key, entry.Value, true
+}
+
+func (m *impl[K, C, V]) Len() int {
+	return len(m.data)
+}
+
+func (m *impl[K, C, V]) Put(key K, value V) {
+	c := m.mapper(key)
+	m.data[c] = &Entry[K, V]{
+		Key:   key,
+		Value: value,
+	}
+}
+
+func (m *impl[K, C, V]) Range(fn func(K, V) error) error {
+	for _, entry := range m.data {
+		if err := fn(entry.Key, entry.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/util/cmap/cmap_test.go
+++ b/internal/util/cmap/cmap_test.go
@@ -1,0 +1,123 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmap
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMap(t *testing.T) {
+	r := require.New(t)
+
+	mapper := func(s string) int {
+		ret, err := strconv.Atoi(s)
+		if err != nil {
+			panic(err)
+		}
+		return ret
+	}
+
+	m := New[string, int, rune](mapper)
+
+	// Check empty state.
+	r.Equal(0, m.Len())
+	found, ok := m.Get("0")
+	r.False(ok)
+	r.Zero(found)
+
+	m.Put("1", '1')
+	m.Put("2", '2')
+	m.Put("3", '3')
+	r.Equal(3, m.Len())
+
+	found = m.GetZero("0")
+	r.Zero(found)
+
+	found, ok = m.Get("0")
+	r.False(ok)
+	r.Zero(found)
+
+	// Basic lookups.
+	found = m.GetZero("1")
+	r.Equal('1', found)
+
+	found, ok = m.Get("1")
+	r.True(ok)
+	r.Equal('1', found)
+
+	found, ok = m.Get("2")
+	r.True(ok)
+	r.Equal('2', found)
+
+	found, ok = m.Get("2")
+	r.True(ok)
+	r.Equal('2', found)
+
+	// Exact match.
+	key, found, ok := m.Match("1")
+	r.Equal("1", key)
+	r.True(ok)
+	r.Equal('1', found)
+
+	// Canonicalized match.
+	key, found, ok = m.Match("01")
+	r.Equal("1", key)
+	r.True(ok)
+	r.Equal('1', found)
+
+	// Canonical replacement.
+	m.Put("001", 'R')
+	r.Equal(3, m.Len())
+	key, found, ok = m.Match("01")
+	r.Equal("001", key)
+	r.True(ok)
+	r.Equal('R', found)
+
+	count := 0
+	r.NoError(m.Range(func(s string, r rune) error {
+		count++
+		return nil
+	}))
+	r.Equal(3, count)
+
+	cpy := New[string, int, rune](mapper)
+	m.CopyInto(cpy)
+	r.Equal(m.Len(), cpy.Len())
+
+	// Entries is not stable, since we don't require the C type to be
+	// ordered.
+	entries := m.Entries()
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Key < entries[j].Key
+	})
+	r.Equal([]Entry[string, rune]{
+		{"001", 'R'},
+		{"2", '2'},
+		{"3", '3'},
+	}, entries)
+
+	// Verify delete.
+	m.Delete("00000001")
+	key, found, ok = m.Match("01")
+	r.Zero(key)
+	r.Zero(found)
+	r.False(ok)
+}

--- a/internal/util/cmap/equal.go
+++ b/internal/util/cmap/equal.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmap
+
+import "github.com/pkg/errors"
+
+var errStop = errors.New("sentinel")
+
+// Comparator returns a comparator for comparable types.
+func Comparator[C comparable]() func(C, C) bool {
+	return func(a C, b C) bool {
+		return a == b
+	}
+}
+
+// Equal returns true if the two maps have an identical canonical keyset
+// and the comparator function returns true for each pairwise key-value
+// mapping between the two maps.
+func Equal[K, V any](a, b Map[K, V], comparator func(V, V) bool) bool {
+	// Nil-nil or identity case
+	if a == b {
+		return true
+	}
+	// XOR
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a.Len() != b.Len() {
+		return false
+	}
+
+	ret := true
+	_ = a.Range(func(aK K, aV V) error {
+		bV, ok := b.Get(aK)
+		if !ok {
+			ret = false
+			return errStop
+		}
+		if !comparator(aV, bV) {
+			ret = false
+			return errStop
+		}
+		return nil
+	})
+
+	return ret
+}

--- a/internal/util/cmap/equal_test.go
+++ b/internal/util/cmap/equal_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqual(t *testing.T) {
+	mapper := Mapper[string, string](strings.ToLower)
+
+	tcs := []struct {
+		a        Map[string, rune]
+		b        Map[string, rune]
+		expected bool
+	}{
+		{
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			a:        NewOf[string, string, rune](mapper, "a", 'a'),
+			b:        nil,
+			expected: false,
+		},
+		{
+			a:        nil,
+			b:        NewOf[string, string, rune](mapper, "a", 'a'),
+			expected: false,
+		},
+		{
+			a:        NewOf[string, string, rune](mapper, "a", 'a'),
+			b:        NewOf[string, string, rune](mapper, "a", 'a'),
+			expected: true,
+		},
+		{
+			a:        NewOf[string, string, rune](mapper, "a", 'a'),
+			b:        NewOf[string, string, rune](mapper, "a", 'a', "b", 'b'),
+			expected: false,
+		},
+		{
+			a:        NewOf[string, string, rune](mapper, "a", 'a'),
+			b:        NewOf[string, string, rune](mapper, "b", 'b'),
+			expected: false,
+		},
+		{
+			a:        NewOf[string, string, rune](mapper, "a", 'a'),
+			b:        NewOf[string, string, rune](mapper, "A", 'a'),
+			expected: true,
+		},
+		{
+			a:        NewOf[string, string, rune](mapper, "a", 'a'),
+			b:        NewOf[string, string, rune](mapper, "A", 'b'),
+			expected: false,
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			result := Equal(tc.a, tc.b, func(a, b rune) bool {
+				return a == b
+			})
+			assert.Equal(t, result, tc.expected)
+		})
+	}
+}

--- a/internal/util/cmap/identity.go
+++ b/internal/util/cmap/identity.go
@@ -1,0 +1,87 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmap
+
+import "encoding/json"
+
+// NewIdentity returns a Map for comparable keys. A basic map type is
+// recommended unless compatibility with the Map interface is necessary.
+func NewIdentity[K comparable, V any]() Map[K, V] {
+	return make(identity[K, V])
+}
+
+type identity[K comparable, V any] map[K]V
+
+func (m identity[K, V]) CopyInto(dest Map[K, V]) {
+	for k, v := range m {
+		dest.Put(k, v)
+	}
+}
+
+func (m identity[K, V]) Delete(key K) {
+	delete(m, key)
+}
+
+func (m identity[K, V]) Entries() []Entry[K, V] {
+	ret := make([]Entry[K, V], 0, len(m))
+	for k, v := range m {
+		ret = append(ret, Entry[K, V]{k, v})
+	}
+	return ret
+}
+
+func (m identity[K, V]) Get(key K) (_ V, ok bool) {
+	ret, ok := m[key]
+	return ret, ok
+}
+
+func (m identity[K, V]) GetZero(key K) V {
+	return m[key]
+}
+
+func (m identity[K, V]) Len() int {
+	return len(m)
+}
+
+func (m identity[K, V]) Match(key K) (_ K, _ V, ok bool) {
+	ret, ok := m[key]
+	if ok {
+		return key, ret, true
+	}
+	return *new(K), *new(V), false
+}
+
+func (m identity[K, V]) Put(key K, value V) {
+	m[key] = value
+}
+
+func (m identity[K, V]) Range(fn func(K, V) error) error {
+	for k, v := range m {
+		if err := fn(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m identity[K, V]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+func (m identity[K, V]) UnmarshalJSON(buf []byte) error {
+	return json.Unmarshal(buf, &m)
+}

--- a/internal/util/cmap/identity_test.go
+++ b/internal/util/cmap/identity_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentity(t *testing.T) {
+	r := require.New(t)
+	m := NewIdentity[string, rune]()
+
+	// Check empty state.
+	r.Equal(0, m.Len())
+	found, ok := m.Get("0")
+	r.False(ok)
+	r.Zero(found)
+
+	m.Put("1", '1')
+	m.Put("2", '2')
+	m.Put("3", '3')
+	r.Equal(3, m.Len())
+
+	found = m.GetZero("0")
+	r.Zero(found)
+
+	found, ok = m.Get("0")
+	r.False(ok)
+	r.Zero(found)
+
+	// Basic lookups.
+	found = m.GetZero("1")
+	r.Equal('1', found)
+
+	found, ok = m.Get("1")
+	r.True(ok)
+	r.Equal('1', found)
+
+	found, ok = m.Get("2")
+	r.True(ok)
+	r.Equal('2', found)
+
+	found, ok = m.Get("2")
+	r.True(ok)
+	r.Equal('2', found)
+
+	// Exact match.
+	key, found, ok := m.Match("1")
+	r.Equal("1", key)
+	r.True(ok)
+	r.Equal('1', found)
+
+	// We dont except a non-exact match to succeed.
+	_, _, ok = m.Match("01")
+	r.False(ok)
+
+	count := 0
+	r.NoError(m.Range(func(s string, r rune) error {
+		count++
+		return nil
+	}))
+	r.Equal(3, count)
+
+	cpy := NewIdentity[string, rune]()
+	m.CopyInto(cpy)
+	r.Equal(m.Len(), cpy.Len())
+
+	// Verify delete.
+	m.Delete("1")
+	key, found, ok = m.Match("1")
+	r.Zero(key)
+	r.Zero(found)
+	r.False(ok)
+}


### PR DESCRIPTION
This package contains a Map implementation where the keys aren't required to be comparable.  Instead, the Map has a mapper function which converts a key into a comparable representation that is used to locate a value.

The motivation for this change is to readily support case-preserving, but case-insentivite identifier mappings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/417)
<!-- Reviewable:end -->
