### PR TITLE
apply: Allow sparse payloads to use SQL DEFAULT expressions

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Copyright headers
         if: ${{ always () }}
-        run: go run github.com/google/addlicense -c "The Cockroach Authors" -l apache -s -v  -check .
+        run: go run github.com/google/addlicense -c "The Cockroach Authors" -l apache -s -v  -check  -ignore '**/testdata/**/*.sql' .
 
       - name: Lint
         if: ${{ always() }}

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -327,7 +327,7 @@ func (a *apply) upsertLocked(
 			// in the input data, but that we don't actually want to
 			// make use of the provided value. For example, generated PK
 			// columns.
-			if targetColumn.UpsertPosition < 0 {
+			if targetColumn.UpsertIndex < 0 {
 				return nil
 			}
 
@@ -344,8 +344,15 @@ func (a *apply) upsertLocked(
 				}
 			}
 
+			// This loop is driven by the fields in the incoming
+			// payload, so we can just set the validity flag (if any) to
+			// a non-null value.
+			if targetColumn.ValidityIndex >= 0 {
+				allArgs[argIdx+targetColumn.ValidityIndex] = true
+			}
+
 			// Assign the value to the relevant offset in the args.
-			allArgs[argIdx+targetColumn.UpsertPosition] = value
+			allArgs[argIdx+targetColumn.UpsertIndex] = value
 			return nil
 		})
 		if err != nil {

--- a/internal/target/apply/column_mapping.go
+++ b/internal/target/apply/column_mapping.go
@@ -38,6 +38,7 @@ type columnMapping struct {
 	Columns              []types.ColData              // All columns named in an upsert statement.
 	Data                 []types.ColData              // Non-PK, non-ignored columns.
 	Deadlines            types.Deadlines              // Allow too-old data to just be dropped.
+	DeleteParameterCount int                          // The number of SQL arguments.
 	Exprs                *ident.Map[string]           // Value-replacement expressions.
 	ExtrasColIdx         int                          // Position of the extras column, or -1 if unconfigured.
 	Positions            *ident.Map[positionalColumn] // Map of idents to column info and position.
@@ -49,10 +50,12 @@ type columnMapping struct {
 }
 
 // positionalColumn augments ColData with the offset of the positional
-// substitution parameter to be used within a batch of values.
+// substitution parameter offsets to be used within a batch of values.
 type positionalColumn struct {
 	types.ColData
-	UpsertPosition int
+	DeleteIndex   int
+	UpsertIndex   int
+	ValidityIndex int
 }
 
 func newColumnMapping(
@@ -81,7 +84,9 @@ func newColumnMapping(
 		}
 
 		// PK columns are always mentioned in DELETE statements.
+		deletePosition := -1
 		if col.Primary {
+			deletePosition = len(ret.PKDelete)
 			ret.PKDelete = append(ret.PKDelete, col)
 		}
 
@@ -89,7 +94,11 @@ func newColumnMapping(
 		// negative value allows us to remember that the column exists,
 		// but that we don't intend to do anything with incoming data
 		// for that column.
-		positionalParameterIndex := -1
+		upsertPosition := -1
+		// Columns with SQL DEFAULT values require a flag to distinguish
+		// between unset fields in the incoming payload and explicit
+		// NULL values.
+		validityPosition := -1
 		// We also determine whether the column appears in an upsert
 		// statement at all.
 		willUpsert := false
@@ -106,7 +115,12 @@ func newColumnMapping(
 			// the template will bake in a fixed expression.
 			willUpsert = true
 		} else {
-			positionalParameterIndex = currentParameterIndex
+			if col.DefaultExpr != "" {
+				validityPosition = currentParameterIndex
+				currentParameterIndex++
+			}
+
+			upsertPosition = currentParameterIndex
 			currentParameterIndex++
 			willUpsert = true
 		}
@@ -116,7 +130,12 @@ func newColumnMapping(
 		// ensures that all data that is part of a mutation has
 		// somewhere to go or has been explicitly ignored, either by the
 		// target database or by the user.
-		ret.Positions.Put(col.Name, positionalColumn{col, positionalParameterIndex})
+		ret.Positions.Put(col.Name, positionalColumn{
+			ColData:       col,
+			DeleteIndex:   deletePosition,
+			UpsertIndex:   upsertPosition,
+			ValidityIndex: validityPosition,
+		})
 
 		if !willUpsert {
 			continue
@@ -141,9 +160,10 @@ func newColumnMapping(
 			ret.Exprs.Put(col.Name, expr)
 		}
 		if ident.Equal(col.Name, cfg.Extras) {
-			ret.ExtrasColIdx = positionalParameterIndex
+			ret.ExtrasColIdx = upsertPosition
 		}
 	}
+	ret.DeleteParameterCount = len(ret.PKDelete)
 	ret.UpsertParameterCount = currentParameterIndex
 
 	// We also allow the user to force non-existent columns to be
@@ -156,7 +176,9 @@ func newColumnMapping(
 					Name:    tgt,
 					Type:    "VOID",
 				},
-				UpsertPosition: -1,
+				DeleteIndex:   -1,
+				UpsertIndex:   -1,
+				ValidityIndex: -1,
 			})
 		}
 		return nil

--- a/internal/target/apply/queries/ora/common.tmpl
+++ b/internal/target/apply/queries/ora/common.tmpl
@@ -28,7 +28,17 @@ pairExpr emits a type-cast SQL expression for a single positional argument.
     {{- if $pair.Expr -}}
         CAST({{ $pair.Expr }} AS {{ $pair.Column.Type }})
     {{- else -}}
-        CAST(:p{{ $pair.Index }} AS {{ $pair.Column.Type }})
+
+        {{- if $pair.ValidityParam -}}
+            CASE WHEN :p{{ $pair.ValidityParam }} IS NOT NULL THEN {{- sp -}}
+        {{- end -}}
+
+        CAST(:p{{ $pair.Param }} AS {{ $pair.Column.Type }})
+
+        {{- if $pair.ValidityParam -}}
+            {{- sp -}} ELSE {{ $pair.Column.DefaultExpr }} END
+        {{- end -}}
+
     {{- end -}}
 {{- end -}}
 

--- a/internal/target/apply/queries/pg/common.tmpl
+++ b/internal/target/apply/queries/pg/common.tmpl
@@ -11,6 +11,11 @@
 {{- /*
 exprs produces a comma-separated list of substitution params tuples with
 adds explicit typecasts: ($1::STRING, $2::INT), (...), (...), ...
+
+If the target column has a SQL DEFAULT expression, we add an additional
+validity check using a CASE expression:
+  CASE WHEN $1::BOOLEAN THEN $2::STRING ELSE 'Default Value' END
+The validity check allows us to distinguish null vs. unset in the payload.
 */ -}}
 {{- define "exprs" -}}
     {{- range $groupIdx, $pairs := $.Vars -}}
@@ -18,16 +23,25 @@ adds explicit typecasts: ($1::STRING, $2::INT), (...), (...), ...
         (
         {{- range $pairIdx, $pair := $pairs -}}
             {{- if $pairIdx -}},{{- end -}}
+
+            {{- if $pair.ValidityParam -}}
+                CASE WHEN ${{ $pair.ValidityParam }}::BOOLEAN THEN {{- sp -}}
+            {{- end -}}
+
             {{- if $pair.Expr -}}
                 ({{ $pair.Expr }})::{{ $pair.Column.Type }}
             {{- else if isUDTArray $pair.Column -}}
-                ${{ $pair.Index }}::TEXT[]::{{ $pair.Column.Type }}
+                ${{ $pair.Param }}::TEXT[]::{{ $pair.Column.Type }}
             {{- else if eq $pair.Column.Type "GEOGRAPHY" -}}
-                st_geogfromgeojson(${{ $pair.Index }}::JSONB)
+                st_geogfromgeojson(${{ $pair.Param }}::JSONB)
             {{- else if eq $pair.Column.Type "GEOMETRY" -}}
-                st_geomfromgeojson(${{ $pair.Index }}::JSONB)
+                st_geomfromgeojson(${{ $pair.Param }}::JSONB)
             {{- else -}}
-                ${{ $pair.Index }}::{{ $pair.Column.Type }}
+                ${{ $pair.Param }}::{{ $pair.Column.Type }}
+            {{- end -}}
+
+            {{- if $pair.ValidityParam -}}
+                {{- sp -}} ELSE {{ $pair.Column.DefaultExpr }} END
             {{- end -}}
         {{- end -}}
         )

--- a/internal/target/apply/testdata/README.md
+++ b/internal/target/apply/testdata/README.md
@@ -1,0 +1,4 @@
+# Template test data
+
+This directory contains golden output for templates_test. To regenerate
+them, set the `rewriteFiles` constant to `true` and re-run the tests.

--- a/internal/target/apply/testdata/ora/base.delete.sql
+++ b/internal/target/apply/testdata/ora/base.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:p2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:p5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/base.upsert.sql
+++ b/internal/target/apply/testdata/ora/base.upsert.sql
@@ -1,0 +1,8 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","val0","val1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:p2 AS INT), CAST(:p3 AS VARCHAR(256)), CAST(:p4 AS VARCHAR(256)), CASE WHEN :p5 IS NOT NULL THEN CAST(:p6 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p7 AS VARCHAR(256)), CAST(:p8 AS INT), CAST(:p9 AS VARCHAR(256)), CAST(:p10 AS VARCHAR(256)), CASE WHEN :p11 IS NOT NULL THEN CAST(:p12 AS INT8) ELSE expr() END FROM DUAL
+)
+SELECT * FROM data) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","val0","val1","has_default") VALUES (x."pk0", x."pk1", x."val0", x."val1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "val0" = x."val0", "val1" = x."val1", "has_default" = x."has_default"

