### PR TITLE
target: Fix edge cases in UDT enum arrays

### DIFF
--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -318,7 +318,7 @@ func (c *conn) onDataTuple(
 				enc[targetCol.Name.Raw()] = string(s)
 			case int64:
 				// if it's a bit need to convert to a string representation
-				if targetCol.Type == mysql.MYSQL_TYPE_BIT {
+				if targetCol.Type == fmt.Sprintf("%d", mysql.MYSQL_TYPE_BIT) {
 					enc[targetCol.Name.Raw()] = strconv.FormatInt(s, 2)
 				} else {
 					enc[targetCol.Name.Raw()] = s
@@ -374,7 +374,7 @@ func (c *conn) onRelation(msg *replication.TableMapEvent) error {
 			Ignored: false,
 			Name:    ident.New(string(msg.ColumnName[idx])),
 			Primary: found,
-			Type:    ctype,
+			Type:    fmt.Sprintf("%d", ctype),
 		}
 	}
 	c.columns.Put(tbl, colData)

--- a/internal/target/apply/queries/pg/common.tmpl
+++ b/internal/target/apply/queries/pg/common.tmpl
@@ -20,8 +20,8 @@ adds explicit typecasts: ($1::STRING, $2::INT), (...), (...), ...
             {{- if $pairIdx -}},{{- end -}}
             {{- if $pair.Expr -}}
                 ({{ $pair.Expr }})::{{ $pair.Column.Type }}
-            {{- else if isUDT $pair.Column.Type -}}
-                ${{ $pair.Index }}::{{ $pair.Column.Type }}
+            {{- else if isUDTArray $pair.Column -}}
+                ${{ $pair.Index }}::TEXT[]::{{ $pair.Column.Type }}
             {{- else if eq $pair.Column.Type "GEOGRAPHY" -}}
                 st_geogfromgeojson(${{ $pair.Index }}::JSONB)
             {{- else if eq $pair.Column.Type "GEOMETRY" -}}

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -36,9 +36,13 @@ var (
 	queries embed.FS
 
 	tmplFuncs = template.FuncMap{
-		"isUDT": func(x any) bool {
-			_, ok := x.(ident.UDT)
-			return ok
+		// The pgx driver has trouble converting from the []any it gets
+		// when the mutation payload is unpacked, since it doesn't
+		// necessarily know the type details of an enum array. This hack
+		// changes the generated SQL so that the substitution parameter
+		// type is a string array, which is then cast to the enum array.
+		"isUDTArray": func(colData types.ColData) bool {
+			return strings.HasSuffix(colData.Type, "[]") && strings.Contains(colData.Type, ".")
 		},
 		// nl is a hack to force the inclusion of newlines in the output
 		// since we generally use the whitespace-consuming template

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -293,7 +293,7 @@ func TestQueryTemplatesPG(t *testing.T) {
 			Name: ident.New("enum"),
 			Type: ident.NewUDT(
 				ident.MustSchema(ident.New("database"), ident.New("schema")),
-				ident.New("MyEnum")),
+				ident.New("MyEnum")).String(),
 		},
 	}
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -201,8 +201,8 @@ type ColData struct {
 	// used by a target database driver.
 	Parse   func(string) (any, bool)
 	Primary bool
-	// Type of the column. Dialect might choose to use a string representation or a enum.
-	Type any
+	// Type of the column.
+	Type string
 }
 
 // Equal returns true if the two ColData are equivalent under

--- a/internal/util/ident/ident_test.go
+++ b/internal/util/ident/ident_test.go
@@ -136,5 +136,6 @@ func TestIdentSize(t *testing.T) {
 	a.Equal(expectedIdentWords, int(unsafe.Sizeof(Ident{})/ptrSize))
 	a.Equal(expectedIdentWords, int(unsafe.Sizeof(Schema{})/ptrSize))
 	a.Equal(expectedIdentWords, int(unsafe.Sizeof(Table{})/ptrSize))
-	a.Equal(expectedIdentWords, int(unsafe.Sizeof(UDT{})/ptrSize))
+	// Plus one for the array field.
+	a.Equal(expectedIdentWords+1, int(unsafe.Sizeof(UDT{})/ptrSize))
 }

--- a/internal/util/ident/parse_test.go
+++ b/internal/util/ident/parse_test.go
@@ -95,6 +95,15 @@ func TestParseIdent(t *testing.T) {
 			input: "\"is \uFFFD error\"",
 			err:   "malformed UTF8 input",
 		},
+		{
+			input: `baz[]`,
+			ident: New(`baz[]`),
+		},
+		{
+			input:     `"baz"[]`,
+			ident:     New(`baz`),
+			remainder: "[]",
+		},
 	}
 
 	for idx, tc := range tcs {

--- a/internal/util/ident/udt_test.go
+++ b/internal/util/ident/udt_test.go
@@ -36,3 +36,18 @@ func TestUDTJson(t *testing.T) {
 	a.Same(id.namespace, id2.namespace)
 	a.Same(id.terminal, id2.terminal)
 }
+
+func TestUDTArrayJson(t *testing.T) {
+	a := assert.New(t)
+
+	id := NewUDTArray(MustSchema(New("db"), New("schema")), New("my_enum"))
+	data, err := json.Marshal(id)
+	a.NoError(err)
+
+	var id2 UDT
+	a.NoError(json.Unmarshal(data, &id2))
+	a.Equal(id, id2)
+	a.True(id2.IsArray())
+	a.Same(id.namespace, id2.namespace)
+	a.Same(id.terminal, id2.terminal)
+}


### PR DESCRIPTION
Arrays of UDT enums were under-tested. Adding tests revealed a number of
deficiencies in how enum types were being represented in the schemawatch
package.

Until we decide to implement a proper typesystem model, this change adds an
array field to the ident.UDT type. It also changes ColData.Type to a string,
since we really only ever need to send the column type back to the target
database after introspecting it. This has a minor knock-on effect in the
mylogical package, although that code only ever looks at the ColData.Type field
for a sentinel value.

A small tweak has been made to the pg template to overcome a limitation in the
pgx driver, where the type information for the array-of-enum isn't always
loaded by the time we want to send the enum values. The substitution parameter
is first cast to `TEXT[]` and thence to the enum array type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/448)
<!-- Reviewable:end -->
