### PR TITLE
schemawatch: Support vanilla PostgreSQL

### DIFF
--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -67,7 +67,7 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	targetSchema, cleanup8, err := base.ProvideTargetSchema(context, targetPool)
+	targetSchema, cleanup8, err := base.ProvideTargetSchema(context, diagnostics, targetPool)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/internal/sinktest/base/wire_gen.go
+++ b/internal/sinktest/base/wire_gen.go
@@ -59,7 +59,7 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	targetSchema, cleanup8, err := ProvideTargetSchema(context, targetPool)
+	targetSchema, cleanup8, err := ProvideTargetSchema(context, diagnostics, targetPool)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -94,7 +94,7 @@ func TestWatch(t *testing.T) {
 		switch fixture.TargetPool.Product {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			r.NoError(retry.Execute(ctx, fixture.TargetPool,
-				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v STRING", tblInfo.Name())))
+				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v VARCHAR", tblInfo.Name())))
 
 		case types.ProductOracle:
 			r.NoError(retry.Execute(ctx, fixture.TargetPool,


### PR DESCRIPTION
This change ports the schema introspection queries from using
CockroachDB-specific porcelain to using the information_schema virtual tables.
The existing table-dependency query is still used for older versions of
CockroachDB that enter an infinite loop when executing the revised CTE.

The test fixture code adds a workaround for the lack of cross-database
information_schema queries by swapping out the underlying database connection
after we've performed a `CREATE DATABASE`.

The schemawatch tests will pass against PostgreSQL v11-v15 by setting
`TEST_TARGET_CONNECT=postgres://postgres:SoupOrSecret@127.0.0.1:5432`

CI testing using PostgreSQL as a target will not be enabled until the apply
package is updated.

X-Ref: #430

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/469)
<!-- Reviewable:end -->
