### PR TITLE
ident: Make identifiers case-preserving, case-insensitive

### DIFF
--- a/internal/sinktest/jumble.go
+++ b/internal/sinktest/jumble.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sinktest
+
+import (
+	"math/rand"
+	"strings"
+	"unicode"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// JumbleIdent returns a case-jumbled version of the Ident.
+func JumbleIdent(id ident.Ident) ident.Ident {
+	var sb strings.Builder
+	for _, r := range id.Raw() {
+		if rand.Float32() < 0.5 {
+			r = unicode.SimpleFold(r) // Replace with another case.
+		}
+		sb.WriteRune(r)
+	}
+	return ident.New(sb.String())
+}
+
+// JumbleSchema returns a case-jumbled version of the Schema.
+func JumbleSchema(sch ident.Schema) ident.Schema {
+	parts := sch.Idents(nil)
+	for i, part := range parts {
+		parts[i] = JumbleIdent(part)
+	}
+	ret, err := ident.NewSchema(parts...)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// JumbleTable returns a case-jumbled version of the Table.
+func JumbleTable(tbl ident.Table) ident.Table {
+	return ident.NewTable(JumbleSchema(tbl.Schema()), JumbleIdent(tbl.Table()))
+}

--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -67,7 +67,7 @@ func ProvideResolvers(
 		stagers:   stagers,
 		watchers:  watchers,
 	}
-	ret.mu.instances = make(map[ident.Schema]*resolver)
+	ret.mu.instances = &ident.SchemaMap[*resolver]{}
 
 	// Resume from previous state.
 	schemas, err := ScanForTargetSchemas(ctx, pool, ret.metaTable)

--- a/internal/source/cdc/request.go
+++ b/internal/source/cdc/request.go
@@ -62,7 +62,7 @@ type request struct {
 	leaf    func(ctx context.Context, req *request) error
 	// keys contains all the columns that make up the primary key
 	// for the target table and their ordinal position within the key.
-	keys      map[ident.Ident]int
+	keys      *ident.Map[int]
 	target    ident.Schematic
 	timestamp hlc.Time
 }

--- a/internal/source/cdc/webhook_query.go
+++ b/internal/source/cdc/webhook_query.go
@@ -64,7 +64,7 @@ func (h *Handler) webhookForQuery(ctx context.Context, req *request) error {
 	}
 	// Aggregate the mutations by target table. We know that the default
 	// batch size for webhooks is reasonable.
-	toProcess := make(map[ident.Table][]types.Mutation)
+	toProcess := &ident.TableMap[[]types.Mutation]{}
 	for _, payload := range message.Payload {
 		qp := queryPayload{
 			keys: keys,
@@ -77,7 +77,7 @@ func (h *Handler) webhookForQuery(ctx context.Context, req *request) error {
 		if err != nil {
 			return err
 		}
-		toProcess[table] = append(toProcess[table], mut)
+		toProcess.Put(table, append(toProcess.GetZero(table), mut))
 	}
 	return h.processMutations(ctx, toProcess)
 }

--- a/internal/source/fslogical/fslogical.go
+++ b/internal/source/fslogical/fslogical.go
@@ -39,20 +39,20 @@ import (
 
 // Dialect reads data from Google Cloud Firestore.
 type Dialect struct {
-	backfillBatchSize int                      // Limit backfill query response size.
-	docIDProperty     string                   // Added to mutation properties.
-	fs                *firestore.Client        // Access to Firestore.
-	idempotent        bool                     // Detect reprocessing the same document.
-	loops             *logical.Factory         // Support dynamic nested collections.
-	memo              types.Memo               // Durable logging of processed doc ids.
-	pool              *types.StagingPool       // Database access.
-	query             firestore.Query          // The base query build from.
-	recurse           bool                     // Scan for dynamic, nested collections.
-	recurseFilter     map[ident.Ident]struct{} // Ignore nested collections with these names.
-	sourceCollection  ident.Ident              // Identifies the loop to the user-script.
-	sourcePath        string                   // The source collection path, for logging.
-	tombstones        *Tombstones              // Filters already-deleted ids.
-	updatedAtProperty ident.Ident              // Order-by property in queries.
+	backfillBatchSize int                  // Limit backfill query response size.
+	docIDProperty     string               // Added to mutation properties.
+	fs                *firestore.Client    // Access to Firestore.
+	idempotent        bool                 // Detect reprocessing the same document.
+	loops             *logical.Factory     // Support dynamic nested collections.
+	memo              types.Memo           // Durable logging of processed doc ids.
+	pool              *types.StagingPool   // Database access.
+	query             firestore.Query      // The base query build from.
+	recurse           bool                 // Scan for dynamic, nested collections.
+	recurseFilter     *ident.Map[struct{}] // Ignore nested collections with these names.
+	sourceCollection  ident.Ident          // Identifies the loop to the user-script.
+	sourcePath        string               // The source collection path, for logging.
+	tombstones        *Tombstones          // Filters already-deleted ids.
+	updatedAtProperty ident.Ident          // Order-by property in queries.
 }
 
 var (
@@ -529,7 +529,7 @@ func (d *Dialect) doRecurse(
 			return errors.Wrapf(err, "loading dynamic collections of %s", doc.Path)
 		}
 
-		if _, skip := d.recurseFilter[ident.New(coll.ID)]; skip {
+		if _, skip := d.recurseFilter.Get(ident.New(coll.ID)); skip {
 			continue
 		}
 

--- a/internal/source/fslogical/provider.go
+++ b/internal/source/fslogical/provider.go
@@ -65,17 +65,17 @@ func ProvideLoops(
 	}
 
 	idx := 0
-	ret := make([]*logical.Loop, len(userscript.Sources))
-	recurseFilter := make(map[ident.Ident]struct{})
+	ret := make([]*logical.Loop, userscript.Sources.Len())
+	recurseFilter := &ident.Map[struct{}]{}
 
-	for sourceName, source := range userscript.Sources {
+	err := userscript.Sources.Range(func(sourceName ident.Ident, source *script.Source) error {
 		var sourcePath string
 		var q firestore.Query
 		if r := sourceName.Raw(); strings.HasPrefix(r, GroupPrefix) {
 			sourcePath = r
 			tail := r[len(GroupPrefix):]
 			q = fs.CollectionGroup(tail).Query
-			recurseFilter[ident.New(tail)] = struct{}{}
+			recurseFilter.Put(ident.New(tail), struct{}{})
 		} else {
 			coll := fs.Collection(r)
 			sourcePath = coll.Path
@@ -100,10 +100,15 @@ func ProvideLoops(
 			updatedAtProperty: cfg.UpdatedAtProperty,
 		}, logical.WithName(sourceName.Raw()))
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
 		idx++
 		log.Infof("started firestore loop %s", sourceName)
+		return nil
+	})
+	if err != nil {
+		loops.Close()
+		return nil, nil, err
 	}
 
 	return ret, loops.Close, nil
@@ -162,9 +167,12 @@ func ProvideTombstones(
 	}
 
 	ret.coll = fs.Collection(cfg.TombstoneCollection)
-	ret.deletesTo = make(map[ident.Ident]ident.Table, len(userscript.Sources))
-	for source, dest := range userscript.Sources {
-		ret.deletesTo[source] = dest.DeletesTo
+	ret.deletesTo = &ident.Map[ident.Table]{}
+	if err := userscript.Sources.Range(func(source ident.Ident, dest *script.Source) error {
+		ret.deletesTo.Put(source, dest.DeletesTo)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	ret.source = ident.New(cfg.TombstoneCollection)
 	ret.mu.cache = &lru.Cache{MaxEntries: 1_000_000}

--- a/internal/source/fslogical/tombstones.go
+++ b/internal/source/fslogical/tombstones.go
@@ -72,8 +72,8 @@ type (
 type Tombstones struct {
 	cfg       *Config
 	coll      *firestore.CollectionRef
-	deletesTo map[ident.Ident]ident.Table // Collection names to target tables.
-	source    ident.Ident                 // The collection name; passed to Events.OnData.
+	deletesTo *ident.Map[ident.Table] // Collection names to target tables.
+	source    ident.Ident             // The collection name; passed to Events.OnData.
 
 	mu struct {
 		sync.RWMutex
@@ -206,7 +206,7 @@ func (t *Tombstones) Process(
 		}
 
 		for _, elt := range evt.elts {
-			tbl, ok := t.deletesTo[ident.New(elt.collection)]
+			tbl, ok := t.deletesTo.Get(ident.New(elt.collection))
 			if !ok {
 				if t.cfg.TombstoneIgnoreUnmapped {
 					log.WithFields(log.Fields{

--- a/internal/source/logical/factory.go
+++ b/internal/source/logical/factory.go
@@ -146,7 +146,7 @@ func (f *Factory) newLoop(ctx context.Context, config *BaseConfig, dialect Diale
 	}
 
 	// Apply logic and configurations defined by the user-script.
-	if len(f.userscript.Sources) > 0 || len(f.userscript.Targets) > 0 {
+	if f.userscript.Sources.Len() > 0 || f.userscript.Targets.Len() > 0 {
 		loop.events.fan = &scriptEvents{
 			Events: loop.events.fan,
 			Script: f.userscript,

--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -48,7 +48,7 @@ import (
 // status updates.
 type conn struct {
 	// Columns, as ordered by the source database.
-	columns map[ident.Table][]types.ColData
+	columns *ident.TableMap[[]types.ColData]
 	// Flavor is one of the mysql.MySQLFlavor or mysql.MariaDBFlavor constants
 	flavor string
 	// Map source ids to target tables.
@@ -294,7 +294,7 @@ func (c *conn) onDataTuple(
 		log.Tracef("Skipping update on %s because it is not in the target schema", tbl)
 		return nil
 	}
-	targetCols, ok := c.columns[tbl]
+	targetCols, ok := c.columns.Get(tbl)
 	if !ok {
 		return errors.Errorf("no column data for %s", tbl)
 	}
@@ -377,7 +377,7 @@ func (c *conn) onRelation(msg *replication.TableMapEvent) error {
 			Type:    ctype,
 		}
 	}
-	c.columns[tbl] = colData
+	c.columns.Put(tbl, colData)
 	return nil
 }
 

--- a/internal/source/mylogical/provider.go
+++ b/internal/source/mylogical/provider.go
@@ -49,7 +49,7 @@ func ProvideDialect(config *Config) (logical.Dialect, error) {
 		TLSConfig: config.tlsConfig,
 	}
 	return &conn{
-		columns:      make(map[ident.Table][]types.ColData),
+		columns:      &ident.TableMap[[]types.ColData]{},
 		flavor:       flavor,
 		relations:    make(map[uint64]ident.Table),
 		sourceConfig: cfg,

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -57,7 +57,7 @@ func (s lsnStamp) Less(other stamp.Stamp) bool { return s.LSN < other.(lsnStamp)
 // status updates.
 type conn struct {
 	// Columns, as ordered by the source database.
-	columns map[ident.Table][]types.ColData
+	columns *ident.TableMap[[]types.ColData]
 	// The pg publication name to subscribe to.
 	publicationName string
 	// Map source ids to target tables.
@@ -256,7 +256,7 @@ func (c *conn) decodeMutation(
 	var mut types.Mutation
 	var key []string
 	enc := make(map[string]any)
-	targetCols, ok := c.columns[tbl]
+	targetCols, ok := c.columns.Get(tbl)
 	if !ok {
 		return mut, errors.Errorf("no column data for %s", tbl)
 	}
@@ -348,7 +348,7 @@ func (c *conn) onRelation(msg *pglogrepl.RelationMessage, targetDB ident.Schema)
 			Type: fmt.Sprintf("%d", col.DataType),
 		}
 	}
-	c.columns[tbl] = colNames
+	c.columns.Put(tbl, colNames)
 
 	log.WithFields(log.Fields{
 		"Columns":    colNames,

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -85,7 +85,7 @@ func ProvideDialect(ctx context.Context, config *Config) (logical.Dialect, error
 	sourceConfig.RuntimeParams["replication"] = "database"
 
 	return &conn{
-		columns:         make(map[ident.Table][]types.ColData),
+		columns:         &ident.TableMap[[]types.ColData]{},
 		publicationName: config.Publication,
 		relations:       make(map[uint32]ident.Table),
 		slotName:        config.Slot,

--- a/internal/staging/applycfg/conf.go
+++ b/internal/staging/applycfg/conf.go
@@ -19,7 +19,7 @@ package applycfg
 import (
 	"time"
 
-	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/cmap"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 )
 
@@ -31,27 +31,31 @@ const SubstitutionToken = "$0"
 type (
 	// SourceColumn is the name of a column found in incoming data.
 	SourceColumn = ident.Ident
+	// SourceColumns is the names of columns found in the source database.
+	SourceColumns = ident.Idents
 	// TargetColumn is the name of a column found in the target database.
 	TargetColumn = ident.Ident
+	// TargetColumns is the names of columns found in the target database.
+	TargetColumns = ident.Idents
 )
 
 // A Config contains per-target-table configuration.
 type Config struct {
-	CASColumns  []TargetColumn                 // The columns for compare-and-set operations.
-	Deadlines   map[TargetColumn]time.Duration // Deadline-based operation.
-	Exprs       map[TargetColumn]string        // Synthetic or replacement SQL expressions.
-	Extras      TargetColumn                   // JSONB column to store unmapped values in.
-	Ignore      map[TargetColumn]bool          // Source column names to ignore.
-	SourceNames map[TargetColumn]SourceColumn  // Look for alternate name in the incoming data.
+	CASColumns  TargetColumns             // The columns for compare-and-set operations.
+	Deadlines   *ident.Map[time.Duration] // Deadline-based operation.
+	Exprs       *ident.Map[string]        // Synthetic or replacement SQL expressions.
+	Extras      TargetColumn              // JSONB column to store unmapped values in.
+	Ignore      *ident.Map[bool]          // Source column names to ignore.
+	SourceNames *ident.Map[SourceColumn]  // Look for alternate name in the incoming data.
 }
 
 // NewConfig constructs a Config with all map fields populated.
 func NewConfig() *Config {
 	return &Config{
-		Deadlines:   make(types.Deadlines),
-		Exprs:       make(map[TargetColumn]string),
-		Ignore:      make(map[TargetColumn]bool),
-		SourceNames: make(map[TargetColumn]SourceColumn),
+		Deadlines:   &ident.Map[time.Duration]{},
+		Exprs:       &ident.Map[string]{},
+		Ignore:      &ident.Map[bool]{},
+		SourceNames: &ident.Map[SourceColumn]{},
 	}
 }
 
@@ -60,30 +64,56 @@ func (t *Config) Copy() *Config {
 	ret := NewConfig()
 
 	ret.CASColumns = append(ret.CASColumns, t.CASColumns...)
-	for k, v := range t.Deadlines {
-		ret.Deadlines[k] = v
-	}
-	for k, v := range t.Exprs {
-		ret.Exprs[k] = v
-	}
+	t.Deadlines.CopyInto(ret.Deadlines)
+	t.Exprs.CopyInto(ret.Exprs)
 	ret.Extras = t.Extras
-	for k, v := range t.Ignore {
-		ret.Ignore[k] = v
-	}
-	for k, v := range t.SourceNames {
-		ret.SourceNames[k] = v
-	}
+	t.Ignore.CopyInto(ret.Ignore)
+	t.SourceNames.CopyInto(ret.SourceNames)
 
 	return ret
+}
+
+// Equal returns true if the other Config is equivalent to the receiver.
+func (t *Config) Equal(o *Config) bool {
+	return t == o || // Identity or nil-nil.
+		(t != nil) && (o != nil) &&
+			t.CASColumns.Equal(o.CASColumns) &&
+			t.Deadlines.Equal(o.Deadlines, cmap.Comparator[time.Duration]()) &&
+			t.Exprs.Equal(o.Exprs, cmap.Comparator[string]()) &&
+			ident.Equal(t.Extras, o.Extras) &&
+			t.Ignore.Equal(o.Ignore, cmap.Comparator[bool]()) &&
+			t.SourceNames.Equal(o.SourceNames, ident.Comparator[ident.Ident]())
 }
 
 // IsZero returns true if the Config represents the absence of a
 // configuration.
 func (t *Config) IsZero() bool {
 	return len(t.CASColumns) == 0 &&
-		len(t.Deadlines) == 0 &&
-		len(t.Exprs) == 0 &&
+		t.Deadlines.Len() == 0 &&
+		t.Exprs.Len() == 0 &&
 		t.Extras.Empty() &&
-		len(t.Ignore) == 0 &&
-		len(t.SourceNames) == 0
+		t.Ignore.Len() == 0 &&
+		t.SourceNames.Len() == 0
+}
+
+// Patch applies any non-empty fields from another Config to the
+// receiver and returns the receiver.
+func (t *Config) Patch(other *Config) *Config {
+	t.CASColumns = append(t.CASColumns, other.CASColumns...)
+	if other.Deadlines != nil {
+		other.Deadlines.CopyInto(t.Deadlines)
+	}
+	if other.Exprs != nil {
+		other.Exprs.CopyInto(t.Exprs)
+	}
+	if !other.Extras.Empty() {
+		t.Extras = other.Extras
+	}
+	if other.Ignore != nil {
+		other.Ignore.CopyInto(t.Ignore)
+	}
+	if other.SourceNames != nil {
+		other.SourceNames.CopyInto(t.SourceNames)
+	}
+	return t
 }

--- a/internal/staging/applycfg/configs.go
+++ b/internal/staging/applycfg/configs.go
@@ -23,12 +23,12 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"reflect"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/cmap"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -49,7 +49,7 @@ type Configs struct {
 
 	mu struct {
 		sync.RWMutex
-		data    map[ident.Table]*Config
+		data    *ident.TableMap[*Config]
 		updated chan struct{} // Closed and swapped when data is updated.
 	}
 
@@ -65,22 +65,20 @@ type Configs struct {
 func (c *Configs) Get(tbl ident.Table) *Config {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if ret, ok := c.mu.data[tbl]; ok {
+	if ret, ok := c.mu.data.Get(tbl); ok {
 		return ret
 	}
 	return configZero
 }
 
 // GetAll returns a deep copy of all known table configurations.
-func (c *Configs) GetAll() map[ident.Table]*Config {
+func (c *Configs) GetAll() *ident.TableMap[*Config] {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	data := c.mu.data
 
-	ret := make(map[ident.Table]*Config, len(data))
-	for k, v := range data {
-		ret[k] = v.Copy()
-	}
+	ret := &ident.TableMap[*Config]{}
+	data.CopyInto(ret)
 	return ret
 }
 
@@ -130,7 +128,7 @@ func (c *Configs) Refresh(ctx context.Context) (changed bool, _ error) {
 		*Config
 		casMap map[int]SourceColumn
 	}
-	nextConfigs := make(map[ident.Table]*tempConfig)
+	nextConfigs := &ident.TableMap[*tempConfig]{}
 
 	for rows.Next() {
 		var targetSchema, targetTable, targetColumn string
@@ -156,10 +154,10 @@ func (c *Configs) Refresh(ctx context.Context) (changed bool, _ error) {
 		targetTableIdent := ident.NewTable(sch, ident.New(targetTable))
 		targetColIdent := ident.New(targetColumn)
 
-		tableData, found := nextConfigs[targetTableIdent]
+		tableData, found := nextConfigs.Get(targetTableIdent)
 		if !found {
 			tableData = &tempConfig{NewConfig(), make(map[int]SourceColumn)}
-			nextConfigs[targetTableIdent] = tableData
+			nextConfigs.Put(targetTableIdent, tableData)
 		}
 
 		if cas != 0 {
@@ -167,10 +165,10 @@ func (c *Configs) Refresh(ctx context.Context) (changed bool, _ error) {
 			tableData.casMap[cas-1] = targetColIdent
 		}
 		if deadline > 0 {
-			tableData.Deadlines[targetColIdent] = deadline
+			tableData.Deadlines.Put(targetColIdent, deadline)
 		}
 		if expr != "" {
-			tableData.Exprs[targetColIdent] = expr
+			tableData.Exprs.Put(targetColIdent, expr)
 		}
 		if extras {
 			if !tableData.Extras.Empty() {
@@ -181,32 +179,37 @@ func (c *Configs) Refresh(ctx context.Context) (changed bool, _ error) {
 			tableData.Extras = targetColIdent
 		}
 		if ignore {
-			tableData.Ignore[targetColIdent] = true
+			tableData.Ignore.Put(targetColIdent, true)
 		}
 		if rename != "" {
-			tableData.SourceNames[targetColIdent] = ident.New(rename)
+			tableData.SourceNames.Put(targetColIdent, ident.New(rename))
 		}
 
 	}
 
-	finalized := make(map[ident.Table]*Config, len(nextConfigs))
-	for table, data := range nextConfigs {
+	finalized := &ident.TableMap[*Config]{}
+	if err := nextConfigs.Range(func(table ident.Table, data *tempConfig) error {
 		// Ensure that the CAS mappings are sane and create the slice.
-		data.CASColumns = make([]SourceColumn, len(data.casMap))
+		data.CASColumns = make(SourceColumns, len(data.casMap))
 		for idx := range data.CASColumns {
 			colName, found := data.casMap[idx]
 			if !found {
-				return false, errors.Errorf("%s: gap in CAS columns at index %d", table, idx)
+				return errors.Errorf("%s: gap in CAS columns at index %d", table, idx)
 			}
 			data.CASColumns[idx] = colName
 		}
-		finalized[table] = data.Config
+		finalized.Put(table, data.Config)
+		return nil
+	}); err != nil {
+		return false, err
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if reflect.DeepEqual(c.mu.data, finalized) {
+	if cmap.Equal[ident.Table, *Config](c.mu.data, finalized, func(a, b *Config) bool {
+		return a.Equal(b)
+	}) {
 		return false, nil
 	}
 
@@ -247,6 +250,7 @@ func (c *Configs) refreshLoop(ctx context.Context) {
 func (c *Configs) Store(
 	ctx context.Context, tx types.StagingQuerier, table ident.Table, cfg *Config,
 ) error {
+	table = table.Canonical()
 	// Delete existing configuration data for the table.
 	if _, err := tx.Exec(ctx,
 		c.sql.delete,
@@ -262,62 +266,64 @@ func (c *Configs) Store(
 	}
 
 	// Collect all referenced source columns.
-	casIdx := make(map[SourceColumn]int)
-	refs := make(map[SourceColumn]struct{})
+	var casIdx ident.Map[int]
+	var refs ident.Map[struct{}]
 	for idx, col := range cfg.CASColumns {
-		refs[col] = struct{}{}
-		casIdx[col] = idx + 1 // Store one-based values.
+		refs.Put(col, struct{}{})
+		casIdx.Put(col, idx+1) // Store one-based values.
 	}
-	for col, val := range cfg.Deadlines {
+	_ = cfg.Deadlines.Range(func(col ident.Ident, val time.Duration) error {
 		if val > 0 {
-			refs[col] = struct{}{}
+			refs.Put(col, struct{}{})
 		}
-	}
-	for col, val := range cfg.Exprs {
+		return nil
+	})
+	_ = cfg.Exprs.Range(func(col ident.Ident, val string) error {
 		if val != "" {
-			refs[col] = struct{}{}
+			refs.Put(col, struct{}{})
 		}
-	}
+		return nil
+	})
 	if !cfg.Extras.Empty() {
-		refs[cfg.Extras] = struct{}{}
+		refs.Put(cfg.Extras, struct{}{})
 	}
-	for col, val := range cfg.Ignore {
+	_ = cfg.Ignore.Range(func(col ident.Ident, val bool) error {
 		if val {
-			refs[col] = struct{}{}
+			refs.Put(col, struct{}{})
 		}
-	}
-	for col, val := range cfg.SourceNames {
+		return nil
+	})
+	_ = cfg.SourceNames.Range(func(col ident.Ident, val SourceColumn) error {
 		if !val.Empty() {
-			refs[col] = struct{}{}
+			refs.Put(col, struct{}{})
 		}
-	}
+		return nil
+	})
 
 	// Insert relevant data for each referenced column. We rely on the
 	// zero values returned from map lookup misses.
-	for col := range refs {
-		if _, err := tx.Exec(ctx,
+	return refs.Range(func(col ident.Ident, _ struct{}) error {
+		_, err := tx.Exec(ctx,
 			c.sql.upsert,
 			table.Schema().Raw(),
 			table.Table().Raw(),
 			col.Raw(),
-			casIdx[col],
-			cfg.Deadlines[col],
-			cfg.Exprs[col],
-			cfg.Extras == col,
-			cfg.Ignore[col],
-			cfg.SourceNames[col].Raw(),
-		); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-
-	return nil
+			casIdx.GetZero(col),
+			cfg.Deadlines.GetZero(col),
+			cfg.Exprs.GetZero(col),
+			ident.Equal(cfg.Extras, col),
+			cfg.Ignore.GetZero(col),
+			cfg.SourceNames.GetZero(col).Raw(),
+		)
+		return errors.WithStack(err)
+	})
 }
 
 // Watch returns a channel that will emit updated Config information.
 // The cancel function should be called when the consumer is no longer
 // interested in updates.
 func (c *Configs) Watch(tbl ident.Table) (ch <-chan *Config, cancel func()) {
+	tbl = tbl.Canonical()
 	ret := make(chan *Config)
 
 	// See discussion in c.watchCtx for why this isn't Background().
@@ -348,7 +354,7 @@ func (c *Configs) waitForUpdate(ctx context.Context, tbl ident.Table, last *Conf
 	// broadcast when the parent watch context has been shut down.
 	for {
 		c.mu.RLock()
-		next, ok := c.mu.data[tbl]
+		next, ok := c.mu.data.Get(tbl)
 		if !ok {
 			next = configZero
 		}
@@ -357,7 +363,7 @@ func (c *Configs) waitForUpdate(ctx context.Context, tbl ident.Table, last *Conf
 
 		// Deep compare the per-table data, since the channel is
 		// replaced whenever any table configuration is refreshed.
-		if next != last && !reflect.DeepEqual(last, next) {
+		if next != last && !last.Equal(next) {
 			return next
 		}
 		last = next

--- a/internal/staging/applycfg/provider.go
+++ b/internal/staging/applycfg/provider.go
@@ -43,7 +43,7 @@ func ProvideConfigs(
 	}
 
 	cfg := &Configs{pool: pool}
-	cfg.mu.data = make(map[ident.Table]*Config)
+	cfg.mu.data = &ident.TableMap[*Config]{}
 	cfg.mu.updated = make(chan struct{})
 	cfg.sql.delete = fmt.Sprintf(deleteConfTemplate, target)
 	cfg.sql.loadAll = fmt.Sprintf(loadConfTemplate, target)

--- a/internal/staging/auth/jwt/jwt.go
+++ b/internal/staging/auth/jwt/jwt.go
@@ -218,7 +218,8 @@ func matches(allowed, requested ident.Schema) bool {
 	requestedParts := requested.Idents(nil)
 
 	for len(allowedParts) > 0 && len(requestedParts) > 0 {
-		partMatches := allowedParts[0] == requestedParts[0] || allowedParts[0] == wildcard
+		partMatches := ident.Equal(allowedParts[0], requestedParts[0]) ||
+			ident.Equal(allowedParts[0], wildcard)
 		if !partMatches {
 			return false
 		}

--- a/internal/staging/leases/leases.go
+++ b/internal/staging/leases/leases.go
@@ -61,7 +61,7 @@ func (c *Config) sanitize() error {
 	if c.Pool == nil {
 		return errors.New("pool must not be nil")
 	}
-	if c.Target == (ident.Table{}) {
+	if c.Target.Empty() {
 		return errors.New("target must be set")
 	}
 	// OK for Guard to be zero.

--- a/internal/staging/stage/provider.go
+++ b/internal/staging/stage/provider.go
@@ -33,6 +33,6 @@ func ProvideFactory(db *types.StagingPool, stagingDB ident.StagingSchema) types.
 		db:        db,
 		stagingDB: stagingDB.Schema(),
 	}
-	f.mu.instances = make(map[ident.Table]*stage)
+	f.mu.instances = &ident.TableMap[*stage]{}
 	return f
 }

--- a/internal/staging/stage/stage.go
+++ b/internal/staging/stage/stage.go
@@ -46,6 +46,7 @@ import (
 // stagingTable returns the staging table name that will store mutations
 // for the given target table.
 func stagingTable(stagingDB ident.Schema, target ident.Table) ident.Table {
+	target = target.Canonical() // Use lower-cased version of the table.
 	mangled := ident.Join(target, ident.Raw, '_')
 	return ident.NewTable(stagingDB, ident.New(mangled))
 }

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -36,7 +36,7 @@ func ProvideFactory(configs *applycfg.Configs, watchers types.Watchers) (types.A
 		configs:  configs,
 		watchers: watchers,
 	}
-	f.mu.instances = make(map[ident.Table]*apply)
+	f.mu.instances = &ident.TableMap[*apply]{}
 	return f, func() {
 		f.mu.Lock()
 		defer f.mu.Unlock()

--- a/internal/target/apply/queries/conditional.tmpl
+++ b/internal/target/apply/queries/conditional.tmpl
@@ -25,13 +25,13 @@ deadlined: filters the incoming data by the deadline columns
 
 deadlined AS (SELECT * from data WHERE ts > now() - '1m'::INTERVAL)
 */ -}}
-{{- if .Deadlines -}}
+{{- $deadlineEntries := .Deadlines.Entries -}}
+{{- if $deadlineEntries -}}
 , {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
 deadlined AS (SELECT * FROM {{ $dataSource }} WHERE
-{{- $andNeeded := false -}} {{- range $dlc, $dli := .Deadlines -}}
-    {{- if $andNeeded -}} AND {{- end -}}
-    ( {{- $dlc -}} >now()-'{{- $dli -}}'::INTERVAL)
-    {{- $andNeeded = true -}}
+{{- range $entryIdx, $entry := $deadlineEntries -}}
+    {{- if $entryIdx -}} AND {{- end -}}
+    ( {{- $entry.Key -}} >now()-'{{- $entry.Value -}}'::INTERVAL)
 {{- end -}})
 {{- $dataSource = "deadlined" -}}
 {{- end -}}

--- a/internal/target/schemawatch/coldata.go
+++ b/internal/target/schemawatch/coldata.go
@@ -32,7 +32,7 @@ func colSliceEqual(a, b []types.ColData) bool {
 		return false
 	}
 	for i := range a {
-		if a[i] != b[i] {
+		if !a[i].Equal(b[i]) {
 			return false
 		}
 	}
@@ -221,7 +221,7 @@ func getColumns(
 			}
 
 			for _, col := range columns {
-				if col.Name != rowID {
+				if !ident.Equal(col.Name, rowID) {
 					next = append(next, col)
 				}
 			}

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -217,7 +217,7 @@ func TestGetColumns(t *testing.T) {
 				}
 			}
 
-			colData, ok := fixture.Watcher.Get().Columns[tableName]
+			colData, ok := fixture.Watcher.Get().Columns.Get(tableName)
 			if !a.Truef(ok, "Snapshot() did not return info for %s", tableName) {
 				return
 			}
@@ -268,11 +268,11 @@ func TestColDataIgnoresViews(t *testing.T) {
 	}
 	viewName := vi.Name()
 
-	colData, ok := fixture.Watcher.Get().Columns[tableName]
+	colData, ok := fixture.Watcher.Get().Columns.Get(tableName)
 	a.True(ok)
 	a.NotNil(colData)
 
-	viewData, ok := fixture.Watcher.Get().Columns[viewName]
+	viewData, ok := fixture.Watcher.Get().Columns.Get(viewName)
 	a.False(ok)
 	a.Nil(viewData)
 }

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -21,16 +21,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWatch(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	// Override the delay to exercise the background goroutine.
 	const delay = time.Second
@@ -38,78 +39,96 @@ func TestWatch(t *testing.T) {
 	defer func() { *schemawatch.RefreshDelay = time.Minute }()
 
 	fixture, cancel, err := all.NewFixture()
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 	defer cancel()
 
 	ctx := fixture.Context
 	dbName := fixture.TargetSchema.Schema()
 	w := fixture.Watcher
 
+	w2, err := fixture.Watchers.Get(ctx, sinktest.JumbleSchema(fixture.TargetSchema.Schema()))
+	r.NoError(err)
+	r.Same(w, w2)
+
 	// Bootstrap column.
 	tblInfo, err := fixture.CreateTargetTable(ctx, "CREATE TABLE %s (pk INT PRIMARY KEY)")
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 
 	ch, cancel, err := w.Watch(tblInfo.Name())
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 	defer cancel()
 
-	select {
-	case <-ctx.Done():
-		a.FailNow("timed out waiting for channel data")
-	case data := <-ch:
-		if a.Len(data, 1) {
-			a.Equal("pk", data[0].Name.Raw())
+	t.Run("smoke", func(t *testing.T) {
+		r := require.New(t)
+
+		select {
+		case <-ctx.Done():
+			r.FailNow("timed out waiting for channel data")
+		case data := <-ch:
+			r.Len(data, 1)
+			r.Equal("pk", data[0].Name.Raw())
 		}
-	}
+	})
+
+	// Check that we can retrieve a jumbled table name.
+	t.Run("jumbled", func(t *testing.T) {
+		r := require.New(t)
+		jumbled := sinktest.JumbleTable(tblInfo.Name())
+
+		ch, cancel, err := w.Watch(jumbled)
+		r.NoError(err)
+		defer cancel()
+
+		select {
+		case <-ctx.Done():
+			r.FailNow("timed out waiting for channel data")
+		case data := <-ch:
+			r.Len(data, 1)
+			r.Equal("pk", data[0].Name.Raw())
+		}
+	})
 
 	// Add a column and expect to see it.
-	switch fixture.TargetPool.Product {
-	case types.ProductCockroachDB, types.ProductPostgreSQL:
-		if !a.NoError(retry.Execute(ctx, fixture.TargetPool,
-			fmt.Sprintf("ALTER TABLE %s ADD COLUMN v STRING", tblInfo.Name()))) {
-			return
+	t.Run("add_column", func(t *testing.T) {
+		r := require.New(t)
+		switch fixture.TargetPool.Product {
+		case types.ProductCockroachDB, types.ProductPostgreSQL:
+			r.NoError(retry.Execute(ctx, fixture.TargetPool,
+				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v STRING", tblInfo.Name())))
+
+		case types.ProductOracle:
+			r.NoError(retry.Execute(ctx, fixture.TargetPool,
+				fmt.Sprintf("ALTER TABLE %s ADD (v INT)", tblInfo.Name())))
+
+		default:
+			r.FailNow("unsupported product")
 		}
 
-	case types.ProductOracle:
-		if !a.NoError(retry.Execute(ctx, fixture.TargetPool,
-			fmt.Sprintf("ALTER TABLE %s ADD (v INT)", tblInfo.Name()))) {
-			return
+		select {
+		case <-ctx.Done():
+			r.FailNow("timed out waiting for channel data")
+		case data := <-ch:
+			r.Len(data, 2)
+			r.Equal("pk", data[0].Name.Raw())
+			r.Equal("v", data[1].Name.Raw())
 		}
-
-	default:
-		a.FailNow("unsupported product")
-	}
-
-	select {
-	case <-ctx.Done():
-		a.FailNow("timed out waiting for channel data")
-	case data := <-ch:
-		if a.Len(data, 2) {
-			a.Equal("pk", data[0].Name.Raw())
-			a.Equal("v", data[1].Name.Raw())
-		}
-	}
+	})
 
 	// Expect the channel to close if the table is dropped.
-	if !a.NoError(tblInfo.DropTable(ctx)) {
-		return
-	}
-	select {
-	case <-ctx.Done():
-		a.FailNow("timed out waiting for channel close")
-	case _, open := <-ch:
-		a.False(open)
-	}
+	t.Run("drop", func(t *testing.T) {
+		r := require.New(t)
+		r.NoError(tblInfo.DropTable(ctx))
+		select {
+		case <-ctx.Done():
+			r.FailNow("timed out waiting for channel close")
+		case _, open := <-ch:
+			r.False(open)
+		}
 
-	// Check that we error out quickly on unknown tables.
-	ch, cancel, err = w.Watch(ident.NewTable(dbName, ident.New("blah")))
-	a.Nil(ch)
-	a.Nil(cancel)
-	a.Error(err)
+		// Check that we error out quickly on unknown tables.
+		ch, cancel, err = w.Watch(ident.NewTable(dbName, ident.New("blah")))
+		r.Nil(ch)
+		r.Nil(cancel)
+		r.Error(err)
+	})
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -55,7 +55,7 @@ type Authenticator interface {
 }
 
 // Deadlines associate a column identifier with a duration.
-type Deadlines map[ident.Ident]time.Duration
+type Deadlines = *ident.Map[time.Duration]
 
 var (
 	// ErrCancelSingleton may be returned by callbacks passed to
@@ -201,9 +201,18 @@ type ColData struct {
 	Type any
 }
 
+// Equal returns true if the two ColData are equivalent under
+// case-insensitivity.
+func (d ColData) Equal(o ColData) bool {
+	return d.Ignored == o.Ignored &&
+		ident.Equal(d.Name, o.Name) &&
+		d.Primary == o.Primary &&
+		d.Type == o.Type
+}
+
 // SchemaData holds SQL schema metadata.
 type SchemaData struct {
-	Columns map[ident.Table][]ColData
+	Columns *ident.TableMap[[]ColData]
 
 	// Order is a two-level slice that represents equivalency-groups
 	// with respect to table foreign-key ordering. That is, if all
@@ -214,6 +223,13 @@ type SchemaData struct {
 	// for deferrable foreign-key constraints:
 	// https://github.com/cockroachdb/cockroach/issues/31632
 	Order [][]ident.Table
+}
+
+// OriginalName returns the name of the table as it is defined in the
+// underlying database.
+func (s *SchemaData) OriginalName(tbl ident.Table) (ident.Table, bool) {
+	ret, _, ok := s.Columns.Match(tbl)
+	return ret, ok
 }
 
 // Product is an enum type to make it easy to switch on the underlying

--- a/internal/util/ident/compare.go
+++ b/internal/util/ident/compare.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ident
+
+import "strings"
+
+// Compare is similar to [strings.Compare]. It returns -1, 0, or 1 if a
+// should sort before, equal to, or after b. Nil or empty values sort
+// before any non-nil, non-empty value.
+func Compare(a, b Identifier) int {
+	// Incrementally consume parts until we see a difference.
+	var aPart, bPart Ident
+	for a != nil && !a.Empty() && b != nil && !b.Empty() {
+		aPart, a = a.Split()
+		bPart, b = b.Split()
+
+		if c := strings.Compare(aPart.Canonical().Raw(), bPart.Canonical().Raw()); c != 0 {
+			return c
+		}
+	}
+	if a == nil || a.Empty() {
+		if b == nil || b.Empty() {
+			return 0
+		}
+		return -1
+	}
+	return 1
+}
+
+// Comparator returns a comparison function.
+func Comparator[I Identifier]() func(I, I) bool {
+	return func(a, b I) bool {
+		return Equal(a, b)
+	}
+}
+
+// Equal returns true if the identifiers are equal without considering
+// case.
+func Equal(a, b Identifier) bool {
+	return Compare(a, b) == 0
+}

--- a/internal/util/ident/compare_test.go
+++ b/internal/util/ident/compare_test.go
@@ -1,0 +1,104 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ident
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompare(t *testing.T) {
+	tcs := []struct {
+		a, b Identifier
+		c    int
+	}{
+		// Zero-case.
+		{
+			a: nil,
+			b: nil,
+			c: 0,
+		},
+		{
+			a: Identifier(nil),
+			b: Identifier(nil),
+			c: 0,
+		},
+		{
+			a: empty,
+			b: empty,
+			c: 0,
+		},
+		{
+			a: nil,
+			b: empty,
+			c: 0,
+		},
+		// Comparison to empty.
+		{
+			a: nil,
+			b: New("foo"),
+			c: -1,
+		},
+		{
+			a: Identifier(nil),
+			b: New("foo"),
+			c: -1,
+		},
+		{
+			a: empty,
+			b: New("foo"),
+			c: -1,
+		},
+		// Lexical ordering.
+		{
+			a: New("bar"),
+			b: New("foo"),
+			c: -1,
+		},
+		// Case-insensitivity.
+		{
+			a: New("foo"),
+			b: New("Foo"),
+			c: 0,
+		},
+		// Multi-part.
+		{
+			a: NewTable(MustSchema(New("db"), Public), New("foo")),
+			b: NewTable(MustSchema(New("DB"), Public), New("FOO")),
+			c: 0,
+		},
+		// Differing lengths.
+		{
+			a: MustSchema(New("db"), Public),
+			b: NewTable(MustSchema(New("DB"), Public), New("FOO")),
+			c: -1,
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			a := assert.New(t)
+			a.Equal(tc.c, Compare(tc.a, tc.b))
+			// Test symmetry.
+			a.Equal(-tc.c, Compare(tc.b, tc.a))
+			// Comparator (and Equal).
+			a.Equal(tc.c == 0, Comparator[Identifier]()(tc.a, tc.b))
+		})
+	}
+}

--- a/internal/util/ident/ident_test.go
+++ b/internal/util/ident/ident_test.go
@@ -19,6 +19,7 @@ package ident
 import (
 	"encoding/json"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,6 +32,7 @@ func TestIdent(t *testing.T) {
 		a.Equal(`""`, id.String())
 		a.Equal("", id.Raw())
 		a.True(id.Empty())
+		a.Equal(id, id.Canonical())
 
 		first, remainder := id.Split()
 		a.True(first.Empty())
@@ -44,6 +46,7 @@ func TestIdent(t *testing.T) {
 		a.Equal(`""`, id.String())
 		a.Equal("", id.Raw())
 		a.True(id.Empty())
+		a.Equal(id, id.Canonical())
 
 		first, remainder := id.Split()
 		a.True(first.Empty())
@@ -57,6 +60,7 @@ func TestIdent(t *testing.T) {
 		a.Equal("table", id.Raw())
 		a.Equal(`"table"`, id.String())
 		a.False(id.Empty())
+		a.Same(id.atom, id.lowered)
 
 		first, remainder := id.Split()
 		a.Equal(id, first)
@@ -69,9 +73,14 @@ func TestIdent(t *testing.T) {
 		id := New("table")
 		id2 := New("table")
 		id3 := New("other")
+		id4 := New("TABLE")
 
 		a.Same(id.atom, id2.atom)
 		a.NotSame(id.atom, id3.atom)
+
+		a.NotSame(id.atom, id4.atom)
+		a.Same(id.atom, id4.lowered)
+		a.Equal(id, id4.Canonical())
 	})
 }
 
@@ -118,4 +127,14 @@ func TestIdentMarshal(t *testing.T) {
 			a.Same(id.atom, id2.atom)
 		})
 	}
+}
+
+func TestIdentSize(t *testing.T) {
+	a := assert.New(t)
+
+	ptrSize := unsafe.Sizeof(uintptr(0))
+	a.Equal(expectedIdentWords, int(unsafe.Sizeof(Ident{})/ptrSize))
+	a.Equal(expectedIdentWords, int(unsafe.Sizeof(Schema{})/ptrSize))
+	a.Equal(expectedIdentWords, int(unsafe.Sizeof(Table{})/ptrSize))
+	a.Equal(expectedIdentWords, int(unsafe.Sizeof(UDT{})/ptrSize))
 }

--- a/internal/util/ident/map.go
+++ b/internal/util/ident/map.go
@@ -1,0 +1,251 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ident
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/cmap"
+	"github.com/pkg/errors"
+)
+
+// Map is a case-insensitive mapping of Ident to values.
+type Map[V any] struct {
+	IdentifierMap[Ident, V]
+}
+
+// MapOf accepts an even number of arguments and constructs a map of
+// identifiers to values. The identifiers may be given as either an
+// Ident or as a string. This function panics if there is invalid input,
+// so its use should be limited to testing.
+func MapOf[V any](args ...any) *Map[V] {
+	if len(args)%2 != 0 {
+		panic("expecting an even number of arguments")
+	}
+	ret := &Map[V]{}
+	for i := 0; i < len(args); i += 2 {
+		var key Ident
+		switch t := args[i].(type) {
+		case Ident:
+			key = t
+		case string:
+			key = New(t)
+		default:
+			panic(fmt.Sprintf("unsupported type %T at index %d", t, i))
+		}
+		ret.Put(key, args[i+1].(V))
+	}
+	return ret
+}
+
+// Equal returns true if the other map is equivalent under identifier
+// case-equivalency. This method exists to reduce the amount of generics
+// syntax needed to call [cmap.Equal].
+func (m *Map[V]) Equal(o *Map[V], comparator func(V, V) bool) bool {
+	return cmap.Equal[Ident, V](m, o, comparator)
+}
+
+// SchemaMap is a case-insensitive mapping of Schema to values.
+type SchemaMap[V any] struct {
+	IdentifierMap[Schema, V]
+}
+
+// TableMap is a case-insensitive mapping of Table to values.
+type TableMap[V any] struct {
+	IdentifierMap[Table, V]
+}
+
+// IdentifierMap implements a case-preserving, but case-insensitive
+// mapping of Identifier instances to values. Prefer using the
+// specialized types instead.
+//
+// Usage notes:
+//   - The zero value of an IdentifierMap is safe to use.
+//   - An IdentifierMap can be serialized to and from a JSON
+//     representation.
+//   - An IdentifierMap is not internally synchronized.
+type IdentifierMap[I Identifier, V any] struct {
+	data cmap.Map[I, V]
+	_    noCopy
+}
+
+var (
+	_ cmap.Map[Identifier, any] = (*IdentifierMap[Identifier, any])(nil)
+	_ json.Marshaler            = (*IdentifierMap[Identifier, any])(nil)
+	_ json.Unmarshaler          = (*IdentifierMap[Identifier, any])(nil)
+)
+
+func (m *IdentifierMap[I, V]) newMap() cmap.Map[I, V] {
+	return cmap.New[I, any, V](func(ident I) any {
+		switch t := Identifier(ident).(type) {
+		case *atom:
+			return t.lowered
+		case *array:
+			return t.lowered
+		case *qualified:
+			return t.lowered
+		case Ident:
+			if t.atom == nil {
+				return (*atom)(nil)
+			}
+			return t.atom.lowered
+		case Schema:
+			if t.array == nil {
+				return (*array)(nil)
+			}
+			return t.array.lowered
+		case Table:
+			if t.qualified == nil {
+				return (*qualified)(nil)
+			}
+			return t.qualified.lowered
+		default:
+			panic(fmt.Sprintf("unimplemented: %T", t))
+		}
+	})
+}
+
+// CopyInto implements cmap.Map.
+func (m *IdentifierMap[I, V]) CopyInto(dest cmap.Map[I, V]) {
+	if m.data != nil {
+		m.data.CopyInto(dest)
+	}
+}
+
+// Delete implements cmap.Map.
+func (m *IdentifierMap[I, V]) Delete(key I) {
+	if m.data != nil {
+		m.data.Delete(key)
+	}
+}
+
+// Entries implements cmap.Map. This will sort the returned slice
+// to ensure stable iteration order.
+func (m *IdentifierMap[I, V]) Entries() []cmap.Entry[I, V] {
+	if m.data != nil {
+		ret := m.data.Entries()
+		sort.Slice(ret, func(i, j int) bool {
+			return Compare(ret[i].Key, ret[j].Key) < 0
+		})
+		return ret
+	}
+	return nil
+}
+
+// Get implements cmap.Map.
+func (m *IdentifierMap[I, V]) Get(key I) (_ V, ok bool) {
+	if m.data != nil {
+		return m.data.Get(key)
+	}
+	return *new(V), false
+}
+
+// GetZero implements cmap.Map.
+func (m *IdentifierMap[I, V]) GetZero(key I) V {
+	if m.data != nil {
+		return m.data.GetZero(key)
+	}
+	return *new(V)
+}
+
+// Len implements cmap.Map.
+func (m *IdentifierMap[I, V]) Len() int {
+	if m.data != nil {
+		return m.data.Len()
+	}
+	return 0
+}
+
+// Match implements cmap.Map.
+func (m *IdentifierMap[I, V]) Match(key I) (_ I, _ V, ok bool) {
+	if m.data != nil {
+		return m.data.Match(key)
+	}
+	return *new(I), *new(V), false
+}
+
+// Put implements cmap.Map
+func (m *IdentifierMap[I, V]) Put(key I, value V) {
+	if m.data == nil {
+		m.data = m.newMap()
+	}
+	m.data.Put(key, value)
+}
+
+// Range implements cmap.Map.
+func (m *IdentifierMap[I, V]) Range(fn func(k I, v V) error) error {
+	if m.data != nil {
+		return m.data.Range(fn)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (m *IdentifierMap[I, V]) MarshalJSON() ([]byte, error) {
+	temp := make(map[string]V)
+	if err := m.Range(func(k I, v V) error {
+		temp[k.Raw()] = v
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return json.Marshal(temp)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (m *IdentifierMap[I, V]) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber() // Preserve large-magnitude JSON numbers.
+	temp := make(map[string]V)
+	if err := dec.Decode(&temp); err != nil {
+		return errors.WithStack(err)
+	}
+
+	next := m.newMap()
+	switch t := (any)(*new(I)).(type) {
+	case Ident:
+		for k, v := range temp {
+			id := New(k)
+			next.Put(Identifier(id).(I), v)
+		}
+
+	case Schema:
+		for k, v := range temp {
+			sch, err := ParseSchema(k)
+			if err != nil {
+				return err
+			}
+			next.Put(Identifier(sch).(I), v)
+		}
+
+	case Table:
+		for k, v := range temp {
+			tbl, err := ParseTable(k)
+			if err != nil {
+				return err
+			}
+			next.Put(Identifier(tbl).(I), v)
+		}
+	default:
+		return errors.Errorf("unimplemented: %T", t)
+	}
+	m.data = next
+	return nil
+}

--- a/internal/util/ident/map_test.go
+++ b/internal/util/ident/map_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ident
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMap(t *testing.T) {
+	r := require.New(t)
+
+	m := MapOf[string](
+		Ident{}, "empty",
+		"foo", "foo",
+		"FOO", "FOO",
+	)
+
+	r.Equal(2, m.Len())
+
+	found, ok := m.Get(Ident{})
+	r.True(ok)
+	r.Equal("empty", found)
+
+	found, ok = m.Get(New("Foo"))
+	r.True(ok)
+	r.Equal("FOO", found)
+}
+
+func TestMapJSON(t *testing.T) {
+	r := require.New(t)
+
+	m := MapOf[Ident](
+		"", New("empty"),
+		"foo", New("foo"),
+		"FOO", New("FOO"),
+	)
+
+	buf, err := json.Marshal(&m)
+	r.NoError(err)
+
+	t.Log(string(buf))
+
+	var next Map[Ident]
+	r.NoError(json.Unmarshal(buf, &next))
+
+	r.Equal(2, next.Len())
+}

--- a/internal/util/ident/nocompare.go
+++ b/internal/util/ident/nocompare.go
@@ -14,22 +14,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package schemawatch
+//go:build !race
 
-import (
-	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/google/wire"
-)
+package ident
 
-// Set is used by Wire.
-var Set = wire.NewSet(
-	ProvideFactory,
-)
+// This is used by a test to ensure that, in production, the identifier
+// types occupy one word.
+const expectedIdentWords = 1
 
-// ProvideFactory is called by Wire to construct the Watchers factory.
-func ProvideFactory(pool *types.TargetPool) (types.Watchers, func()) {
-	w := &factory{pool: pool}
-	w.mu.data = &ident.SchemaMap[*watcher]{}
-	return w, w.close
-}
+// A noCompare struct can be added to a type to prevent it from being
+// used as a comparable type (e.g. in a map key). An alternate version
+// of this type (containing a slice) will be used if the "race" build
+// tag is present, since that is how we execute our tests.
+//
+// This should be an external lint tool in a future state.
+type noCompare struct{}

--- a/internal/util/ident/nocompare_race.go
+++ b/internal/util/ident/nocompare_race.go
@@ -14,22 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package schemawatch
+//go:build race
 
-import (
-	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/google/wire"
-)
+package ident
 
-// Set is used by Wire.
-var Set = wire.NewSet(
-	ProvideFactory,
-)
+const expectedIdentWords = 4
 
-// ProvideFactory is called by Wire to construct the Watchers factory.
-func ProvideFactory(pool *types.TargetPool) (types.Watchers, func()) {
-	w := &factory{pool: pool}
-	w.mu.data = &ident.SchemaMap[*watcher]{}
-	return w, w.close
+// See comments in primary file.
+type noCompare struct {
+	_ []struct{}
 }

--- a/internal/util/ident/parse.go
+++ b/internal/util/ident/parse.go
@@ -139,7 +139,7 @@ func ParseTable(s string) (Table, error) {
 	}
 	last := parts[len(parts)-1]
 
-	return Table{qualifieds.Get(qualifiedKey{
+	return Table{qualified: qualifieds.Get(qualifiedKey{
 		namespace: sch.array,
 		terminal:  last.atom,
 	})}, nil

--- a/internal/util/ident/schema.go
+++ b/internal/util/ident/schema.go
@@ -25,6 +25,7 @@ import (
 // A Schema identifier is a multipart identifier for a Table container.
 // This type is immutable and suitable for use as a map key.
 type Schema struct {
+	_ noCompare
 	*array
 }
 
@@ -50,7 +51,16 @@ func NewSchema(parts ...Ident) (Schema, error) {
 	for idx, part := range parts {
 		key[idx] = part.atom
 	}
-	return Schema{arrays.Get(key)}, nil
+	return Schema{array: arrays.Get(key)}, nil
+}
+
+// Canonical returns a canonicalized form of the SQL schema name. That
+// is, it returns a lower-cased form of the enclosed SQL identifiers.
+func (s Schema) Canonical() Schema {
+	if s.array == nil {
+		return Schema{}
+	}
+	return Schema{array: s.array.lowered}
 }
 
 // Contains returns true if the given table is defined within the

--- a/internal/util/ident/schema_test.go
+++ b/internal/util/ident/schema_test.go
@@ -32,6 +32,8 @@ func TestSchema(t *testing.T) {
 		a.Equal("", s.Raw())
 		a.True(s.Empty())
 		a.Equal(s, s.Schema())
+		a.Equal(s, s.Canonical())
+		a.Nil(s.array)
 
 		// Zero schema contains no tables.
 		a.False(s.Contains(NewTable(s, New("foo"))))
@@ -53,6 +55,8 @@ func TestSchema(t *testing.T) {
 		a.True(s.Empty())
 		a.Same(s.array, MustSchema().array)
 		a.Equal(s, s.Schema())
+		a.Equal(s, s.Canonical())
+		a.Nil(s.array)
 
 		// Empty schema contains no tables.
 		a.False(s.Contains(NewTable(s, New("foo"))))
@@ -75,12 +79,20 @@ func TestSchema(t *testing.T) {
 		a.Same(s.array, MustSchema(New("foo")).array)
 		a.True(s.Contains(NewTable(s, New("foo"))))
 		a.Equal(s, s.Schema())
+		a.Equal(s, s.Canonical())
+		a.Same(s.array, s.array.lowered)
 
 		first, remainder := s.Split()
 		a.Equal(New("foo"), first)
 		a.True(remainder.Empty())
 
 		checkSchemaJSON(t, s)
+
+		s2, err := NewSchema(New("FOO"))
+		a.NoError(err)
+		a.NotEqual(s, s2)
+		a.Equal(s.Canonical(), s2.Canonical())
+		a.Same(s.array, s2.array.lowered)
 	})
 
 	t.Run("two", func(t *testing.T) {
@@ -94,6 +106,8 @@ func TestSchema(t *testing.T) {
 		a.Same(s.array, MustSchema(New("foo"), New("bar")).array)
 		a.True(s.Contains(NewTable(s, New("foo"))))
 		a.Equal(s, s.Schema())
+		a.Equal(s, s.Canonical())
+		a.Same(s.array, s.array.lowered)
 
 		first, remainder := s.Split()
 		a.Equal(New("foo"), first)
@@ -104,6 +118,12 @@ func TestSchema(t *testing.T) {
 		a.True(remainder.Empty())
 
 		checkSchemaJSON(t, s)
+
+		s2, err := NewSchema(New("FOO"), New("BaR"))
+		a.NoError(err)
+		a.NotEqual(s, s2)
+		a.Equal(s.Canonical(), s2.Canonical())
+		a.Same(s.array, s2.array.lowered)
 	})
 
 	t.Run("three", func(t *testing.T) {

--- a/internal/util/ident/table.go
+++ b/internal/util/ident/table.go
@@ -22,9 +22,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// A Table is an identifier with an enclosing Schema. This type is an
-// immutable value type, suitable for use as a map key.
+// A Table is an identifier with an enclosing Schema.
 type Table struct {
+	_ noCompare
 	*qualified
 }
 
@@ -33,7 +33,16 @@ func NewTable(enclosing Schema, name Ident) Table {
 	if enclosing.Empty() && name.Empty() {
 		return Table{}
 	}
-	return Table{qualifieds.Get(qualifiedKey{enclosing.array, name.atom})}
+	return Table{qualified: qualifieds.Get(qualifiedKey{enclosing.array, name.atom})}
+}
+
+// Canonical returns a canonical form of the table identifier.  That is,
+// it returns a lower-cased form of the enclosed identifiers.
+func (t Table) Canonical() Table {
+	if t.qualified == nil {
+		return Table{}
+	}
+	return Table{qualified: t.qualified.lowered}
 }
 
 // Schema implements Schematic by returning the enclosing Schema.
@@ -41,7 +50,7 @@ func (t Table) Schema() Schema {
 	if t.qualified == nil {
 		return Schema{}
 	}
-	return Schema{t.qualified.namespace}
+	return Schema{array: t.qualified.namespace}
 }
 
 // Table returns the table's identifier.
@@ -49,7 +58,7 @@ func (t Table) Table() Ident {
 	if t.qualified == nil {
 		return Ident{}
 	}
-	return Ident{t.qualified.terminal}
+	return Ident{atom: t.qualified.terminal}
 }
 
 // UnmarshalJSON parses a JSON array.

--- a/internal/util/ident/table_test.go
+++ b/internal/util/ident/table_test.go
@@ -34,6 +34,8 @@ func TestTable(t *testing.T) {
 		a.True(tbl.Empty())
 		a.Equal(Schema{}, tbl.Schema())
 		a.Equal(Ident{}, tbl.Table())
+		a.Equal(Table{}, tbl.Canonical())
+		a.Nil(tbl.qualified)
 
 		first, remainder := tbl.Split()
 		a.True(first.Empty())
@@ -52,6 +54,8 @@ func TestTable(t *testing.T) {
 		a.True(tbl.Empty())
 		a.Equal(Schema{}, tbl.Schema())
 		a.Equal(Ident{}, tbl.Table())
+		a.Equal(Table{}, tbl.Canonical())
+		a.Nil(tbl.qualified)
 
 		first, remainder := tbl.Split()
 		a.True(first.Empty())
@@ -70,6 +74,8 @@ func TestTable(t *testing.T) {
 		a.False(tbl.Empty())
 		a.Equal(Schema{}, tbl.Schema())
 		a.Equal(New("table"), tbl.Table())
+		a.Equal(tbl, tbl.Canonical())
+		a.Same(tbl.qualified, tbl.qualified.lowered)
 
 		first, remainder := tbl.Split()
 		a.Equal(New("table"), first)
@@ -77,6 +83,10 @@ func TestTable(t *testing.T) {
 
 		checkTableJSON(t, tbl)
 		checkTableText(t, tbl)
+
+		tbl2 := NewTable(Schema{}, New("TABLE"))
+		a.Equal(tbl, tbl2.Canonical())
+		a.Same(tbl.qualified, tbl2.qualified.lowered)
 	})
 
 	t.Run("two", func(t *testing.T) {
@@ -99,6 +109,10 @@ func TestTable(t *testing.T) {
 
 		checkTableJSON(t, tbl)
 		checkTableText(t, tbl)
+
+		tbl2 := NewTable(MustSchema(New("DB")), New("TABLE"))
+		a.Equal(tbl, tbl2.Canonical())
+		a.Same(tbl.qualified, tbl2.qualified.lowered)
 	})
 
 	t.Run("three", func(t *testing.T) {
@@ -125,6 +139,10 @@ func TestTable(t *testing.T) {
 
 		checkTableJSON(t, tbl)
 		checkTableText(t, tbl)
+
+		tbl2 := NewTable(MustSchema(New("DB"), Public), New("TABLE"))
+		a.Equal(tbl, tbl2.Canonical())
+		a.Same(tbl.qualified, tbl2.qualified.lowered)
 	})
 }
 

--- a/internal/util/ident/udt.go
+++ b/internal/util/ident/udt.go
@@ -18,12 +18,13 @@ package ident
 
 // A UDT is the name of a user-defined type, such as an enum.
 type UDT struct {
+	_ noCompare
 	*qualified
 }
 
 // NewUDT constructs an identifier for a user-defined type.
 func NewUDT(enclosing Schema, name Ident) UDT {
-	return UDT{qualifieds.Get(qualifiedKey{enclosing.array, name.atom})}
+	return UDT{qualified: qualifieds.Get(qualifiedKey{enclosing.array, name.atom})}
 }
 
 // Name returns the UDT's leaf name identifier.
@@ -31,7 +32,7 @@ func (t UDT) Name() Ident {
 	if t.qualified == nil {
 		return Ident{}
 	}
-	return Ident{t.qualified.terminal}
+	return Ident{atom: t.qualified.terminal}
 }
 
 // Schema returns the schema from the UDT.
@@ -39,7 +40,7 @@ func (t UDT) Schema() Schema {
 	if t.qualified == nil {
 		return Schema{}
 	}
-	return Schema{t.qualified.namespace}
+	return Schema{array: t.qualified.namespace}
 }
 
 // UnmarshalJSON parses a JSON array.


### PR DESCRIPTION
This change makes cdc-sink treat identifiers in a case-insensitive manner, while preserving the case. This will help us in casese where two different databases have differing case rules. It also brings the user experience closer to what one might normally expect from a SQL database.

This change assumes that no reasonable schema has two columns or tables which are distinguishable solely by their case.

The ident package is changed in the following ways:
* The internal types (atom, array, qualified) now maintain a pointer to a lower-cased version of the identifier. We continue to intern all incoming identifiers, so the lower-casing happens exactly once for any unique identifier.
* New Map types, for Ident, Schema, and Table, are added which provide case-insensitive treatments of identifiers. It would be straightforward, should the need arise, to use build flags to replace the case-insensitive implementation with a case-sensitive one.
* The exported ident types have a new zero-length field member added called noCompare. The noCompare type is defined in a file with build rules and will prevent the identifier types from being treated as comparable by the go compiler when tests are run. This forces future developers to only use the ident.Map types, ident.Compare, and ident.Equals.
* applycfg.Config had relied upon comparable-type behavior, so it gets a proper Equals method.
* The remaining changes throughout the code base are mechanical in order to make the code compile again.
* The test code for schema-related APIs is updated to pass jumbled-case identifiers. The cdc handler code also uses jumbled-case JSON payloads and URLs to ensure good coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/418)
<!-- Reviewable:end -->