--- a/internal/target/apply/testdata/ora/cas.delete.sql
+++ b/internal/target/apply/testdata/ora/cas.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:p2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:p5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/cas.upsert.sql
+++ b/internal/target/apply/testdata/ora/cas.upsert.sql
@@ -1,0 +1,15 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","val0","val1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:p2 AS INT), CAST(:p3 AS VARCHAR(256)), CAST(:p4 AS VARCHAR(256)), CASE WHEN :p5 IS NOT NULL THEN CAST(:p6 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p7 AS VARCHAR(256)), CAST(:p8 AS INT), CAST(:p9 AS VARCHAR(256)), CAST(:p10 AS VARCHAR(256)), CASE WHEN :p11 IS NOT NULL THEN CAST(:p12 AS INT8) ELSE expr() END FROM DUAL
+),
+active AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "schema"."table" JOIN data USING ("pk0","pk1")),
+action AS (
+SELECT "pk0","pk1", data."val0",data."val1",data."has_default" FROM data
+LEFT JOIN active USING ("pk0","pk1") WHERE active."val1" IS NULL OR
+(data."val1",data."val0") > (active."val1",active."val0"))
+SELECT * FROM action) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","val0","val1","has_default") VALUES (x."pk0", x."pk1", x."val0", x."val1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "val0" = x."val0", "val1" = x."val1", "has_default" = x."has_default"

