### PR TITLE
diag: Add diagnostics collector

### DIFF
--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -41,20 +43,19 @@ func Command() *cobra.Command {
 		Short: "start a pg logical replication feed",
 		Use:   "pglogical",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if metricsAddr != "" {
-				if err := metricsServer(metricsAddr); err != nil {
-					return err
-				}
-			}
-
-			loop, cancelLoop, err := pglogical.Start(cmd.Context(), cfg)
+			repl, cancelLoop, err := pglogical.Start(cmd.Context(), cfg)
 			if err != nil {
 				return err
+			}
+			if metricsAddr != "" {
+				if err := metricsServer(metricsAddr, repl.Diagnostics); err != nil {
+					return err
+				}
 			}
 			// Pause any log.Exit() or log.Fatal() until the server exits.
 			log.DeferExitHandler(func() {
 				cancelLoop()
-				<-loop.Stopped()
+				<-repl.Loop.Stopped()
 			})
 			// Wait for shutdown. The main function uses log.Exit()
 			// to call the above handler.
@@ -71,8 +72,9 @@ func Command() *cobra.Command {
 
 // metricsServer starts a trivial prometheus endpoint server which runs
 // until the context is canceled.
-func metricsServer(bindAddr string) error {
+func metricsServer(bindAddr string, diags *diag.Diagnostics) error {
 	mux := &http.ServeMux{}
+	mux.Handle("/_/diag", diags.Handler(trust.New()))
 	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/dop251/goja"
@@ -116,6 +117,7 @@ func ProvideUserScript(
 	ctx context.Context,
 	applyConfigs *applycfg.Configs,
 	boot *Loader,
+	diags *diag.Diagnostics,
 	stagingPool *types.StagingPool,
 	target TargetSchema,
 	watchers types.Watchers,
@@ -142,6 +144,9 @@ func ProvideUserScript(
 	}
 
 	if err := ret.bind(boot); err != nil {
+		return nil, err
+	}
+	if err := diags.Register("script", ret); err != nil {
 		return nil, err
 	}
 

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/dop251/goja"
 	"github.com/pkg/errors"
@@ -89,6 +90,16 @@ type UserScript struct {
 	rtMu    sync.Mutex    // Serialize access to the VM.
 	target  ident.Schema  // The schema being populated.
 	watcher types.Watcher // Access to target schema.
+}
+
+var _ diag.Diagnostic = (*UserScript)(nil)
+
+// Diagnostic implements [diag.Diagnostic].
+func (s *UserScript) Diagnostic(_ context.Context) any {
+	return map[string]any{
+		"sources": s.Sources,
+		"targets": s.Targets,
+	}
 }
 
 // bind validates the user configuration against the target schema and

--- a/internal/script/wire_gen.go
+++ b/internal/script/wire_gen.go
@@ -24,9 +24,10 @@ func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema Tar
 	if err != nil {
 		return nil, err
 	}
+	diagnostics := fixture.Diagnostics
 	stagingPool := baseFixture.StagingPool
 	watchers := fixture.Watchers
-	userScript, err := ProvideUserScript(context, configs, loader, stagingPool, targetSchema, watchers)
+	userScript, err := ProvideUserScript(context, configs, loader, diagnostics, stagingPool, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Fixture provides a complete set of database-backed services. One can
@@ -33,6 +34,7 @@ type Fixture struct {
 
 	Appliers       types.Appliers
 	Configs        *applycfg.Configs
+	Diagnostics    *diag.Diagnostics
 	Memo           types.Memo
 	Stagers        types.Stagers
 	VersionChecker *version.Checker

--- a/internal/sinktest/diag.go
+++ b/internal/sinktest/diag.go
@@ -14,23 +14,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package sinktest
 
 import (
-	"encoding/json"
-	"net/http"
+	"context"
+	"testing"
 
-	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
-// DebugHandler returns a trivial http Handler that will dump the
-// current configuration as a JSON document.
-func DebugHandler(cfgs *applycfg.Configs) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("content-type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		_ = enc.Encode(cfgs.GetAll())
-	})
+// CheckDiagnostics ensures that all diagnostic data can be serialized
+// to JSON.
+func CheckDiagnostics(ctx context.Context, t *testing.T, diags *diag.Diagnostics) {
+	t.Helper()
+	a := require.New(t)
+
+	w := log.StandardLogger().WriterLevel(log.TraceLevel)
+	a.NoError(diags.Write(ctx, w, false /* pretty */))
+	a.NoError(w.Close())
 }

--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -23,9 +23,9 @@ package cdc
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/httpauth"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -87,21 +87,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) checkAccess(
 	ctx context.Context, r *http.Request, target ident.Schema,
 ) (bool, error) {
-	var token string
-	if raw := r.Header.Get("Authorization"); raw != "" {
-		if strings.HasPrefix(raw, "Bearer ") {
-			token = raw[7:]
-		}
-	} else if token = r.URL.Query().Get("access_token"); token != "" {
-		// Delete the token query parameter to prevent logging later
-		// on. This doesn't take care of issues with L7
-		// loadbalancers, but this param is used by other
-		// OAuth-style implementations and will hopefully be
-		// discarded without logging.
-		values := r.URL.Query()
-		values.Del("access_token")
-		r.URL.RawQuery = values.Encode()
-	}
+	token := httpauth.Token(r)
 	// It's OK if token is empty here, we might be using a trivial
 	// Authenticator.
 	ok, err := h.Authenticator.Check(ctx, target, token)

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
 	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -41,6 +42,7 @@ func newTestFixture(*all.Fixture, *Config) (*testFixture, func(), error) {
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
 			"Appliers", "Fixture", "Stagers", "Watchers"),
+		diag.New,
 		leases.Set,
 		logical.Set,
 		script.Set,

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -39,6 +40,7 @@ func Start(context.Context, *Config) ([]*logical.Loop, func(), error) {
 		ProvideFirestoreClient,
 		ProvideLoops,
 		ProvideTombstones,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,
@@ -52,7 +54,7 @@ func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, func(), erro
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
-			"Appliers", "Fixture", "Configs", "Memo", "VersionChecker", "Watchers"),
+			"Appliers", "Diagnostics", "Fixture", "Configs", "Memo", "VersionChecker", "Watchers"),
 		ProvideFirestoreClient,
 		ProvideLoops,
 		ProvideTombstones,

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -30,6 +30,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	"github.com/cockroachdb/cdc-sink/internal/script"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
@@ -299,4 +300,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 	}
 
 	log.Info("all deletes done")
+
+	// Ensure diagnostics can be reported.
+	sinktest.CheckDiagnostics(ctx, t, fixture.Diagnostics)
 }

--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
 	"github.com/go-mysql-org/go-mysql/client"
@@ -69,7 +70,20 @@ const (
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=mutationType
 
-var _ logical.Dialect = (*conn)(nil)
+var (
+	_ diag.Diagnostic = (*conn)(nil)
+	_ logical.Dialect = (*conn)(nil)
+)
+
+// Diagnostics implements [diag.Diagnostic].
+func (c *conn) Diagnostic(_ context.Context) any {
+	return map[string]any{
+		"columns":      c.columns,
+		"flavor":       c.flavor,
+		"relations":    c.relations,
+		"sourceConfig": c.sourceConfig,
+	}
+}
 
 // Process implements logical.Dialect and receives a sequence of logical
 // replication messages, or possibly a rollbackMessage.

--- a/internal/source/mylogical/injector.go
+++ b/internal/source/mylogical/injector.go
@@ -26,15 +26,24 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
+// MYLogical isa MySQL/MariaDB logical replication loop.
+type MYLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
+}
+
 // Start creates a MySQL/MariaDB logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
 	panic(wire.Build(
 		wire.Bind(new(logical.Config), new(*Config)),
+		wire.Struct(new(MYLogical), "*"),
 		Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -151,7 +152,7 @@ func testMYLogical(t *testing.T, backfill, immediate bool) {
 	}
 
 	// Start the connection, to demonstrate that we can backfill pending mutations.
-	loop, cancelLoop, err := Start(ctx, config)
+	repl, cancelLoop, err := Start(ctx, config)
 	if !a.NoError(err) {
 		return
 	}
@@ -227,11 +228,13 @@ func testMYLogical(t *testing.T, backfill, immediate bool) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
+
 	cancelLoop()
 	select {
 	case <-ctx.Done():
 		a.Fail("cancelConn timed out")
-	case <-loop.Stopped():
+	case <-repl.Loop.Stopped():
 		// OK
 	}
 }
@@ -424,7 +427,7 @@ func TestDataTypes(t *testing.T) {
 	}
 
 	// Start the connection, to demonstrate that we can backfill pending mutations.
-	loop, cancelLoop, err := Start(ctx, config)
+	repl, cancelLoop, err := Start(ctx, config)
 	if !a.NoError(err) {
 		return
 	}
@@ -449,9 +452,11 @@ func TestDataTypes(t *testing.T) {
 		})
 	}
 
+	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
+
 	cancelLoop()
 	select {
-	case <-loop.Stopped():
+	case <-repl.Loop.Stopped():
 	case <-ctx.Done():
 	}
 }

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -15,49 +15,74 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Injectors from injector.go:
 
 // Start creates a MySQL/MariaDB logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
+	diagnostics, cleanup := diag.New(ctx)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	loader, err := script.ProvideLoader(scriptConfig)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	baseConfig, err := logical.ProvideBaseConfig(config, loader)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
-	stagingPool, cleanup, err := logical.ProvideStagingPool(ctx, baseConfig)
+	stagingPool, cleanup2, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	targetPool, cleanup3, err := logical.ProvideTargetPool(ctx, baseConfig)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
-	appliers, cleanup5 := apply.ProvideFactory(configs, targetPool, watchers)
+	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, diagnostics, stagingPool, stagingSchema)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	targetPool, cleanup4, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
+	if err != nil {
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	watchers, cleanup5, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	if err != nil {
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	appliers, cleanup6, err := apply.ProvideFactory(configs, diagnostics, targetPool, watchers)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -66,8 +91,9 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		return nil, nil, err
 	}
 	targetSchema := logical.ProvideUserScriptTarget(baseConfig)
-	userScript, err := script.ProvideUserScript(ctx, configs, loader, stagingPool, targetSchema, watchers)
+	userScript, err := script.ProvideUserScript(ctx, configs, loader, diagnostics, stagingPool, targetSchema, watchers)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -76,8 +102,9 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		return nil, nil, err
 	}
 	checker := version.ProvideChecker(stagingPool, memoMemo)
-	factory, cleanup6, err := logical.ProvideFactory(ctx, appliers, config, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
+	factory, cleanup7, err := logical.ProvideFactory(ctx, appliers, config, diagnostics, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -87,6 +114,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	}
 	dialect, err := ProvideDialect(config)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -97,6 +125,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	}
 	loop, err := logical.ProvideLoop(ctx, factory, dialect)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -105,7 +134,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	return loop, func() {
+	myLogical := &MYLogical{
+		Diagnostics: diagnostics,
+		Loop:        loop,
+	}
+	return myLogical, func() {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -113,4 +147,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup2()
 		cleanup()
 	}, nil
+}
+
+// injector.go:
+
+// MYLogical isa MySQL/MariaDB logical replication loop.
+type MYLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
 }

