### PR TITLE
diag: Add diagnostics collector

### DIFF
--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 
 	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -41,20 +43,19 @@ func Command() *cobra.Command {
 		Short: "start a pg logical replication feed",
 		Use:   "pglogical",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if metricsAddr != "" {
-				if err := metricsServer(metricsAddr); err != nil {
-					return err
-				}
-			}
-
-			loop, cancelLoop, err := pglogical.Start(cmd.Context(), cfg)
+			repl, cancelLoop, err := pglogical.Start(cmd.Context(), cfg)
 			if err != nil {
 				return err
+			}
+			if metricsAddr != "" {
+				if err := metricsServer(metricsAddr, repl.Diagnostics); err != nil {
+					return err
+				}
 			}
 			// Pause any log.Exit() or log.Fatal() until the server exits.
 			log.DeferExitHandler(func() {
 				cancelLoop()
-				<-loop.Stopped()
+				<-repl.Loop.Stopped()
 			})
 			// Wait for shutdown. The main function uses log.Exit()
 			// to call the above handler.
@@ -71,8 +72,9 @@ func Command() *cobra.Command {
 
 // metricsServer starts a trivial prometheus endpoint server which runs
 // until the context is canceled.
-func metricsServer(bindAddr string) error {
+func metricsServer(bindAddr string, diags *diag.Diagnostics) error {
 	mux := &http.ServeMux{}
+	mux.Handle("/_/diag", diags.Handler(trust.New()))
 	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))

--- a/internal/script/injector.go
+++ b/internal/script/injector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -34,6 +35,7 @@ func Evaluate(
 	ctx context.Context,
 	loader *Loader,
 	configs *applycfg.Configs,
+	diags *diag.Diagnostics,
 	stagingPool *types.StagingPool,
 	targetSchema TargetSchema,
 	watchers types.Watchers,
@@ -44,7 +46,7 @@ func Evaluate(
 func newScriptFromFixture(*all.Fixture, *Config, TargetSchema) (*UserScript, error) {
 	panic(wire.Build(
 		Set,
-		wire.FieldsOf(new(*all.Fixture), "Fixture", "Configs", "Watchers"),
+		wire.FieldsOf(new(*all.Fixture), "Diagnostics", "Fixture", "Configs", "Watchers"),
 		wire.FieldsOf(new(*base.Fixture), "Context", "StagingPool"),
 	))
 }

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/dop251/goja"
@@ -116,6 +117,7 @@ func ProvideUserScript(
 	ctx context.Context,
 	applyConfigs *applycfg.Configs,
 	boot *Loader,
+	diags *diag.Diagnostics,
 	stagingPool *types.StagingPool,
 	target TargetSchema,
 	watchers types.Watchers,
@@ -142,6 +144,9 @@ func ProvideUserScript(
 	}
 
 	if err := ret.bind(boot); err != nil {
+		return nil, err
+	}
+	if err := diags.Register("script", ret); err != nil {
 		return nil, err
 	}
 

--- a/internal/script/wire_gen.go
+++ b/internal/script/wire_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 import (
@@ -20,8 +21,8 @@ import (
 // Injectors from injector.go:
 
 // Evaluate the loaded script.
-func Evaluate(ctx context.Context, loader *Loader, configs *applycfg.Configs, stagingPool *types.StagingPool, targetSchema TargetSchema, watchers types.Watchers) (*UserScript, error) {
-	userScript, err := ProvideUserScript(ctx, configs, loader, stagingPool, targetSchema, watchers)
+func Evaluate(ctx context.Context, loader *Loader, configs *applycfg.Configs, diags *diag.Diagnostics, stagingPool *types.StagingPool, targetSchema TargetSchema, watchers types.Watchers) (*UserScript, error) {
+	userScript, err := ProvideUserScript(ctx, configs, loader, diags, stagingPool, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}
@@ -36,9 +37,10 @@ func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema Tar
 	if err != nil {
 		return nil, err
 	}
+	diagnostics := fixture.Diagnostics
 	stagingPool := baseFixture.StagingPool
 	watchers := fixture.Watchers
-	userScript, err := ProvideUserScript(contextContext, configs, loader, stagingPool, targetSchema, watchers)
+	userScript, err := ProvideUserScript(contextContext, configs, loader, diagnostics, stagingPool, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Fixture provides a complete set of database-backed services. One can
@@ -33,6 +34,7 @@ type Fixture struct {
 
 	Appliers       types.Appliers
 	Configs        *applycfg.Configs
+	Diagnostics    *diag.Diagnostics
 	Memo           types.Memo
 	Stagers        types.Stagers
 	VersionChecker *version.Checker

--- a/internal/sinktest/diag.go
+++ b/internal/sinktest/diag.go
@@ -14,27 +14,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build wireinject
-// +build wireinject
-
-package logical
+package sinktest
 
 import (
 	"context"
+	"testing"
 
-	"github.com/cockroachdb/cdc-sink/internal/script"
-	"github.com/cockroachdb/cdc-sink/internal/staging"
-	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
-	"github.com/google/wire"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
-func NewFactoryForTests(ctx context.Context, config Config) (*Factory, func(), error) {
-	panic(wire.Build(
-		Set,
-		diag.New,
-		script.Set,
-		staging.Set,
-		target.Set,
-	))
+// CheckDiagnostics ensures that all diagnostic data can be serialized
+// to JSON.
+func CheckDiagnostics(ctx context.Context, t *testing.T, diags *diag.Diagnostics) {
+	t.Helper()
+	a := require.New(t)
+
+	w := log.StandardLogger().WriterLevel(log.TraceLevel)
+	a.NoError(diags.Write(ctx, w, false /* pretty */))
+	a.NoError(w.Close())
 }

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
 	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -41,6 +42,7 @@ func newTestFixture(*all.Fixture, *Config) (*testFixture, func(), error) {
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
 			"Appliers", "Configs", "Fixture", "Memo", "Stagers", "VersionChecker", "Watchers"),
+		diag.New,
 		leases.Set,
 		logical.Set,
 		script.Set,

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
 	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Injectors from test_fixture.go:
@@ -33,39 +34,46 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(),
 	if err != nil {
 		return nil, nil, err
 	}
-	stagingPool, cleanup, err := logical.ProvideStagingPool(context, baseConfig)
+	diagnostics, cleanup := diag.New(context)
+	stagingPool, cleanup2, err := logical.ProvideStagingPool(context, baseConfig, diagnostics)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
+		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
 	typesLeases, err := leases.ProvideLeases(context, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
 	configs := fixture.Configs
 	memo := fixture.Memo
-	targetPool, cleanup2, err := logical.ProvideTargetPool(context, baseConfig)
+	targetPool, cleanup3, err := logical.ProvideTargetPool(context, baseConfig, diagnostics)
 	if err != nil {
+		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
 	watchers := fixture.Watchers
 	checker := fixture.VersionChecker
-	factory, err := logical.ProvideFactory(context, appliers, configs, baseConfig, memo, loader, stagingPool, targetPool, watchers, checker)
+	factory, err := logical.ProvideFactory(context, appliers, configs, baseConfig, diagnostics, memo, loader, stagingPool, targetPool, watchers, checker)
 	if err != nil {
+		cleanup3()
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
 	metaTable := ProvideMetaTable(config)
 	stagers := fixture.Stagers
-	resolvers, cleanup3, err := ProvideResolvers(context, config, typesLeases, factory, metaTable, stagingPool, stagers, watchers)
+	resolvers, cleanup4, err := ProvideResolvers(context, config, typesLeases, factory, metaTable, stagingPool, stagers, watchers)
 	if err != nil {
+		cleanup3()
 		cleanup2()
 		cleanup()
 		return nil, nil, err
@@ -85,6 +93,7 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(),
 		Resolvers: resolvers,
 	}
 	return cdcTestFixture, func() {
+		cleanup4()
 		cleanup3()
 		cleanup2()
 		cleanup()

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -40,6 +41,7 @@ func Start(context.Context, *Config) ([]*logical.Loop, func(), error) {
 		ProvideLoops,
 		ProvideScriptTarget,
 		ProvideTombstones,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,
@@ -53,7 +55,7 @@ func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, func(), erro
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
-			"Appliers", "Fixture", "Configs", "Memo", "VersionChecker", "Watchers"),
+			"Appliers", "Diagnostics", "Fixture", "Configs", "Memo", "VersionChecker", "Watchers"),
 		ProvideFirestoreClient,
 		ProvideLoops,
 		ProvideScriptTarget,

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -30,6 +30,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	"github.com/cockroachdb/cdc-sink/internal/script"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
@@ -301,4 +302,7 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 	}
 
 	log.Info("all deletes done")
+
+	// Ensure diagnostics can be reported.
+	sinktest.CheckDiagnostics(ctx, t, fixture.Diagnostics)
 }

--- a/internal/source/logical/wire_gen.go
+++ b/internal/source/logical/wire_gen.go
@@ -14,47 +14,72 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Injectors from injector.go:
 
 func NewFactoryForTests(ctx context.Context, config Config) (*Factory, func(), error) {
+	diagnostics, cleanup := diag.New(ctx)
 	scriptConfig, err := ProvideUserScriptConfig(config)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	loader, err := script.ProvideLoader(scriptConfig)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	baseConfig, err := ProvideBaseConfig(config, loader)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
-	stagingPool, cleanup, err := ProvideStagingPool(ctx, baseConfig)
+	stagingPool, cleanup2, err := ProvideStagingPool(ctx, baseConfig, diagnostics)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	stagingSchema, err := ProvideStagingDB(baseConfig)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	targetPool, cleanup3, err := ProvideTargetPool(ctx, baseConfig)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
-	appliers, cleanup5 := apply.ProvideFactory(configs, targetPool, watchers)
+	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, diagnostics, stagingPool, stagingSchema)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	targetPool, cleanup4, err := ProvideTargetPool(ctx, baseConfig, diagnostics)
+	if err != nil {
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	watchers, cleanup5, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	if err != nil {
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	appliers, cleanup6, err := apply.ProvideFactory(configs, diagnostics, targetPool, watchers)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -63,8 +88,9 @@ func NewFactoryForTests(ctx context.Context, config Config) (*Factory, func(), e
 		return nil, nil, err
 	}
 	checker := version.ProvideChecker(stagingPool, memoMemo)
-	factory, err := ProvideFactory(ctx, appliers, configs, baseConfig, memoMemo, loader, stagingPool, targetPool, watchers, checker)
+	factory, err := ProvideFactory(ctx, appliers, configs, baseConfig, diagnostics, memoMemo, loader, stagingPool, targetPool, watchers, checker)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -73,6 +99,7 @@ func NewFactoryForTests(ctx context.Context, config Config) (*Factory, func(), e
 		return nil, nil, err
 	}
 	return factory, func() {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()

--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
 	"github.com/go-mysql-org/go-mysql/client"
@@ -69,7 +70,19 @@ const (
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=mutationType
 
-var _ logical.Dialect = (*conn)(nil)
+var (
+	_ diag.Diagnostic = (*conn)(nil)
+	_ logical.Dialect = (*conn)(nil)
+)
+
+// Diagnostics implements [diag.Diagnostic].
+func (c *conn) Diagnostic(_ context.Context) any {
+	return map[string]any{
+		"columns":   c.columns,
+		"flavor":    c.flavor,
+		"relations": c.relations,
+	}
+}
 
 // Process implements logical.Dialect and receives a sequence of logical
 // replication messages, or possibly a rollbackMessage.

--- a/internal/source/mylogical/injector.go
+++ b/internal/source/mylogical/injector.go
@@ -26,15 +26,24 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
+// MYLogical isa MySQL/MariaDB logical replication loop.
+type MYLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
+}
+
 // Start creates a MySQL/MariaDB logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
 	panic(wire.Build(
 		wire.Bind(new(logical.Config), new(*Config)),
+		wire.Struct(new(MYLogical), "*"),
 		Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/source/pglogical/injector.go
+++ b/internal/source/pglogical/injector.go
@@ -26,15 +26,24 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
+// PGLogical is a PostgreSQL logical replication loop.
+type PGLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
+}
+
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 	panic(wire.Build(
 		wire.Bind(new(logical.Config), new(*Config)),
+		wire.Struct(new(PGLogical), "*"),
 		Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
@@ -141,7 +142,7 @@ func testPGLogical(t *testing.T, allowBackfill, immediate bool, withChaosProb fl
 	} else {
 		cfg.BackfillWindow = 0
 	}
-	loop, cancelLoop, err := Start(ctx, cfg)
+	repl, cancelLoop, err := Start(ctx, cfg)
 	if !a.NoError(err) {
 		return
 	}
@@ -222,11 +223,13 @@ func testPGLogical(t *testing.T, allowBackfill, immediate bool, withChaosProb fl
 		}
 	}
 
+	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
+
 	cancelLoop()
 	select {
 	case <-ctx.Done():
 		a.Fail("cancelConn timed out")
-	case <-loop.Stopped():
+	case <-repl.Loop.Stopped():
 		// OK
 	}
 }
@@ -349,7 +352,7 @@ func TestDataTypes(t *testing.T) {
 	log.Info(tgts)
 
 	// Start the connection, to demonstrate that we can backfill pending mutations.
-	loop, cancelLoop, err := Start(ctx, &Config{
+	repl, cancelLoop, err := Start(ctx, &Config{
 		BaseConfig: logical.BaseConfig{
 			RetryDelay:    time.Nanosecond,
 			StagingSchema: fixture.StagingDB.Schema(),
@@ -386,9 +389,11 @@ func TestDataTypes(t *testing.T) {
 		})
 	}
 
+	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
+
 	cancelLoop()
 	select {
-	case <-loop.Stopped():
+	case <-repl.Loop.Stopped():
 	case <-ctx.Done():
 	}
 }

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -15,53 +15,79 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 )
 
 // Injectors from injector.go:
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
+func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
+	diagnostics, cleanup := diag.New(ctx)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	loader, err := script.ProvideLoader(scriptConfig)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	dialect, err := ProvideDialect(ctx, config, loader)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	baseConfig, err := logical.ProvideBaseConfig(config, loader)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
-	stagingPool, cleanup, err := logical.ProvideStagingPool(ctx, baseConfig)
+	stagingPool, cleanup2, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	configs, cleanup2, err := applycfg.ProvideConfigs(ctx, stagingPool, stagingSchema)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	targetPool, cleanup3, err := logical.ProvideTargetPool(ctx, baseConfig)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	watchers, cleanup4 := schemawatch.ProvideFactory(targetPool)
-	appliers, cleanup5 := apply.ProvideFactory(configs, targetPool, watchers)
+	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, diagnostics, stagingPool, stagingSchema)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	targetPool, cleanup4, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
+	if err != nil {
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	watchers, cleanup5, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	if err != nil {
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	appliers, cleanup6, err := apply.ProvideFactory(configs, diagnostics, targetPool, watchers)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -70,8 +96,9 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		return nil, nil, err
 	}
 	checker := version.ProvideChecker(stagingPool, memoMemo)
-	factory, err := logical.ProvideFactory(ctx, appliers, configs, baseConfig, memoMemo, loader, stagingPool, targetPool, watchers, checker)
+	factory, err := logical.ProvideFactory(ctx, appliers, configs, baseConfig, diagnostics, memoMemo, loader, stagingPool, targetPool, watchers, checker)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -79,8 +106,9 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	loop, cleanup6, err := ProvideLoop(config, dialect, factory)
+	loop, cleanup7, err := ProvideLoop(config, dialect, factory)
 	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -88,7 +116,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	return loop, func() {
+	pgLogical := &PGLogical{
+		Diagnostics: diagnostics,
+		Loop:        loop,
+	}
+	return pgLogical, func() {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -96,4 +129,12 @@ func Start(ctx context.Context, config *Config) (*logical.Loop, func(), error) {
 		cleanup2()
 		cleanup()
 	}, nil
+}
+
+// injector.go:
+
+// PGLogical is a PostgreSQL logical replication loop.
+type PGLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
 }

--- a/internal/source/server/injector.go
+++ b/internal/source/server/injector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
 
@@ -34,6 +35,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
 )
@@ -36,6 +37,7 @@ import (
 type testFixture struct {
 	Authenticator types.Authenticator
 	Config        *Config
+	Diagnostics   *diag.Diagnostics
 	Listener      net.Listener
 	StagingPool   *types.StagingPool
 	Server        *Server
@@ -49,6 +51,7 @@ func newTestFixture(context.Context, *Config) (*testFixture, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
+		diag.New,
 		logical.Set,
 		script.Set,
 		staging.Set,

--- a/internal/staging/applycfg/configs.go
+++ b/internal/staging/applycfg/configs.go
@@ -60,6 +60,11 @@ type Configs struct {
 	}
 }
 
+// Diagnostic implements [diag.Diagnostic].
+func (c *Configs) Diagnostic(_ context.Context) any {
+	return c.GetAll()
+}
+
 // Get returns the configuration for the named table, or a non-nil, zero
 // value if no configuration has been provided.
 func (c *Configs) Get(tbl ident.Table) *Config {

--- a/internal/staging/auth/broken/broken.go
+++ b/internal/staging/auth/broken/broken.go
@@ -14,33 +14,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package trust contains a types.Authenticator which always returns true.
-package trust
+// Package broken contains an Authenticator that always fails.
+package broken
 
 import (
 	"context"
+	"errors"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 )
 
-// authenticator is a no-op implementation of types.Authenticator
-// that always returns true.
-type authenticator struct{}
+// ErrBroken can be expected by tests.
+var ErrBroken = errors.New("broken")
 
-// New returns an Authenticator which always allows incoming requests.
+// New returns an Authenticator that always returns [ErrBroken].
 func New() types.Authenticator {
-	return &authenticator{}
+	return &broken{}
 }
 
-var _ types.Authenticator = (*authenticator)(nil)
+type broken struct{}
 
-// Check always returns true.
-func (a *authenticator) Check(context.Context, ident.Schema, string) (bool, error) {
-	return true, nil
-}
-
-// Diagnostic implements diag.Diagnostic.
-func (a *authenticator) Diagnostic(context.Context) any {
-	return map[string]bool{"trust": true}
+func (b *broken) Check(context.Context, ident.Schema, string) (ok bool, _ error) {
+	return false, ErrBroken
 }

--- a/internal/staging/auth/jwt/jwt.go
+++ b/internal/staging/auth/jwt/jwt.go
@@ -143,6 +143,27 @@ func (a *authenticator) Check(
 	return false, nil
 }
 
+// Diagnostic implements [diag.Diagnostic].
+func (a *authenticator) Diagnostic(context.Context) any {
+	type payload struct {
+		JWT        bool
+		PublicKeys int
+		Revoked    map[string]bool
+	}
+	p := payload{
+		JWT:     true,
+		Revoked: map[string]bool{},
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	p.PublicKeys = len(a.mu.publicKeys)
+	for id := range a.mu.revoked {
+		p.Revoked[id] = true
+	}
+	return p
+}
+
 const (
 	ensureKeysTemplate = `
 CREATE TABLE IF NOT EXISTS %s (

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -168,7 +168,7 @@ func (a *apply) Apply(ctx context.Context, tx types.TargetQuerier, muts []types.
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	if a.mu.templates.Len() == 0 {
+	if a.mu.templates.Positions.Len() == 0 {
 		return errors.Errorf("no ColumnData available for %s", a.target)
 	}
 
@@ -303,7 +303,7 @@ func (a *apply) upsertLocked(
 		var unexpectedColumns []string
 
 		err = rowData.Range(func(incomingColName ident.Ident, value any) error {
-			targetColumn, ok := a.mu.templates.Get(incomingColName)
+			targetColumn, ok := a.mu.templates.Positions.Get(incomingColName)
 
 			// The incoming data didn't map to a column. Report an error
 			// if no extras column has been configured or accumulate it

--- a/internal/target/apply/column_mapping.go
+++ b/internal/target/apply/column_mapping.go
@@ -34,18 +34,18 @@ import (
 // The columnMapping also contains data about the target schema that we
 // want to memoize.
 type columnMapping struct {
-	*ident.Map[positionalColumn]                    // Map of idents to column info and position.
-	Conditions                   []types.ColData    // The version-like fields for CAS ops.
-	Columns                      []types.ColData    // All columns named in an upsert statement.
-	Data                         []types.ColData    // Non-PK, non-ignored columns.
-	Deadlines                    types.Deadlines    // Allow too-old data to just be dropped.
-	Exprs                        *ident.Map[string] // Value-replacement expressions.
-	ExtrasColIdx                 int                // Position of the extras column, or -1 if unconfigured.
-	Product                      types.Product      // Target database product.
-	PK                           []types.ColData    // The names of the PK columns.
-	PKDelete                     []types.ColData    // The names of the PK columns to delete.
-	TableName                    ident.Table        // The target table.
-	UpsertParameterCount         int                // The number of SQL arguments.
+	Conditions           []types.ColData              // The version-like fields for CAS ops.
+	Columns              []types.ColData              // All columns named in an upsert statement.
+	Data                 []types.ColData              // Non-PK, non-ignored columns.
+	Deadlines            types.Deadlines              // Allow too-old data to just be dropped.
+	Exprs                *ident.Map[string]           // Value-replacement expressions.
+	ExtrasColIdx         int                          // Position of the extras column, or -1 if unconfigured.
+	Positions            *ident.Map[positionalColumn] // Map of idents to column info and position.
+	Product              types.Product                // Target database product.
+	PK                   []types.ColData              // The names of the PK columns.
+	PKDelete             []types.ColData              // The names of the PK columns to delete.
+	TableName            ident.Table                  // The target table.
+	UpsertParameterCount int                          // The number of SQL arguments.
 }
 
 // positionalColumn augments ColData with the offset of the positional
@@ -63,7 +63,7 @@ func newColumnMapping(
 		Deadlines:    &ident.Map[time.Duration]{},
 		Exprs:        &ident.Map[string]{},
 		ExtrasColIdx: -1,
-		Map:          &ident.Map[positionalColumn]{},
+		Positions:    &ident.Map[positionalColumn]{},
 		Product:      product,
 		TableName:    table,
 	}
@@ -76,7 +76,7 @@ func newColumnMapping(
 	// Track the positional parameters for an upsert.
 	currentParameterIndex := 0
 	for _, col := range cols {
-		if _, collision := ret.Get(col.Name); collision {
+		if _, collision := ret.Positions.Get(col.Name); collision {
 			return nil, errors.Errorf("column name collision: %s", col.Name)
 		}
 
@@ -116,7 +116,7 @@ func newColumnMapping(
 		// ensures that all data that is part of a mutation has
 		// somewhere to go or has been explicitly ignored, either by the
 		// target database or by the user.
-		ret.Put(col.Name, positionalColumn{col, positionalParameterIndex})
+		ret.Positions.Put(col.Name, positionalColumn{col, positionalParameterIndex})
 
 		if !willUpsert {
 			continue
@@ -149,8 +149,8 @@ func newColumnMapping(
 	// We also allow the user to force non-existent columns to be
 	// ignored (e.g. to drop a column).
 	_ = cfg.Ignore.Range(func(tgt ident.Ident, _ bool) error {
-		if _, alreadyIgnored := ret.Get(tgt); !alreadyIgnored {
-			ret.Put(tgt, positionalColumn{
+		if _, alreadyIgnored := ret.Positions.Get(tgt); !alreadyIgnored {
+			ret.Positions.Put(tgt, positionalColumn{
 				ColData: types.ColData{
 					Ignored: true,
 					Name:    tgt,
@@ -164,8 +164,8 @@ func newColumnMapping(
 
 	// Add redundant mappings for renamed columns.
 	if err := cfg.SourceNames.Range(func(tgt ident.Ident, src applycfg.SourceColumn) error {
-		if found, ok := ret.Get(tgt); ok {
-			ret.Put(src, found)
+		if found, ok := ret.Positions.Get(tgt); ok {
+			ret.Positions.Put(src, found)
 		}
 		return nil
 	}); err != nil {

--- a/internal/target/schemawatch/provider.go
+++ b/internal/target/schemawatch/provider.go
@@ -18,6 +18,7 @@ package schemawatch
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/wire"
 )
@@ -28,8 +29,11 @@ var Set = wire.NewSet(
 )
 
 // ProvideFactory is called by Wire to construct the Watchers factory.
-func ProvideFactory(pool *types.TargetPool) (types.Watchers, func()) {
+func ProvideFactory(pool *types.TargetPool, d *diag.Diagnostics) (types.Watchers, func(), error) {
 	w := &factory{pool: pool}
 	w.mu.data = &ident.SchemaMap[*watcher]{}
-	return w, w.close
+	if err := d.Register("schema", w); err != nil {
+		return nil, nil, err
+	}
+	return w, w.close, nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -199,7 +199,7 @@ type ColData struct {
 	// A Parse function may be supplied to allow a string representation
 	// of a complex datatype to be converted into a type more readily
 	// used by a target database driver.
-	Parse   func(string) (any, bool)
+	Parse   func(string) (any, bool) `json:"-"`
 	Primary bool
 	// Type of the column.
 	Type string

--- a/internal/util/diag/diag.go
+++ b/internal/util/diag/diag.go
@@ -1,0 +1,177 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package diag contains a mechanism for cdc-sink components to report
+// structured diagnostic information.
+package diag
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"runtime/debug"
+	"sync"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/httpauth"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Schema is passed to the authenticator.
+var Schema = ident.MustSchema(ident.New("_"), ident.New("diag"))
+
+// Diagnostic is implemented by any type that can provide structured
+// diagnostic data for use in a support engagement.
+type Diagnostic interface {
+	// Diagnostic returns a json-serializable value that represent the
+	// reportable state of the component.
+	Diagnostic(context.Context) any
+}
+
+// A DiagnosticFn is passed to [Diagnostics.Register]. This type is use
+// similarly to [http.HandlerFunc].
+type DiagnosticFn func(context.Context) any
+
+// Diagnostic implements Diagnostic.
+func (c DiagnosticFn) Diagnostic(ctx context.Context) any {
+	return c(ctx)
+}
+
+// Diagnostics serves as a registry for Diagnostic implementations.
+type Diagnostics struct {
+	mu struct {
+		sync.RWMutex
+		impls map[string]Diagnostic
+	}
+}
+
+// New constructs a Diagnostics. The instance will write itself to the
+// log stream if the process receives a SIGUSR1.
+func New(ctx context.Context) (*Diagnostics, func()) {
+	ret := &Diagnostics{}
+	ret.mu.impls = map[string]Diagnostic{
+		"build": DiagnosticFn(func(context.Context) any {
+			bi, ok := debug.ReadBuildInfo()
+			if !ok {
+				return nil
+			}
+			info := make(map[string]string, len(bi.Settings))
+			for _, s := range bi.Settings {
+				info[s.Key] = s.Value
+			}
+			return info
+		}),
+		"cmd": DiagnosticFn(func(context.Context) any {
+			return os.Args
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	logOnSignal(ctx, ret)
+
+	return ret, cancel
+}
+
+// Handler returns an [http.Handler] to provide a summary report.
+// The [Schema] value will be passed to the Authenticator.
+func (d *Diagnostics) Handler(auth types.Authenticator) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		token := httpauth.Token(req)
+		ok, err := auth.Check(req.Context(), Schema, token)
+		if err != nil {
+			log.WithError(err).Warn("could not authenticate request")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := d.Write(req.Context(), w, true); err != nil {
+			log.WithError(err).Warn("could not write diagnostics")
+		}
+	})
+}
+
+// Payload returns the diagnostic payload.
+func (d *Diagnostics) Payload(ctx context.Context) map[string]any {
+	ret := make(map[string]any)
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for key, impl := range d.mu.impls {
+		ret[key] = impl.Diagnostic(ctx)
+	}
+
+	return ret
+}
+
+// Register adds a callback to generate a portion of the diagnostics
+// output. The name will be used as the key in the emitted JSON literal,
+// and the value will be the serialized form of the callback's return
+// value. This method will return an error if the same name is
+// registered twice.
+//
+// Note that the callback may be called at any time (possibly
+// concurrently), so implementations should be written in a thread-safe
+// manner.
+func (d *Diagnostics) Register(name string, intf Diagnostic) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, conflict := d.mu.impls[name]; conflict {
+		return errors.Errorf("%s already registered", name)
+	}
+	d.mu.impls[name] = intf
+	return nil
+}
+
+// Unregister removes a registration.
+func (d *Diagnostics) Unregister(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.mu.impls, name)
+}
+
+// Wrap returns a new instance of Diagnostics that will report its
+// values as an embedded value.
+func (d *Diagnostics) Wrap(name string) (*Diagnostics, error) {
+	next := &Diagnostics{}
+	next.mu.impls = map[string]Diagnostic{}
+
+	return next, d.Register(name, DiagnosticFn(func(ctx context.Context) any {
+		return next.Payload(ctx)
+	}))
+}
+
+// Write the diagnostic report.
+func (d *Diagnostics) Write(ctx context.Context, w io.Writer, pretty bool) error {
+	p := d.Payload(ctx)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(true)
+	if pretty {
+		enc.SetIndent("", " ")
+	}
+	return enc.Encode(p)
+}

--- a/internal/util/diag/diag_test.go
+++ b/internal/util/diag/diag_test.go
@@ -1,0 +1,117 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/broken"
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/reject"
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuth(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d, cancel := New(ctx)
+	defer cancel()
+
+	tcs := []struct {
+		auth   types.Authenticator
+		expect int
+	}{
+		{
+			auth:   trust.New(),
+			expect: http.StatusOK,
+		},
+		{
+			auth:   reject.New(),
+			expect: http.StatusForbidden,
+		},
+		{
+			auth:   broken.New(),
+			expect: http.StatusInternalServerError,
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			r := require.New(t)
+			// The path is irrelevant here.
+			req := httptest.NewRequest(http.MethodGet, "/_/diag", nil)
+			w := httptest.NewRecorder()
+
+			d.Handler(tc.auth).ServeHTTP(w, req)
+			r.Equal(tc.expect, w.Code)
+		})
+	}
+}
+
+func TestDiagnostics(t *testing.T) {
+	r := require.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d, cancel := New(ctx)
+	defer cancel()
+
+	var didCall atomic.Bool
+	r.NoError(d.Register("foo", DiagnosticFn(func(context.Context) any {
+		didCall.Store(true)
+		return "XYZZY"
+	})))
+
+	// Re-reginstration should fail.
+	r.ErrorContains(d.Register("foo", nil), "foo already registered")
+
+	// Add a nested diagnostic.
+	sub, err := d.Wrap("sub")
+	r.NoError(err)
+	r.NoError(sub.Register("bar", DiagnosticFn(func(ctx context.Context) any {
+		return "baz"
+	})))
+
+	var buf bytes.Buffer
+	r.NoError(d.Write(context.Background(), &buf, false))
+	r.True(didCall.Load())
+
+	// Spot-check the contents.
+	var parsed map[string]any
+	r.NoError(json.Unmarshal(buf.Bytes(), &parsed))
+	r.Contains(parsed, "build") // Automatically added
+	r.Contains(parsed, "cmd")
+	r.Equal("XYZZY", parsed["foo"])
+	r.Equal(map[string]any{"bar": "baz"}, parsed["sub"])
+
+	before := len(d.mu.impls)
+	d.Unregister("foo")
+	r.Equal(before-1, len(d.mu.impls))
+
+	// Not an error
+	d.Unregister("unknown")
+}

--- a/internal/util/diag/signal_windows.go
+++ b/internal/util/diag/signal_windows.go
@@ -14,27 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build wireinject
-// +build wireinject
+//go:build windows
 
-package logical
+package diag
 
-import (
-	"context"
+import "context"
 
-	"github.com/cockroachdb/cdc-sink/internal/script"
-	"github.com/cockroachdb/cdc-sink/internal/staging"
-	"github.com/cockroachdb/cdc-sink/internal/target"
-	"github.com/cockroachdb/cdc-sink/internal/util/diag"
-	"github.com/google/wire"
-)
-
-func NewFactoryForTests(ctx context.Context, config Config) (*Factory, func(), error) {
-	panic(wire.Build(
-		Set,
-		diag.New,
-		script.Set,
-		staging.Set,
-		target.Set,
-	))
-}
+// logOnSignal is a no-op on Windows.
+func logOnSignal(ctx context.Context, d *Diagnostics) {}

--- a/internal/util/httpauth/httpauth.go
+++ b/internal/util/httpauth/httpauth.go
@@ -1,0 +1,48 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpauth contains a common function for extracting
+// credentials from an HTTP request.
+package httpauth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Token returns the bearer authorization header or the access_token
+// HTTP parameter associated with the request. If an authorization query
+// parameter is used, the request will be updated to delete that
+// parameter. This function will return an empty string if no
+// authorization token is associated with the request.
+func Token(req *http.Request) string {
+	var token string
+	if raw := req.Header.Get("Authorization"); raw != "" {
+		if strings.HasPrefix(raw, "Bearer ") {
+			token = raw[7:]
+		}
+	} else if token = req.URL.Query().Get("access_token"); token != "" {
+		// Delete the token query parameter to prevent logging later
+		// on. This doesn't take care of issues with L7
+		// loadbalancers, but this param is used by other
+		// OAuth-style implementations and will hopefully be
+		// discarded without logging.
+		values := req.URL.Query()
+		values.Del("access_token")
+		req.URL.RawQuery = values.Encode()
+	}
+	return token
+}

--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -88,7 +88,15 @@ func OpenOracleAsTarget(
 			return nil, errors.Wrap(err, "could not query version")
 		}
 
-		return ret, attachOptions(ctx, ret.DB, options)
+		if err := attachOptions(ctx, ret.DB, options); err != nil {
+			return nil, err
+		}
+
+		if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
+			return nil, err
+		}
+
+		return ret, nil
 	})
 }
 

--- a/internal/util/stdpool/pgx.go
+++ b/internal/util/stdpool/pgx.go
@@ -92,6 +92,10 @@ func OpenPgxAsStaging(
 		return nil, nil, errors.Errorf("only CockroachDB is supported as a staging server; saw %q", ret.Version)
 	}
 
+	if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
+		return nil, nil, err
+	}
+
 	success = true
 	return ret, cancel, err
 }
@@ -138,6 +142,10 @@ func OpenPgxAsTarget(
 		ret.Product = types.ProductPostgreSQL
 	default:
 		return nil, nil, errors.Errorf("unknown product for version: %s", ret.Version)
+	}
+
+	if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
+		return nil, nil, err
 	}
 
 	success = true


### PR DESCRIPTION
Note this is stacked on top of PR #439.

This change adds a global diagnostics collector to improve the supportability
of cdc-sink. The diag package allows various components to register themselves
in order to produce an arbitrary blob of JSON that we can use to support
customers. The applycfg package had an initial implementation of exporting the
current configuration via an HTTP endpoint; this change generalizes and expands
on it.

Review notes:
* The diag package defines the collector and a basic interface for returning a
  json value.
* Components are registered with the diag package by their provider functions.
* Diagnostics are available at /_/diag, which is protected by the active
  authenticator when in C2X modes.
* Hyrum's law notwithstanding, the data returned by the diagnostic endpoint is
  not intended to represent a stable API,
* The `Start()` function in the mylogical and pglogical packages now return a
  wrapper struct instead of the replication loop. This allows the Diagnostics
  struct to also be returned to the caller.
* It's debatable whether or not the `Diagnostic()` method should accept a
  Context. It's not used currently, but this will save some churn later on if
  some future implementation needs it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/440)
<!-- Reviewable:end -->
