### PR TITLE
schemawatch: Don't trim default expressions

### DIFF
--- a/internal/target/schemawatch/coldata.go
+++ b/internal/target/schemawatch/coldata.go
@@ -170,14 +170,6 @@ func getColumns(
 			}
 			if defaultExpr.Valid {
 				column.DefaultExpr = defaultExpr.String
-				// CockroachDB prior to v23.1 returns the datatype in
-				// the expression (e.g. `Foo`:::STRING). We want to
-				// strip that type assertion out to generate consistent
-				// behavior.
-				castIdx := strings.LastIndex(column.DefaultExpr, ":::")
-				if castIdx != -1 {
-					column.DefaultExpr = column.DefaultExpr[:castIdx]
-				}
 				// Oracle also likes to include some dangling whitespace.
 				column.DefaultExpr = strings.TrimSpace(column.DefaultExpr)
 			}


### PR DESCRIPTION
The code in PR #450 attempted to homogenize the column default expressions. The testing was insufficint and only looked at constant default expressions. The string trimming would lose any trailing parentheses in more complex expressions.

This change no longer tries to remove the varying type assertions that we might see in CockroachDB and PostgreSQL and updates the tests to be more permissive about expected values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/456)
<!-- Reviewable:end -->