--- a/internal/target/apply/testdata/ora/casDeadline.delete.sql
+++ b/internal/target/apply/testdata/ora/casDeadline.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:p2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:p5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/casDeadline.upsert.sql
+++ b/internal/target/apply/testdata/ora/casDeadline.upsert.sql
@@ -1,0 +1,16 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","val0","val1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:p2 AS INT), CAST(:p3 AS VARCHAR(256)), CAST(:p4 AS VARCHAR(256)), CASE WHEN :p5 IS NOT NULL THEN CAST(:p6 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p7 AS VARCHAR(256)), CAST(:p8 AS INT), CAST(:p9 AS VARCHAR(256)), CAST(:p10 AS VARCHAR(256)), CASE WHEN :p11 IS NOT NULL THEN CAST(:p12 AS INT8) ELSE expr() END FROM DUAL
+),
+deadlined AS (SELECT * FROM data WHERE("val0"> (CURRENT_TIMESTAMP - NUMTODSINTERVAL(3600, 'SECOND')))AND("val1"> (CURRENT_TIMESTAMP - NUMTODSINTERVAL(1, 'SECOND')))),
+active AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "schema"."table" JOIN deadlined USING ("pk0","pk1")),
+action AS (
+SELECT "pk0","pk1", deadlined."val0",deadlined."val1",deadlined."has_default" FROM deadlined
+LEFT JOIN active USING ("pk0","pk1") WHERE active."val1" IS NULL OR
+(deadlined."val1",deadlined."val0") > (active."val1",active."val0"))
+SELECT * FROM action) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","val0","val1","has_default") VALUES (x."pk0", x."pk1", x."val0", x."val1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "val0" = x."val0", "val1" = x."val1", "has_default" = x."has_default"

