### PR TITLE
Docker: Faster cross-compile setup

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Docker meta
@@ -55,7 +53,6 @@ jobs:
           labels: |
             org.opencontainers.image.title=CDC Sink
             org.opencontainers.image.vendor=Cockroach Labs Inc.
-            org.opencontainers.image.descripton=Prototype, not officially supported
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2


### PR DESCRIPTION
This change makes the builder image run using the host platform, rather than
being run under emulation. This drops the docker build time from 20 minutes to
4.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/452)
<!-- Reviewable:end -->
