### PR TITLE
internal: Use newer sync/atomic APIs

### DIFF
--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -505,7 +505,7 @@ func (r *resolver) selectTimestamp(ctx context.Context, after hlc.Time) (hlc.Tim
 // goroutines which it spawns will terminate when the context is
 // canceled.
 func (r *resolver) retireLoop(ctx context.Context) {
-	var toRetire atomic.Value
+	var toRetire atomic.Pointer[hlc.Time]
 	wakeup := make(chan struct{}, 1)
 
 	// Coalesce incoming candidates value. This goroutine will exit
@@ -515,7 +515,7 @@ func (r *resolver) retireLoop(ctx context.Context) {
 		for {
 			select {
 			case retire := <-r.retirements:
-				toRetire.Store(retire)
+				toRetire.Store(&retire)
 				select {
 				case wakeup <- struct{}{}:
 				default:
@@ -531,7 +531,7 @@ func (r *resolver) retireLoop(ctx context.Context) {
 	// will exit when the wakeup channel has been closed.
 	go func() {
 		for range wakeup {
-			next := toRetire.Load().(hlc.Time)
+			next := *toRetire.Load()
 			log.Tracef("retiring mutations in %s <= %s", r.target, next)
 
 			targetTables := r.watcher.Get().Columns

--- a/internal/source/logical/generator_test.go
+++ b/internal/source/logical/generator_test.go
@@ -54,8 +54,8 @@ type generatorDialect struct {
 
 	// Counters to ensure we shut down cleanly.
 	atomic struct {
-		readIntoExits int32
-		processExits  int32
+		readIntoExits atomic.Int32
+		processExits  atomic.Int32
 	}
 
 	workRequested chan struct{}
@@ -107,7 +107,7 @@ func (g *generatorDialect) ReadInto(
 	ctx context.Context, ch chan<- logical.Message, state logical.State,
 ) error {
 	log.Trace("ReadInto starting")
-	defer atomic.AddInt32(&g.atomic.readIntoExits, 1)
+	defer g.atomic.readIntoExits.Add(1)
 
 	var nextBatchNumber int
 	// If we're recovering from a failure condition, reset to a consistent point.
@@ -159,7 +159,7 @@ func (g *generatorDialect) Process(
 	ctx context.Context, ch <-chan logical.Message, events logical.Events,
 ) error {
 	log.Trace("Process starting")
-	defer atomic.AddInt32(&g.atomic.processExits, 1)
+	defer g.atomic.processExits.Add(1)
 
 	for m := range ch {
 		g.processMu.Lock()

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -18,7 +18,6 @@ package logical_test
 
 import (
 	"fmt"
-	"sync/atomic"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -140,8 +139,8 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 		a.Fail("timed out waiting for shutdown")
 	}
 	if !withChaos && !allowBackfill {
-		a.Equal(int32(1), atomic.LoadInt32(&gen.atomic.processExits))
-		a.Equal(int32(1), atomic.LoadInt32(&gen.atomic.readIntoExits))
+		a.Equal(int32(1), gen.atomic.processExits.Load())
+		a.Equal(int32(1), gen.atomic.readIntoExits.Load())
 	}
 
 	select {

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -469,7 +469,7 @@ func benchmarkStage(b *testing.B, batchSize int) {
 		b.Fatal(err)
 	}
 
-	allBytes := int64(0)
+	var allBytes atomic.Int64
 	muts := mutations.Generator(ctx, 100000, 0.5)
 
 	b.ResetTimer()
@@ -479,7 +479,7 @@ func benchmarkStage(b *testing.B, batchSize int) {
 			for i := range batch {
 				mut := <-muts
 				batch[i] = mut
-				atomic.AddInt64(&allBytes, int64(len(mut.Data)+len(mut.Key)))
+				allBytes.Add(int64(len(mut.Data) + len(mut.Key)))
 			}
 			if err := s.Store(ctx, fixture.StagingPool, batch); err != nil {
 				b.Fatal(err)
@@ -487,6 +487,6 @@ func benchmarkStage(b *testing.B, batchSize int) {
 		}
 	})
 	// Use JSON byte count as throughput measure.
-	b.SetBytes(atomic.LoadInt64(&allBytes))
+	b.SetBytes(allBytes.Load())
 
 }

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -1145,7 +1145,7 @@ func benchConditions(b *testing.B, cfg benchConfig) {
 	// Create a source of Mutatation data.
 	muts := mutations.Generator(ctx, 100000, 0)
 
-	var loopTotal int64
+	var loopTotal atomic.Int64
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		batch := make([]types.Mutation, cfg.batchSize)
@@ -1155,7 +1155,7 @@ func benchConditions(b *testing.B, cfg benchConfig) {
 			for i := range batch {
 				mut := <-muts
 				batch[i] = mut
-				atomic.AddInt64(&loopTotal, int64(len(mut.Data)))
+				loopTotal.Add(int64(len(mut.Data)))
 			}
 
 			// Applying a discarded mutation should never result in an error.
@@ -1167,5 +1167,5 @@ func benchConditions(b *testing.B, cfg benchConfig) {
 	})
 
 	// Use bytes as a throughput measure.
-	b.SetBytes(atomic.LoadInt64(&loopTotal))
+	b.SetBytes(loopTotal.Load())
 }


### PR DESCRIPTION
This change uses the newer atomic value types for improved ergonomics (e.g. atomic.Bool instead of swapping zero and one).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/442)
<!-- Reviewable:end -->