--- a/internal/target/apply/testdata/ora/deadline.delete.sql
+++ b/internal/target/apply/testdata/ora/deadline.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:p2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:p5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/deadline.upsert.sql
+++ b/internal/target/apply/testdata/ora/deadline.upsert.sql
@@ -1,0 +1,9 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","val0","val1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:p2 AS INT), CAST(:p3 AS VARCHAR(256)), CAST(:p4 AS VARCHAR(256)), CASE WHEN :p5 IS NOT NULL THEN CAST(:p6 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p7 AS VARCHAR(256)), CAST(:p8 AS INT), CAST(:p9 AS VARCHAR(256)), CAST(:p10 AS VARCHAR(256)), CASE WHEN :p11 IS NOT NULL THEN CAST(:p12 AS INT8) ELSE expr() END FROM DUAL
+),
+deadlined AS (SELECT * FROM data WHERE("val0"> (CURRENT_TIMESTAMP - NUMTODSINTERVAL(3600, 'SECOND')))AND("val1"> (CURRENT_TIMESTAMP - NUMTODSINTERVAL(1, 'SECOND'))))
+SELECT * FROM deadlined) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","val0","val1","has_default") VALUES (x."pk0", x."pk1", x."val0", x."val1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "val0" = x."val0", "val1" = x."val1", "has_default" = x."has_default"

--- a/internal/target/apply/testdata/ora/expr.delete.sql
+++ b/internal/target/apply/testdata/ora/expr.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:ref2+:ref2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:ref5+:ref5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/expr.upsert.sql
+++ b/internal/target/apply/testdata/ora/expr.upsert.sql
@@ -1,0 +1,8 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","val0","val1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:ref2+:ref2 AS INT), CAST('fixed' AS VARCHAR(256)), CAST(:ref3||'foobar' AS VARCHAR(256)), CASE WHEN :p4 IS NOT NULL THEN CAST(:p5 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p6 AS VARCHAR(256)), CAST(:ref7+:ref7 AS INT), CAST('fixed' AS VARCHAR(256)), CAST(:ref8||'foobar' AS VARCHAR(256)), CASE WHEN :p9 IS NOT NULL THEN CAST(:p10 AS INT8) ELSE expr() END FROM DUAL
+)
+SELECT * FROM data) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","val0","val1","has_default") VALUES (x."pk0", x."pk1", x."val0", x."val1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "val0" = x."val0", "val1" = x."val1", "has_default" = x."has_default"

--- a/internal/target/apply/testdata/ora/ignore.delete.sql
+++ b/internal/target/apply/testdata/ora/ignore.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:p2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:p5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/ignore.upsert.sql
+++ b/internal/target/apply/testdata/ora/ignore.upsert.sql
@@ -1,0 +1,8 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:p2 AS INT), CASE WHEN :p3 IS NOT NULL THEN CAST(:p4 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p5 AS VARCHAR(256)), CAST(:p6 AS INT), CASE WHEN :p7 IS NOT NULL THEN CAST(:p8 AS INT8) ELSE expr() END FROM DUAL
+)
+SELECT * FROM data) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","has_default") VALUES (x."pk0", x."pk1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "has_default" = x."has_default"

