### PR TITLE
logical: Detect concurrent loop errors in fanWorkers

### DIFF
--- a/internal/source/logical/generator_test.go
+++ b/internal/source/logical/generator_test.go
@@ -183,11 +183,16 @@ func (g *generatorDialect) Process(
 		for _, tbl := range g.tables {
 			mut := types.Mutation{
 				Key:  []byte(fmt.Sprintf(`[%d]`, msg.Index)),
-				Data: []byte(fmt.Sprintf(`{"k":%d,"v":"%d"}`, msg.Index, msg.Index)),
+				Data: []byte(fmt.Sprintf(`{"k":%[1]d,"v":"%[1]d","ref": %[1]d}`, msg.Index)),
 			}
 			if err := events.OnData(ctx, tbl.Table(), tbl, []types.Mutation{mut}); err != nil {
 				return err
 			}
+		}
+
+		// Ensure that we can wait for data in flight, if necessary.
+		if err := events.Flush(ctx); err != nil {
+			return err
 		}
 
 		if err := events.OnCommit(ctx); err != nil {


### PR DESCRIPTION
The fanWorkers.Flush() method had no way to report errors encountered by concurrent worker goroutines. This change adds a flag to the fanWorkers mutex state to indicate that a loop goroutine has exited. If a loop worker has exited, we know that the errgroup that's managing the other goroutines will report that error.

Additionally, the logical_test.go hadn't kept up with all modes that a logical loop can be configured for (e.g. foreign keys). This change ensures that FK modes are covered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/454)
<!-- Reviewable:end -->
