### PR TITLE
cmd: Unify logical commands

### DIFF
--- a/internal/cmd/fslogical/fslogical.go
+++ b/internal/cmd/fslogical/fslogical.go
@@ -19,85 +19,20 @@
 package fslogical
 
 import (
-	"net"
-	"net/http"
-
 	"github.com/cockroachdb/cdc-sink/internal/source/fslogical"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
+	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 // Command returns the fslogical subcommand.
 func Command() *cobra.Command {
 	cfg := &fslogical.Config{}
-
-	var metricsAddr string
-	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
+	return stdlogical.New(&stdlogical.Template{
+		Bind:  cfg.Bind,
 		Short: "start a Google Cloud Firestore logical replication feed",
-		Use:   "fslogical",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if metricsAddr != "" {
-				if err := metricsServer(metricsAddr); err != nil {
-					return err
-				}
-			}
-
-			loops, cancelLoops, err := fslogical.Start(cmd.Context(), cfg)
-			if err != nil {
-				return err
-			}
-			// Pause any log.Exit() or log.Fatal() until the server exits.
-			log.DeferExitHandler(func() {
-				cancelLoops()
-				for _, loop := range loops {
-					<-loop.Stopped()
-				}
-			})
-			// Wait for shutdown. The main function uses log.Exit()
-			// to call the above handler.
-			<-cmd.Context().Done()
-			return nil
+		Start: func(cmd *cobra.Command) (any, func(), error) {
+			return fslogical.Start(cmd.Context(), cfg)
 		},
-	}
-	cfg.Bind(cmd.Flags())
-	cmd.Flags().StringVar(&metricsAddr, "metricsAddr", "",
-		"a host:port to serve metrics from at /_/varz")
-
-	return cmd
-}
-
-// metricsServer starts a trivial prometheus endpoint server which runs
-// until the context is canceled.
-func metricsServer(bindAddr string) error {
-	mux := &http.ServeMux{}
-	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
+		Use: "fslogical",
 	})
-	mux.Handle("/_/varz", promhttp.InstrumentMetricHandler(
-		prometheus.DefaultRegisterer,
-		promhttp.HandlerFor(
-			prometheus.DefaultGatherer,
-			promhttp.HandlerOpts{
-				EnableOpenMetrics: true,
-				ErrorLog:          log.StandardLogger().WithField("promhttp", "true"),
-			})))
-	mux.Handle("/", http.NotFoundHandler())
-
-	l, err := net.Listen("tcp", bindAddr)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	srv := &http.Server{
-		Handler: h2c.NewHandler(mux, &http2.Server{}),
-	}
-	log.Infof("metrics server bound to %s", l.Addr())
-	go srv.Serve(l)
-	return nil
 }

--- a/internal/cmd/fslogical/fslogical_test.go
+++ b/internal/cmd/fslogical/fslogical_test.go
@@ -14,25 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package pglogical contains a command to perform logical replication
-// from a PostgreSQL source server.
-package pglogical
+package fslogical
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
-	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Command returns the pglogical subcommand.
-func Command() *cobra.Command {
-	cfg := &pglogical.Config{}
-	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a pg logical replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return pglogical.Start(cmd.Context(), cfg)
-		},
-		Use: "pglogical",
-	})
+// TestCommand ensures that the CLI command can be constructed and
+// that all flag binding works.
+func TestCommand(t *testing.T) {
+	r := require.New(t)
+	r.NoError(Command().Help())
 }

--- a/internal/cmd/mylogical/mylogical_test.go
+++ b/internal/cmd/mylogical/mylogical_test.go
@@ -14,25 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package pglogical contains a command to perform logical replication
-// from a PostgreSQL source server.
-package pglogical
+package mylogical
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
-	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Command returns the pglogical subcommand.
-func Command() *cobra.Command {
-	cfg := &pglogical.Config{}
-	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a pg logical replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return pglogical.Start(cmd.Context(), cfg)
-		},
-		Use: "pglogical",
-	})
+// TestCommand ensures that the CLI command can be constructed and
+// that all flag binding works.
+func TestCommand(t *testing.T) {
+	r := require.New(t)
+	r.NoError(Command().Help())
 }