--- a/internal/target/apply/testdata/ora/source names.delete.sql
+++ b/internal/target/apply/testdata/ora/source names.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "schema"."table" WHERE ("pk0","pk1","ignored_pk")IN((CAST(:p1 AS VARCHAR(256)),CAST(:p2 AS INT),CAST(:p3 AS INT)),
+(CAST(:p4 AS VARCHAR(256)),CAST(:p5 AS INT),CAST(:p6 AS INT)))

--- a/internal/target/apply/testdata/ora/source names.upsert.sql
+++ b/internal/target/apply/testdata/ora/source names.upsert.sql
@@ -1,0 +1,8 @@
+MERGE INTO "schema"."table" USING (
+WITH data ("pk0","pk1","val0","val1","has_default") AS (
+SELECT CAST(:p1 AS VARCHAR(256)), CAST(:p2 AS INT), CAST(:p3 AS VARCHAR(256)), CAST(:p4 AS VARCHAR(256)), CASE WHEN :p5 IS NOT NULL THEN CAST(:p6 AS INT8) ELSE expr() END FROM DUAL UNION ALL 
+SELECT CAST(:p7 AS VARCHAR(256)), CAST(:p8 AS INT), CAST(:p9 AS VARCHAR(256)), CAST(:p10 AS VARCHAR(256)), CASE WHEN :p11 IS NOT NULL THEN CAST(:p12 AS INT8) ELSE expr() END FROM DUAL
+)
+SELECT * FROM data) x ON ("schema"."table"."pk0" = x."pk0" AND "schema"."table"."pk1" = x."pk1")
+WHEN NOT MATCHED THEN INSERT ("pk0","pk1","val0","val1","has_default") VALUES (x."pk0", x."pk1", x."val0", x."val1", x."has_default")
+WHEN MATCHED THEN UPDATE SET "val0" = x."val0", "val1" = x."val1", "has_default" = x."has_default"

--- a/internal/target/apply/testdata/pg/base.delete.sql
+++ b/internal/target/apply/testdata/pg/base.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/base.upsert.sql
+++ b/internal/target/apply/testdata/pg/base.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog","enum","has_default"
+) VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/pg/cas.delete.sql
+++ b/internal/target/apply/testdata/pg/cas.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/cas.upsert.sql
+++ b/internal/target/apply/testdata/pg/cas.upsert.sql
@@ -1,0 +1,17 @@
+WITH data("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
+VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
+current AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "database"."schema"."table"
+JOIN data
+USING ("pk0","pk1")),
+action AS (
+SELECT data.* FROM data
+LEFT JOIN current
+USING ("pk0","pk1")
+WHERE current."pk0" IS NULL OR
+(data."val1",data."val0") > (current."val1",current."val0"))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+SELECT * FROM action

--- a/internal/target/apply/testdata/pg/casDeadline.delete.sql
+++ b/internal/target/apply/testdata/pg/casDeadline.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/casDeadline.upsert.sql
+++ b/internal/target/apply/testdata/pg/casDeadline.upsert.sql
@@ -1,0 +1,18 @@
+WITH data("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
+VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
+deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL)),
+current AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "database"."schema"."table"
+JOIN deadlined
+USING ("pk0","pk1")),
+action AS (
+SELECT deadlined.* FROM deadlined
+LEFT JOIN current
+USING ("pk0","pk1")
+WHERE current."pk0" IS NULL OR
+(deadlined."val1",deadlined."val0") > (current."val1",current."val0"))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+SELECT * FROM action

