### PR TITLE
ident: Schema.Contains fix for nested namespaces

### DIFF
--- a/internal/util/ident/schema.go
+++ b/internal/util/ident/schema.go
@@ -66,7 +66,25 @@ func (s Schema) Canonical() Schema {
 // Contains returns true if the given table is defined within the
 // Schema.
 func (s Schema) Contains(table Table) bool {
-	return s.array != nil && table.qualified != nil && s.array == table.qualified.namespace
+	sParts := s.Idents(make([]Ident, 0, maxArrayLength))
+	tParts := table.Idents(make([]Ident, 0, maxArrayLength+1))
+
+	// Empty schema contains no tables.
+	if len(sParts) == 0 {
+		return false
+	}
+	// The table must have an enclosing namespace (i.e. have more parts
+	// than a schema which would enclose it).
+	if len(sParts) >= len(tParts) {
+		return false
+	}
+	// The schema parts should then be a prefix of the table parts.
+	for idx, sPart := range sParts {
+		if !Equal(sPart, tParts[idx]) {
+			return false
+		}
+	}
+	return true
 }
 
 // Relative returns a new schema, relative to the receiver. For an input

--- a/internal/util/ident/schema_test.go
+++ b/internal/util/ident/schema_test.go
@@ -93,6 +93,12 @@ func TestSchema(t *testing.T) {
 		a.NotEqual(s, s2)
 		a.Equal(s.Canonical(), s2.Canonical())
 		a.Same(s.array, s2.array.lowered)
+
+		// Schema "foo" should contain a table defined in a sub-schema, regardless of case.
+		a.True(s.Contains(NewTable(MustSchema(New("foo"), Public), New("bar"))))
+		a.True(s.Contains(NewTable(MustSchema(New("foo"), New("other")), New("bar"))))
+		a.True(s.Contains(NewTable(MustSchema(New("FOO"), Public), New("bar"))))
+		a.True(s.Contains(NewTable(MustSchema(New("FOO"), New("OTHER")), New("bar"))))
 	})
 
 	t.Run("two", func(t *testing.T) {


### PR DESCRIPTION
This change updates the behavior of Schema.Contains() so that a schema "db" will return true for a table "db.public.tbl".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/428)
<!-- Reviewable:end -->
