### PR TITLE
cdc: Fix flag panic due to bad merge

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -81,6 +81,10 @@ jobs:
         if: ${{ always() }}
         run: go run github.com/google/go-licenses check .
 
+      - name: Ensure binary starts
+        if: ${{ always () }}
+        run: go run . help
+
   # Integration matrix tests for all supported CRDB and source DBs.
   tests:
     name: Integration Tests

--- a/internal/source/cdc/config.go
+++ b/internal/source/cdc/config.go
@@ -62,12 +62,6 @@ type Config struct {
 func (c *Config) Bind(f *pflag.FlagSet) {
 	c.BaseConfig.Bind(f)
 
-	// We set the targetDB based on the value in the incoming HTTP
-	// request.
-	if err := f.MarkHidden("targetDB"); err != nil {
-		panic(err)
-	}
-
 	f.BoolVar(&c.FlushEveryTimestamp, "flushEveryTimestamp", false,
 		"preserve intermediate updates from the source in transactional mode; "+
 			"may negatively impact throughput")


### PR DESCRIPTION
PR #439 had a bad merge hunk which keeps the binary from starting. This change also adds a check to ensure that the main entry point starts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/451)
<!-- Reviewable:end -->