--- a/internal/cmd/pglogical/pglogical_test.go
+++ b/internal/cmd/pglogical/pglogical_test.go
@@ -14,25 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package pglogical contains a command to perform logical replication
-// from a PostgreSQL source server.
 package pglogical
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
-	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Command returns the pglogical subcommand.
-func Command() *cobra.Command {
-	cfg := &pglogical.Config{}
-	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a pg logical replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return pglogical.Start(cmd.Context(), cfg)
-		},
-		Use: "pglogical",
-	})
+// TestCommand ensures that the CLI command can be constructed and
+// that all flag binding works.
+func TestCommand(t *testing.T) {
+	r := require.New(t)
+	r.NoError(Command().Help())
 }

--- a/internal/cmd/start/start_test.go
+++ b/internal/cmd/start/start_test.go
@@ -14,25 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package pglogical contains a command to perform logical replication
-// from a PostgreSQL source server.
-package pglogical
+package start
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
-	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Command returns the pglogical subcommand.
-func Command() *cobra.Command {
-	cfg := &pglogical.Config{}
-	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a pg logical replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return pglogical.Start(cmd.Context(), cfg)
-		},
-		Use: "pglogical",
-	})
+// TestCommand ensures that the CLI command can be constructed and
+// that all flag binding works.
+func TestCommand(t *testing.T) {
+	r := require.New(t)
+	r.NoError(Command().Help())
 }

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -34,9 +34,10 @@ import (
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(context.Context, *Config) ([]*logical.Loop, func(), error) {
+func Start(context.Context, *Config) (*FSLogical, func(), error) {
 	panic(wire.Build(
 		wire.Bind(new(logical.Config), new(*Config)),
+		wire.Struct(new(FSLogical), "*"),
 		ProvideFirestoreClient,
 		ProvideLoops,
 		ProvideScriptTarget,

--- a/internal/source/fslogical/wire_gen.go
+++ b/internal/source/fslogical/wire_gen.go
@@ -23,7 +23,7 @@ import (
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(contextContext context.Context, config *Config) ([]*logical.Loop, func(), error) {
+func Start(contextContext context.Context, config *Config) (*FSLogical, func(), error) {
 	diagnostics, cleanup := diag.New(contextContext)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
@@ -147,7 +147,11 @@ func Start(contextContext context.Context, config *Config) ([]*logical.Loop, fun
 		cleanup()
 		return nil, nil, err
 	}
-	return v, func() {
+	fsLogical := &FSLogical{
+		Diagnostics: diagnostics,
+		Loops:       v,
+	}
+	return fsLogical, func() {
 		cleanup9()
 		cleanup8()
 		cleanup7()

--- a/internal/source/mylogical/mylogical.go
+++ b/internal/source/mylogical/mylogical.go
@@ -14,33 +14,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build wireinject
-// +build wireinject
-
 package mylogical
 
 import (
-	"context"
-
-	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
-	"github.com/cockroachdb/cdc-sink/internal/staging"
-	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
-	"github.com/google/wire"
+	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
 )
 
-// Start creates a MySQL/MariaDB logical replication loop using the
-// provided configuration.
-func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
-	panic(wire.Build(
-		wire.Bind(new(logical.Config), new(*Config)),
-		wire.Struct(new(MYLogical), "*"),
-		Set,
-		diag.New,
-		logical.Set,
-		script.Set,
-		staging.Set,
-		target.Set,
-	))
+// MYLogical is a MySQL/MariaDB logical replication loop.
+type MYLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
+}
+
+var (
+	_ stdlogical.HasDiagnostics = (*MYLogical)(nil)
+	_ stdlogical.HasStoppable   = (*MYLogical)(nil)
+)
+
+// GetDiagnostics implements [stdlogical.HasDiagnostics].
+func (l *MYLogical) GetDiagnostics() *diag.Diagnostics {
+	return l.Diagnostics
+}
+
+// GetStoppable implements [stdlogical.HasStoppable].
+func (l *MYLogical) GetStoppable() types.Stoppable {
+	return l.Loop
 }

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -130,11 +130,3 @@ func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
 		cleanup()
 	}, nil
 }
-
-// injector.go:
-
-// MYLogical isa MySQL/MariaDB logical replication loop.
-type MYLogical struct {
-	Diagnostics *diag.Diagnostics
-	Loop        *logical.Loop
-}

--- a/internal/source/pglogical/injector.go
+++ b/internal/source/pglogical/injector.go
@@ -30,12 +30,6 @@ import (
 	"github.com/google/wire"
 )
 
-// PGLogical is a PostgreSQL logical replication loop.
-type PGLogical struct {
-	Diagnostics *diag.Diagnostics
-	Loop        *logical.Loop
-}
-
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
 func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {

--- a/internal/source/pglogical/pglogical.go
+++ b/internal/source/pglogical/pglogical.go
@@ -14,33 +14,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build wireinject
-// +build wireinject
-
-package mylogical
+package pglogical
 
 import (
-	"context"
-
-	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
-	"github.com/cockroachdb/cdc-sink/internal/staging"
-	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
-	"github.com/google/wire"
+	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
 )
 
-// Start creates a MySQL/MariaDB logical replication loop using the
-// provided configuration.
-func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
-	panic(wire.Build(
-		wire.Bind(new(logical.Config), new(*Config)),
-		wire.Struct(new(MYLogical), "*"),
-		Set,
-		diag.New,
-		logical.Set,
-		script.Set,
-		staging.Set,
-		target.Set,
-	))
+// PGLogical is a PostgreSQL logical replication loop.
+type PGLogical struct {
+	Diagnostics *diag.Diagnostics
+	Loop        *logical.Loop
+}
+
+var (
+	_ stdlogical.HasDiagnostics = (*PGLogical)(nil)
+	_ stdlogical.HasStoppable   = (*PGLogical)(nil)
+)
+
+// GetDiagnostics implements [stdlogical.HasDiagnostics].
+func (l *PGLogical) GetDiagnostics() *diag.Diagnostics {
+	return l.Diagnostics
+}
+
+// GetStoppable implements [stdlogical.HasStoppable].
+func (l *PGLogical) GetStoppable() types.Stoppable {
+	return l.Loop
 }

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -130,11 +130,3 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 	}, nil
 }
-
-// injector.go:
-
-// PGLogical is a PostgreSQL logical replication loop.
-type PGLogical struct {
-	Diagnostics *diag.Diagnostics
-	Loop        *logical.Loop
-}

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -33,6 +33,7 @@ import (
 	jwtAuth "github.com/cockroachdb/cdc-sink/internal/staging/auth/jwt"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
 	joonix "github.com/joonix/log"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -105,6 +106,8 @@ func testIntegration(t *testing.T, immediate bool, webhook bool) {
 	})
 	r.NoError(err)
 	defer cancel()
+	// This is normally taken care of by stdlogical.Command.
+	stdlogical.AddHandlers(targetFixture.Authenticator, targetFixture.Server.mux, targetFixture.Diagnostics)
 
 	// Set up source and target tables.
 	source, err := sourceFixture.CreateSourceTable(ctx, "CREATE TABLE %s (pk INT PRIMARY KEY, val STRING)")

--- a/internal/source/server/server.go
+++ b/internal/source/server/server.go
@@ -20,12 +20,48 @@ package server
 
 // This file contains code repackaged from main.go
 
-import _ "net/http/pprof" // Register pprof debugging endpoints.
+import (
+	"net/http"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
+)
 
 // A Server receives incoming CockroachDB changefeed messages and
 // applies them to a target cluster.
 type Server struct {
+	auth    types.Authenticator
+	diags   *diag.Diagnostics
+	mux     *http.ServeMux
 	stopped chan struct{}
+}
+
+var (
+	_ stdlogical.HasAuthenticator = (*Server)(nil)
+	_ stdlogical.HasDiagnostics   = (*Server)(nil)
+	_ stdlogical.HasServeMux      = (*Server)(nil)
+	_ stdlogical.HasStoppable     = (*Server)(nil)
+)
+
+// GetAuthenticator implements [stdlogical.HasAuthenticator].
+func (s *Server) GetAuthenticator() types.Authenticator {
+	return s.auth
+}
+
+// GetDiagnostics implements [stdlogical.HasDiagnostics].
+func (s *Server) GetDiagnostics() *diag.Diagnostics {
+	return s.diags
+}
+
+// GetServeMux implements [stdlogical.HasServeMux].
+func (s *Server) GetServeMux() *http.ServeMux {
+	return s.mux
+}
+
+// GetStoppable implements [stdlogical.HasStoppable].
+func (s *Server) GetStoppable() types.Stoppable {
+	return s
 }
 
 // Stopped returns a channel that will be closed when the server has

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -331,6 +331,31 @@ type StagingPool struct {
 	_ noCopy
 }
 
+// A Stoppable object can indicate when it has reached a terminal state.
+type Stoppable interface {
+	Stopped() <-chan struct{}
+}
+
+// Stoppables aggregates multiple Stoppable instances.
+type Stoppables []Stoppable
+
+// Stopped implements Stoppable to return a channel that is closed
+// when all enclosed elements have been stopped.
+func (s Stoppables) Stopped() <-chan struct{} {
+	chans := make([]<-chan struct{}, len(s))
+	for idx, stoppable := range s {
+		chans[idx] = stoppable.Stopped()
+	}
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		for _, sub := range chans {
+			<-sub
+		}
+	}()
+	return ch
+}
+
 // SourcePool is an injection point for a connection to a source
 // database.
 type SourcePool struct {

--- a/internal/util/stdlogical/stdlogical.go
+++ b/internal/util/stdlogical/stdlogical.go
@@ -1,0 +1,206 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stdlogical contains a template for building a standard
+// logical-replication CLI command.
+package stdlogical
+
+import (
+	"context"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // Register pprof handlers.
+	"runtime/debug"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// MetricsAddrFlag is a global flag that will start an HTTP server.
+const MetricsAddrFlag = "metricsAddr"
+
+// HasAuthenticator allows the object to supply a [types.Authenticator].
+type HasAuthenticator interface {
+	GetAuthenticator() types.Authenticator
+}
+
+// HasDiagnostics allows the object to supply a [diag.Diagnostics].
+type HasDiagnostics interface {
+	GetDiagnostics() *diag.Diagnostics
+}
+
+// HasStoppable allows the object to supply a [types.Stoppable] that
+// will defer exiting until its [types.Stoppable.Stopped] channel is
+// closed.
+type HasStoppable interface {
+	GetStoppable() types.Stoppable
+}
+
+// HasServeMux allows the object to provide a [http.ServeMux] to bind
+// the endpoints to, if the [MetricsAddrFlag] is not set.
+type HasServeMux interface {
+	GetServeMux() *http.ServeMux
+}
+
+// A Template contains the input for [New].
+type Template struct {
+	// An optional function for CLI flag registration.
+	Bind func(*pflag.FlagSet)
+	// An optional default value for [MetricsAddrFlag].
+	Metrics string
+	// Passed to [cobra.Command.Short].
+	Short string
+	// Start should return an object that implements zero or more of the
+	// capability interfaces in this package.
+	Start func(cmd *cobra.Command) (started any, cancel func(), err error)
+	// Passed to [cobra.Command.Use].
+	Use string
+	// Called once all setup has been completed.
+	testCallback func()
+}
+
+// New constructs a standard logical-replication command.
+func New(t *Template) *cobra.Command {
+	var metricsAddr string
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Short: t.Short,
+		Use:   t.Use,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Print build info on startup so we always have a place
+			// to start debugging from.
+			if bi, ok := debug.ReadBuildInfo(); ok {
+				info := make(log.Fields, len(bi.Settings))
+				for _, s := range bi.Settings {
+					info[s.Key] = s.Value
+				}
+				log.WithFields(info).Info("cdc-sink starting")
+			}
+
+			// Delegate startup.
+			started, cancel, err := t.Start(cmd)
+			if err != nil {
+				return err
+			}
+
+			var auth types.Authenticator
+			if x, ok := started.(HasAuthenticator); ok {
+				auth = x.GetAuthenticator()
+			} else {
+				auth = trust.New()
+			}
+
+			// Find or create a Diagnostics instance.
+			var diags *diag.Diagnostics
+			if x, ok := started.(HasDiagnostics); ok {
+				diags = x.GetDiagnostics()
+			} else {
+				var cancelDiags func()
+				diags, cancelDiags = diag.New(cmd.Context())
+				defer cancelDiags()
+			}
+
+			// Start metrics on a separate port or bind to an existing mux.
+			if metricsAddr != "" {
+				cancelServer, err := MetricsServer(auth, metricsAddr, diags)
+				if err != nil {
+					return err
+				}
+				defer cancelServer()
+			} else if x, ok := started.(HasServeMux); ok {
+				AddHandlers(auth, x.GetServeMux(), diags)
+			}
+
+			// Pause any log.Exit() or log.Fatal() until the server exits.
+			log.DeferExitHandler(func() {
+				cancel()
+				if x, ok := started.(HasStoppable); ok {
+					<-x.GetStoppable().Stopped()
+				}
+			})
+			if t.testCallback != nil {
+				t.testCallback()
+			}
+			// Wait for shutdown. The main function uses log.Exit()
+			// to call the above handler.
+			<-cmd.Context().Done()
+			return nil
+		},
+	}
+	if t.Bind != nil {
+		t.Bind(cmd.Flags())
+	}
+	cmd.Flags().StringVar(&metricsAddr, MetricsAddrFlag, t.Metrics,
+		"a host:port on which to serve metrics and diagnostics")
+	return cmd
+}
+
+// AddHandlers populates the ServeMux with diagnostic endpoints.
+func AddHandlers(auth types.Authenticator, mux *http.ServeMux, diags *diag.Diagnostics) {
+	// The pprof handlers attach themselves to the system-default mux.
+	// The index page also assumes that the handlers are reachable from
+	// this specific prefix. It seems unlikely that this would collide
+	// with an actual database schema.
+	mux.Handle("/debug/pprof/", http.DefaultServeMux)
+	mux.Handle("/_/diag", diags.Handler(auth))
+	mux.Handle("/_/varz", promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer,
+		promhttp.HandlerFor(
+			prometheus.DefaultGatherer,
+			promhttp.HandlerOpts{
+				EnableOpenMetrics: true,
+				ErrorLog:          log.StandardLogger().WithField("promhttp", "true"),
+			})))
+	mux.Handle("/_/", http.NotFoundHandler()) // Reserve all under /_/
+}
+
+// MetricsServer starts a trivial HTTP server which runs until canceled.
+func MetricsServer(
+	auth types.Authenticator, bindAddr string, diags *diag.Diagnostics,
+) (func(), error) {
+	mux := &http.ServeMux{}
+	AddHandlers(auth, mux, diags)
+	mux.HandleFunc("/_/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+	mux.Handle("/", http.NotFoundHandler())
+
+	l, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	srv := &http.Server{
+		Handler: h2c.NewHandler(mux, &http2.Server{}),
+	}
+	log.Infof("metrics server bound to %s", l.Addr())
+	go srv.Serve(l)
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}, nil
+}

--- a/internal/util/stdlogical/stdlogical_test.go
+++ b/internal/util/stdlogical/stdlogical_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stdlogical
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoke(t *testing.T) {
+	r := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ready := make(chan struct{})
+
+	cmd := New(&Template{
+		Bind:    nil, // No extra CLI flags
+		Metrics: "127.0.0.1:13013",
+		Start: func(cmd *cobra.Command) (started any, cancel func(), err error) {
+			return nil, nil, nil
+		},
+		Use: "test",
+		testCallback: func() {
+			close(ready)
+		},
+	})
+	// Override os.Args.
+	cmd.SetArgs([]string{})
+
+	// Start the server in the background.
+	go func() {
+		r.NoError(cmd.ExecuteContext(ctx))
+	}()
+
+	select {
+	case <-ctx.Done():
+		r.Fail("timed out waiting for server")
+	case <-ready:
+	}
+
+	resp, err := http.Get("http://127.0.0.1:13013/_/diag")
+	r.NoError(err)
+	r.Equal(http.StatusOK, resp.StatusCode)
+
+	w := log.StandardLogger().Writer()
+	count, err := io.Copy(w, resp.Body)
+	r.NoError(err)
+	r.NotZero(count)
+	r.NoError(w.Close())
+
+	cancel()
+}


### PR DESCRIPTION
This change extracts the heavily-duplicated code in the fslogical, mylogical, pglogical, and start commands into a common stdlogical package.

Notable changes:
- We can now test that the CLI flag binding code runs to completion.
- The binary buildinfo is logged on startup.
- The CDC server may run the diags server on a separate port.

Closes #117

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/457)
<!-- Reviewable:end -->
