### PR TITLE
codecov: Ignore generated files

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,21 @@
+# Copyright 2023 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+github_checks:
+  annotations: true
+ignore:
+  - '**/wire_gen.go' # Most error callbacks are unused.
+  - '**/*_string.go' # Strings are for debugging use only.


### PR DESCRIPTION
This change adds a codecov.yml file to make the codecov reports more actionable. It also adds a flag to enable line-by-line reporting via GitHub code annotations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/455)
<!-- Reviewable:end -->
