### PR TITLE
workflow: Fix spontaneous cancellation of cache warming workflow

### DIFF
--- a/.github/workflows/warm-build-cache.yaml
+++ b/.github/workflows/warm-build-cache.yaml
@@ -23,12 +23,17 @@ permissions:
 on:
   workflow_call:
   workflow_dispatch:
+concurrency:
+  # Using github.workflow here would inherit the name from the caller,
+  # which isn't what we want to do. We want to serialize multiple
+  # callers so that the cache and build happen exactly once.
+  # https://github.com/orgs/community/discussions/30708#discussioncomment-3518412
+  group: warm-cache-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   warm-build-cache:
     name: Warm build cache
     runs-on: ubuntu-latest
-    concurrency:
-      group: warm-cache
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
We've been seeing unexpected cancellation of the cache-warming workflow. This
change moves the concurrency block from the job up to the workflow itself and
explicitly sets cancel-in-progress to false to see if that solves the problem.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/463)
<!-- Reviewable:end -->
