### PR TITLE
fslogical: Fix backfill pagination

### DIFF
--- a/internal/source/fslogical/provider.go
+++ b/internal/source/fslogical/provider.go
@@ -76,9 +76,11 @@ func ProvideLoops(
 	}
 
 	err := userscript.Sources.Range(func(sourceName ident.Ident, source *script.Source) error {
+		var isGroup bool
 		var sourcePath string
 		var q firestore.Query
 		if r := sourceName.Raw(); strings.HasPrefix(r, GroupPrefix) {
+			isGroup = true
 			sourcePath = r
 			tail := r[len(GroupPrefix):]
 			q = fs.CollectionGroup(tail).Query
@@ -99,6 +101,7 @@ func ProvideLoops(
 			memo:              memo,
 			pool:              pool,
 			query:             q,
+			queryIsGroup:      isGroup,
 			tombstones:        st,
 			recurse:           source.Recurse,
 			recurseFilter:     recurseFilter,

--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -60,6 +60,8 @@ func (c *Config) Preflight() error {
 	if err := c.LoopConfig.Preflight(); err != nil {
 		return err
 	}
+	// See discussion on the field.
+	c.LoopConfig.SuppressStampOrderChecks = true
 	if c.Publication == "" {
 		return errors.New("no publication name was configured")
 	}


### PR DESCRIPTION
The firestore.DocumentID sentinel usually works correctly with the values that one might expect to find in `doc.Ref.ID` when querying single collections. However, when querying collection groups, that value needs to be more (globally) unique, since the same document ID can, in theory, exist within multiple collection groups that are being queried.

This change removes a misguided attempt at solving for this, with a new understanding of how this sentinel behaves. Reference URLs are included in the docstring on `Dialect.backfillPoint()`.

The previous code was, in effect, randomly sampling swathes of document ids, while the test code only checked that we arrived at the desired number of rows in the target tables. In order to verify that ID-based pagination is working correctly, all documents to be backfilled are inserted at the same timestamp. A new test control is added to LoopConfig, which allows the test code to delay the loop switching from backfill to streaming mode. When deployed into production, the stochastic nature eventually sampled all rows in sufficiently small or sufficiently long-running attempts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/458)
<!-- Reviewable:end -->
