### PR TITLE
mylogical: relax @@version_comment check

### DIFF
--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -440,17 +440,14 @@ func getFlavor(config *Config) (string, error) {
 			}
 		}
 		return mysql.MariaDBFlavor, nil
-	} else if strings.Contains(version, "MySQL") || version == "Source distribution" {
-		for _, v := range mySQLSystemSettings {
-			err = checkSystemSetting(c, v[0], v[1])
-			if err != nil {
-				return "", err
-			}
-		}
-		return mysql.MySQLFlavor, nil
-	} else {
-		return "", errors.New("unknown server")
 	}
+	for _, v := range mySQLSystemSettings {
+		err = checkSystemSetting(c, v[0], v[1])
+		if err != nil {
+			return "", err
+		}
+	}
+	return mysql.MySQLFlavor, nil
 }
 
 func checkSystemSetting(c *client.Conn, variable string, expected string) error {


### PR DESCRIPTION
Depending on how MySQL is shipped, it can show up as `Homebrew` or `Source distribution` without `MySQL` actually being in the string. As such, relax the `@@version_comment` check to allow anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/462)
<!-- Reviewable:end -->