--- a/internal/target/apply/testdata/pg/deadline.delete.sql
+++ b/internal/target/apply/testdata/pg/deadline.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/deadline.upsert.sql
+++ b/internal/target/apply/testdata/pg/deadline.upsert.sql
@@ -1,0 +1,7 @@
+WITH data("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
+VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
+deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+SELECT * FROM deadlined

--- a/internal/target/apply/testdata/pg/expr.delete.sql
+++ b/internal/target/apply/testdata/pg/expr.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,($2+$2)::INT8,$3::STRING),
+($4::STRING,($5+$5)::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/expr.upsert.sql
+++ b/internal/target/apply/testdata/pg/expr.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","enum","has_default"
+) VALUES
+($1::STRING,($2+$2)::INT8,('fixed')::STRING,($3||'foobar')::STRING,$4::"database"."schema"."MyEnum",CASE WHEN $5::BOOLEAN THEN $6::INT8 ELSE expr() END),
+($7::STRING,($8+$8)::INT8,('fixed')::STRING,($9||'foobar')::STRING,$10::"database"."schema"."MyEnum",CASE WHEN $11::BOOLEAN THEN $12::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/pg/ignore.delete.sql
+++ b/internal/target/apply/testdata/pg/ignore.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/ignore.upsert.sql
+++ b/internal/target/apply/testdata/pg/ignore.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","enum","has_default"
+) VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,$5::"database"."schema"."MyEnum",CASE WHEN $6::BOOLEAN THEN $7::INT8 ELSE expr() END),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,$12::"database"."schema"."MyEnum",CASE WHEN $13::BOOLEAN THEN $14::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/pg/source_names.delete.sql
+++ b/internal/target/apply/testdata/pg/source_names.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/pg/source_names.upsert.sql
+++ b/internal/target/apply/testdata/pg/source_names.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog","enum","has_default"
+) VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -218,6 +218,21 @@ func TestGetColumns(t *testing.T) {
 				"e", "NUMBER(4,2)",
 			),
 		},
+		// Check default value extraction
+		{
+			tableSchema: "a INT PRIMARY KEY, b VARCHAR(2048) DEFAULT 'Hello World!'",
+			primaryKeys: []string{"a"},
+			dataCols:    []string{"b"},
+			check: func(t *testing.T, data []types.ColData) {
+				for _, col := range data {
+					if ident.Equal(col.Name, ident.New("b")) {
+						assert.Equal(t, "'Hello World!'", col.DefaultExpr)
+						return
+					}
+				}
+				assert.Fail(t, "did not find b column")
+			},
+		},
 	}
 
 	// Enum with a boring name.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -194,8 +194,10 @@ type Stagers interface {
 
 // ColData hold SQL column metadata.
 type ColData struct {
-	Ignored bool
-	Name    ident.Ident
+	// A SQL expression to use with sparse payloads.
+	DefaultExpr string
+	Ignored     bool
+	Name        ident.Ident
 	// A Parse function may be supplied to allow a string representation
 	// of a complex datatype to be converted into a type more readily
 	// used by a target database driver.
@@ -208,7 +210,8 @@ type ColData struct {
 // Equal returns true if the two ColData are equivalent under
 // case-insensitivity.
 func (d ColData) Equal(o ColData) bool {
-	return d.Ignored == o.Ignored &&
+	return d.DefaultExpr == o.DefaultExpr &&
+		d.Ignored == o.Ignored &&
 		ident.Equal(d.Name, o.Name) &&
 		// Parse is excluded, since functions are not comparable.
 		d.Primary == o.Primary &&


### PR DESCRIPTION
This change allows sparse payloads to interact nicely with columns that have a `DEFAULT` expression. That is, the `DEFAULT` expression for a column will be part of the upsert operation if no value for that column is provided by the incoming payload. This improves migration use-cases, where there may be a non-trivial amount of on-the-fly schema migration.

This behavior can already be accomplished by using an apply configuration or a userscript, but the cdc-sink operator would have to maintain the default value in both the SQL schema and the cdc-sink configuration.

Columns that support sparse operation add an extra parameter to their upsert expression that uses a `CASE` expression to select between the next parameter or the default expression.  It is not possible to use the `DEFAULT` keyword in this context, so we augment the schema introspection code to retrieve the appropriate expression.

The template test has been overhauled to use golden-output files, which can be regenerated by changing the `rewriteFiles` constant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/450)
<!-- Reviewable:end -->