--- a/internal/source/pglogical/injector.go
+++ b/internal/source/pglogical/injector.go
@@ -26,15 +26,24 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
+// PGLogical is a PostgreSQL logical replication loop.
+type PGLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
+}
+
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 	panic(wire.Build(
 		wire.Bind(new(logical.Config), new(*Config)),
+		wire.Struct(new(PGLogical), "*"),
 		Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -15,49 +15,74 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Injectors from injector.go:
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
+	diagnostics, cleanup := diag.New(ctx)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	loader, err := script.ProvideLoader(scriptConfig)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	baseConfig, err := logical.ProvideBaseConfig(config, loader)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
-	stagingPool, cleanup, err := logical.ProvideStagingPool(ctx, baseConfig)
+	stagingPool, cleanup2, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	targetPool, cleanup3, err := logical.ProvideTargetPool(ctx, baseConfig)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
-	appliers, cleanup5 := apply.ProvideFactory(configs, targetPool, watchers)
+	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, diagnostics, stagingPool, stagingSchema)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	targetPool, cleanup4, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
+	if err != nil {
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	watchers, cleanup5, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	if err != nil {
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	appliers, cleanup6, err := apply.ProvideFactory(configs, diagnostics, targetPool, watchers)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -66,8 +91,9 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		return nil, nil, err
 	}
 	targetSchema := logical.ProvideUserScriptTarget(baseConfig)
-	userScript, err := script.ProvideUserScript(ctx, configs, loader, stagingPool, targetSchema, watchers)
+	userScript, err := script.ProvideUserScript(ctx, configs, loader, diagnostics, stagingPool, targetSchema, watchers)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -76,8 +102,9 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		return nil, nil, err
 	}
 	checker := version.ProvideChecker(stagingPool, memoMemo)
-	factory, cleanup6, err := logical.ProvideFactory(ctx, appliers, config, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
+	factory, cleanup7, err := logical.ProvideFactory(ctx, appliers, config, diagnostics, memoMemo, stagingPool, targetPool, userScript, watchers, checker)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -87,6 +114,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	}
 	dialect, err := ProvideDialect(ctx, config)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -97,6 +125,7 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 	}
 	loop, err := logical.ProvideLoop(ctx, factory, dialect)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -105,7 +134,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	return loop, func() {
+	pgLogical := &PGLogical{
+		Diagnostics: diagnostics,
+		Loop:        loop,
+	}
+	return pgLogical, func() {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -113,4 +147,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup2()
 		cleanup()
 	}, nil
+}
+
+// injector.go:
+
+// PGLogical is a PostgreSQL logical replication loop.
+type PGLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
 }

