### PR TITLE
logical: Fix stall if apply fails in nested backfill mode

### DIFF
--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -76,13 +76,14 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 	const numEmits = 100
 	gen.emit(numEmits)
 
-	var dialect logical.Dialect = gen
+	var chaosProb float32
 	if withChaos {
-		dialect = logical.WithChaos(gen, 0.05)
+		chaosProb = 0.1
 	}
 
 	cfg := &logical.BaseConfig{
 		ApplyTimeout:   time.Second, // Increase to make using the debugger easier.
+		ChaosProb:      chaosProb,
 		Immediate:      immediate,
 		RetryDelay:     time.Nanosecond,
 		StagingConn:    fixture.StagingPool.ConnectionString,
@@ -103,7 +104,7 @@ func testLogicalSmoke(t *testing.T, allowBackfill, immediate, withChaos bool) {
 	defer cancelFactory()
 
 	loop, cancelLoop, err := factory.Start(&logical.LoopConfig{
-		Dialect:      dialect,
+		Dialect:      gen,
 		LoopName:     "generator",
 		TargetSchema: dbName,
 	})


### PR DESCRIPTION
The fslogical frontend will experience a stall if a nested collection is being processed in backfill mode and a mutation cannot be applied. This is because the Flush() method waits on a counter condition variable that would never be decremented.

This change ensures that the decrement always happens by hoisting the guts of the loop() method into a closure and calling the decrement API via defer.

Testing for this condition is performed by plumbing the choas probability into fanWorkers to simulate the applier failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/449)
<!-- Reviewable:end -->
