### PR TITLE
workflow: Pre-warm go module cache

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -35,9 +35,28 @@ on:
   workflow_dispatch:  # Make it easy to push other branches/tags.
 
 jobs:
+  # This job is required by the jobs below.  It ensures that all go
+  # modules are cached within the local GitHub cache before executing
+  # the full test matrix. We've been seeing some requests to the
+  # upstream module cache fail due to network rate-limiting.
+  warm-build-cache:
+    name: Warm build cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Download modules
+        run: go mod download
+
   binaries:
     name: Binaries
     runs-on: ubuntu-latest
+    needs: warm-build-cache
     strategy:
       matrix:
         include:
@@ -96,18 +115,11 @@ jobs:
           echo "$DISTRO_PATHS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      # Use separate build caches for each target platform.
-      - id: cache_key
-        name: Write cache key
-        run: echo '${{ github.job }} ${{ toJSON(matrix) }} ${{ hashFiles('go.sum') }}' > CACHE_KEY
-
       - id: setup_go
         name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: true
-          cache-dependency-path: CACHE_KEY
 
       - id: licenses
         name: Bundle license files

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -34,23 +34,36 @@ on:
       - '.github/workflows/golang.yaml'
 
 jobs:
-  # Static code-quality checks.
-  code-quality:
-    name: Code Quality
+  # This job is required by the jobs below.  It ensures that all go
+  # modules are cached within the local GitHub cache before executing
+  # the full test matrix. We've been seeing some requests to the
+  # upstream module cache fail due to network rate-limiting.
+  warm-build-cache:
+    name: Warm build cache
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      # Just cache based on job and go.sum contents.
-      - name: Write cache key
-        run: echo '${{ github.job }} ${{ hashFiles('go.sum') }}' > CACHE_KEY
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: true
-          cache-dependency-path: CACHE_KEY
+
+      - name: Download modules
+        run: go mod download
+
+  # Static code-quality checks.
+  code-quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    needs: warm-build-cache
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
 
       - name: crlfmt returns no deltas
         if: ${{ always() }}
@@ -87,6 +100,7 @@ jobs:
   tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    needs: warm-build-cache
     strategy:
       fail-fast: false
       # Refer to the CRDB support policy when determining how many
@@ -135,16 +149,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Just cache based on job and go.sum contents.
-      - name: Write cache key
-        run: echo '${{ github.job }} ${{ hashFiles('go.sum') }}' > CACHE_KEY
-
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: true
-          cache-dependency-path: CACHE_KEY
 
       # Ensure we can grab any private images we need for testing.
       - name: Log in to GitHub Package Registry


### PR DESCRIPTION
We've been seeing some build failures due the upstream go modules cache
rate-limiting our HTTP requests. This change adds a job to pre-warm the local
setup-go cache, instead of allowing each component of the test matrix to
download modules independently.

This change also removes a few build steps related to computing the setup-go
cache key, since caching is the default mode in v4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/427)
<!-- Reviewable:end -->