--- a/internal/source/server/injector.go
+++ b/internal/source/server/injector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -34,6 +35,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -17,16 +17,21 @@
 package server
 
 import (
+	"crypto/tls"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	jwtAuth "github.com/cockroachdb/cdc-sink/internal/staging/auth/jwt"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	joonix "github.com/joonix/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -126,12 +131,12 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 	method, priv, err := jwtAuth.InsertTestingKey(ctx, targetFixture.StagingPool, targetFixture.Authenticator, targetFixture.StagingDB)
 	r.NoError(err)
 
-	_, token, err := jwtAuth.Sign(method, priv, []ident.Schema{target.Schema()})
+	_, token, err := jwtAuth.Sign(method, priv, []ident.Schema{target.Schema(), diag.Schema})
 	r.NoError(err)
 
 	params := make(url.Values)
 	// Set up the changefeed.
-	var feedURL url.URL
+	var diagURL, feedURL url.URL
 	var createStmt string
 	if webhook {
 		params.Set("insecure_tls_skip_verify", "true")
@@ -146,6 +151,13 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 			"WITH updated," +
 			"     resolved='1s'," +
 			"     webhook_auth_header='Bearer " + token + "'"
+
+		diagURL = url.URL{
+			Scheme:   "https",
+			Host:     targetFixture.Listener.Addr().String(),
+			Path:     "/_/diag",
+			RawQuery: "access_token=" + token,
+		}
 	} else {
 		// No webhook_auth_header, so bake it into the query string.
 		// See comments in cdc.Handler.ServeHTTP checkAccess.
@@ -159,7 +171,15 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 		createStmt = "CREATE CHANGEFEED FOR TABLE %s " +
 			"INTO '" + feedURL.String() + "' " +
 			"WITH updated,resolved='1s'"
+
+		diagURL = url.URL{
+			Scheme:   "http",
+			Host:     targetFixture.Listener.Addr().String(),
+			Path:     "/_/diag",
+			RawQuery: "access_token=" + token,
+		}
 	}
+
 	// Don't wait the entire 30s. This options was introduced in the
 	// same versions as webhooks.
 	if supportsMinCheckpoint(sourceFixture.TargetPool.Version) {
@@ -198,7 +218,38 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 
 	metrics, err := prometheus.DefaultGatherer.Gather()
 	a.NoError(err)
-	log.WithField("metrics", metrics).Debug()
+	log.WithField("metrics", metrics).Trace()
+
+	sinktest.CheckDiagnostics(ctx, t, targetFixture.Diagnostics)
+
+	// Ensure that diagnostic endpoint is protected, since it has
+	// potentially-sensitive connect strings.
+	t.Run("check diag endpoint", func(t *testing.T) {
+		a := assert.New(t)
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+		u := diagURL.String()
+		resp, err := client.Get(u)
+		if a.NoError(err) {
+			a.Equal(http.StatusOK, resp.StatusCode, u)
+			a.Equal("application/json", resp.Header.Get("content-type"))
+			buf, _ := io.ReadAll(resp.Body)
+			t.Log(string(buf))
+		}
+
+		// Remove auth info.
+		diagURL.RawQuery = ""
+		u = diagURL.String()
+		resp, err = client.Get(u)
+		if a.NoError(err) {
+			a.Equal(http.StatusForbidden, resp.StatusCode, u)
+		}
+	})
 }
 
 func supportsMinCheckpoint(version string) bool {

--- a/internal/source/server/provider.go
+++ b/internal/source/server/provider.go
@@ -30,11 +30,10 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
-	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/jwt"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
 	"github.com/pkg/errors"
@@ -69,21 +68,28 @@ func ProvideAuthenticator(
 
 // ProvideListener is called by Wire to construct the incoming network
 // socket for the server.
-func ProvideListener(config *Config) (net.Listener, func(), error) {
+func ProvideListener(config *Config, diags *diag.Diagnostics) (net.Listener, func(), error) {
 	// Start listening only when everything else is ready.
 	l, err := net.Listen("tcp", config.BindAddr)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "could not bind to %q", config.BindAddr)
 	}
 	log.WithField("address", l.Addr()).Info("Server listening")
+	if err := diags.Register("listener", diag.DiagnosticFn(func(context.Context) any {
+		return l.Addr().String()
+	})); err != nil {
+		_ = l.Close()
+		return nil, nil, err
+	}
 	return l, func() { _ = l.Close() }, nil
 }
 
 // ProvideMux is called by Wire to construct the http.ServeMux that
 // routes requests.
 func ProvideMux(
+	auth types.Authenticator,
 	handler *cdc.Handler,
-	applyConf *applycfg.Configs,
+	diags *diag.Diagnostics,
 	stagingPool *types.StagingPool,
 	targetPool *types.TargetPool,
 ) *http.ServeMux {
@@ -93,7 +99,7 @@ func ProvideMux(
 	// this specific prefix. It seems unlikely that this would collide
 	// with an actual database schema.
 	mux.Handle("/debug/pprof/", http.DefaultServeMux)
-	mux.Handle("/_/config/apply", apply.DebugHandler(applyConf))
+	mux.Handle("/_/diag", diags.Handler(auth))
 	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if err := stagingPool.Ping(r.Context()); err != nil {
 			log.WithError(err).Warn("health check failed for staging pool")

--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
 )
@@ -36,6 +37,7 @@ import (
 type testFixture struct {
 	Authenticator types.Authenticator
 	Config        *Config
+	Diagnostics   *diag.Diagnostics
 	Listener      net.Listener
 	StagingPool   *types.StagingPool
 	Server        *Server
@@ -49,6 +51,7 @@ func newTestFixture(context.Context, *Config) (*testFixture, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/staging/applycfg/configs.go
+++ b/internal/staging/applycfg/configs.go
@@ -60,6 +60,11 @@ type Configs struct {
 	}
 }
 
+// Diagnostic implements [diag.Diagnostic].
+func (c *Configs) Diagnostic(_ context.Context) any {
+	return c.GetAll()
+}
+
 // Get returns the configuration for the named table, or a non-nil, zero
 // value if no configuration has been provided.
 func (c *Configs) Get(tbl ident.Table) *Config {

--- a/internal/staging/auth/broken/broken.go
+++ b/internal/staging/auth/broken/broken.go
@@ -14,21 +14,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build wireinject
-// +build wireinject
-
-package script
+// Package broken contains an Authenticator that always fails.
+package broken
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
-	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
-	"github.com/google/wire"
+	"context"
+	"errors"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 )
 
-func newScriptFromFixture(*all.Fixture, *Config, TargetSchema) (*UserScript, error) {
-	panic(wire.Build(
-		Set,
-		wire.FieldsOf(new(*all.Fixture), "Diagnostics", "Fixture", "Configs", "Watchers"),
-		wire.FieldsOf(new(*base.Fixture), "Context", "StagingPool"),
-	))
+// ErrBroken can be expected by tests.
+var ErrBroken = errors.New("broken")
+
+// New returns an Authenticator that always returns [ErrBroken].
+func New() types.Authenticator {
+	return &broken{}
+}
+
+type broken struct{}
+
+func (b *broken) Check(context.Context, ident.Schema, string) (ok bool, _ error) {
+	return false, ErrBroken
 }

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -168,7 +168,7 @@ func (a *apply) Apply(ctx context.Context, tx types.TargetQuerier, muts []types.
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	if a.mu.templates.Len() == 0 {
+	if a.mu.templates.Pos.Len() == 0 {
 		return errors.Errorf("no ColumnData available for %s", a.target)
 	}
 
@@ -303,7 +303,7 @@ func (a *apply) upsertLocked(
 		var unexpectedColumns []string
 
 		err = rowData.Range(func(incomingColName ident.Ident, value any) error {
-			targetColumn, ok := a.mu.templates.Get(incomingColName)
+			targetColumn, ok := a.mu.templates.Pos.Get(incomingColName)
 
 			// The incoming data didn't map to a column. Report an error
 			// if no extras column has been configured or accumulate it

--- a/internal/target/schemawatch/provider.go
+++ b/internal/target/schemawatch/provider.go
@@ -18,6 +18,7 @@ package schemawatch
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
 )
@@ -28,8 +29,11 @@ var Set = wire.NewSet(
 )
 
 // ProvideFactory is called by Wire to construct the Watchers factory.
-func ProvideFactory(pool *types.TargetPool) (types.Watchers, func()) {
+func ProvideFactory(pool *types.TargetPool, d *diag.Diagnostics) (types.Watchers, func(), error) {
 	w := &factory{pool: pool}
 	w.mu.data = &ident.SchemaMap[*watcher]{}
-	return w, w.close
+	if err := d.Register("schema", w); err != nil {
+		return nil, nil, err
+	}
+	return w, w.close, nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -199,7 +199,7 @@ type ColData struct {
 	// A Parse function may be supplied to allow a string representation
 	// of a complex datatype to be converted into a type more readily
 	// used by a target database driver.
-	Parse   func(string) (any, bool)
+	Parse   func(string) (any, bool) `json:"-"`
 	Primary bool
 	// Type of the column. Dialect might choose to use a string representation or a enum.
 	Type any

--- a/internal/util/diag/diag.go
+++ b/internal/util/diag/diag.go
@@ -1,0 +1,173 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package diag contains a mechanism for cdc-sink components to report
+// structured diagnostic information.
+package diag
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"sync"
+	"syscall"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/httpauth"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Schema is passed to the authenticator.
+var Schema = ident.MustSchema(ident.New("_"), ident.New("diag"))
+
+// Diagnostic is implemented by any type that can provide structured
+// diagnostic data for use in a support engagement.
+type Diagnostic interface {
+	// Diagnostic returns a json-serializable value that represent the
+	// reportable state of the component.
+	Diagnostic(context.Context) any
+}
+
+// A DiagnosticFn is passed to [Diagnostics.Register]. This type is use
+// similarly to [http.HandlerFunc].
+type DiagnosticFn func(context.Context) any
+
+// Diagnostic implements Diagnostic.
+func (c DiagnosticFn) Diagnostic(ctx context.Context) any {
+	return c(ctx)
+}
+
+// Diagnostics serves as a registry for Diagnostic implementations.
+type Diagnostics struct {
+	mu struct {
+		sync.RWMutex
+		impls map[string]Diagnostic
+	}
+}
+
+// New constructs a Diagnostics. The instance will write itself to the
+// log stream if the process receives a SIGUSR1.
+func New(ctx context.Context) (*Diagnostics, func()) {
+	ret := &Diagnostics{}
+	ret.mu.impls = map[string]Diagnostic{
+		"build": DiagnosticFn(func(context.Context) any {
+			bi, ok := debug.ReadBuildInfo()
+			if !ok {
+				return nil
+			}
+			info := make(map[string]string, len(bi.Settings))
+			for _, s := range bi.Settings {
+				info[s.Key] = s.Value
+			}
+			return info
+		}),
+		"cmd": DiagnosticFn(func(context.Context) any {
+			return os.Args
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR1)
+	go func() {
+		defer signal.Stop(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ch:
+				log.WithFields(ret.Payload(ctx)).Info("diagnostics")
+			}
+		}
+	}()
+
+	return ret, cancel
+}
+
+// Register adds a callback to generate a portion of the diagnostics
+// output. The name will be used as the key in the emitted JSON literal,
+// and the value will be the serialized form of the callback's return
+// value. This method will return an error if the same name is
+// registered twice.
+//
+// Note that the callback may be called at any time (possibly
+// concurrently), so implementations should be written in a thread-safe
+// manner.
+func (d *Diagnostics) Register(name string, intf Diagnostic) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, conflict := d.mu.impls[name]; conflict {
+		return errors.Errorf("%s already registered", name)
+	}
+	d.mu.impls[name] = intf
+	return nil
+}
+
+// Handler returns an [http.Handler] to provide a summary report.
+// The [Schema] value will be passed to the Authenticator.
+func (d *Diagnostics) Handler(auth types.Authenticator) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		token := httpauth.Token(req)
+		ok, err := auth.Check(req.Context(), Schema, token)
+		if err != nil {
+			log.WithError(err).Warn("could not authenticate request")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := d.Write(req.Context(), w, true); err != nil {
+			log.WithError(err).Warn("could not write diagnostics")
+		}
+	})
+}
+
+// Payload returns the diagnostic payload.
+func (d *Diagnostics) Payload(ctx context.Context) map[string]any {
+	ret := make(map[string]any)
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for key, impl := range d.mu.impls {
+		ret[key] = impl.Diagnostic(ctx)
+	}
+
+	return ret
+}
+
+// Write the diagnostic report.
+func (d *Diagnostics) Write(ctx context.Context, w io.Writer, pretty bool) error {
+	p := d.Payload(ctx)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(true)
+	if pretty {
+		enc.SetIndent("", " ")
+	}
+	return enc.Encode(p)
+}

--- a/internal/util/diag/diag_test.go
+++ b/internal/util/diag/diag_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/broken"
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/reject"
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnostics(t *testing.T) {
+	r := require.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d, cancel := New(ctx)
+	defer cancel()
+
+	var didCall atomic.Bool
+	r.NoError(d.Register("foo", DiagnosticFn(func(context.Context) any {
+		didCall.Store(true)
+		return "XYZZY"
+	})))
+	r.ErrorContains(d.Register("foo", nil), "foo already registered")
+
+	var buf strings.Builder
+	r.NoError(d.Write(context.Background(), &buf, false))
+	r.True(didCall.Load())
+	// The exact contents are sensitive to the build.
+	r.Contains(buf.String(), "XYZZY")
+}
+
+func TestAuth(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d, cancel := New(ctx)
+	defer cancel()
+
+	tcs := []struct {
+		auth   types.Authenticator
+		expect int
+	}{
+		{
+			auth:   trust.New(),
+			expect: http.StatusOK,
+		},
+		{
+			auth:   reject.New(),
+			expect: http.StatusForbidden,
+		},
+		{
+			auth:   broken.New(),
+			expect: http.StatusInternalServerError,
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			r := require.New(t)
+			// The path is irrelevant here.
+			req := httptest.NewRequest(http.MethodGet, "/_/diag", nil)
+			w := httptest.NewRecorder()
+
+			d.Handler(tc.auth).ServeHTTP(w, req)
+			r.Equal(tc.expect, w.Code)
+		})
+	}
+}

--- a/internal/util/httpauth/httpauth.go
+++ b/internal/util/httpauth/httpauth.go
@@ -1,0 +1,48 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpauth contains a common function for extracting
+// credentials from an HTTP request.
+package httpauth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Token returns the bearer authorization header or the access_token
+// HTTP parameter associated with the request. If an authorization query
+// parameter is used, the request will be updated to delete that
+// parameter. This function will return an empty string if no
+// authorization token is associated with the request.
+func Token(req *http.Request) string {
+	var token string
+	if raw := req.Header.Get("Authorization"); raw != "" {
+		if strings.HasPrefix(raw, "Bearer ") {
+			token = raw[7:]
+		}
+	} else if token = req.URL.Query().Get("access_token"); token != "" {
+		// Delete the token query parameter to prevent logging later
+		// on. This doesn't take care of issues with L7
+		// loadbalancers, but this param is used by other
+		// OAuth-style implementations and will hopefully be
+		// discarded without logging.
+		values := req.URL.Query()
+		values.Del("access_token")
+		req.URL.RawQuery = values.Encode()
+	}
+	return token
+}

--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -88,7 +88,15 @@ func OpenOracleAsTarget(
 			return nil, errors.Wrap(err, "could not query version")
 		}
 
-		return ret, attachOptions(ctx, ret.DB, options)
+		if err := attachOptions(ctx, ret.DB, options); err != nil {
+			return nil, err
+		}
+
+		if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
+			return nil, err
+		}
+
+		return ret, nil
 	})
 }
 

--- a/internal/util/stdpool/pgx.go
+++ b/internal/util/stdpool/pgx.go
@@ -92,6 +92,10 @@ func OpenPgxAsStaging(
 		return nil, nil, errors.Errorf("only CockroachDB is supported as a staging server; saw %q", ret.Version)
 	}
 
+	if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
+		return nil, nil, err
+	}
+
 	success = true
 	return ret, cancel, err
 }
@@ -138,6 +142,10 @@ func OpenPgxAsTarget(
 		ret.Product = types.ProductPostgreSQL
 	default:
 		return nil, nil, errors.Errorf("unknown product for version: %s", ret.Version)
+	}
+
+	if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
+		return nil, nil, err
 	}
 
 	success = true


### PR DESCRIPTION
This change adds a global diagnostics collector to improve the supportability of cdc-sink. The diag package allows various components to register themselves in order to produce an arbitrary blob of JSON that we can use to support customers. The applycfg package had an initial implementation of exporting the current configuration via an HTTP endpoint, this change generalizes and expands on it.

Review notes:
* The diag package defines the collector and a basic interface for returning a json value.
* Components are registered with the diag package by their provider functions.
* Diagnostics are available at /_/diag, which is protected by the active authenticator when in C2X modes. The data returned here is not intended to represent a stable API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/436)
<!-- Reviewable:end -->
