### PR TITLE
workflow: Rearrange the deck chairs

### DIFF
--- a/.github/workflows/go-binaries.yaml
+++ b/.github/workflows/go-binaries.yaml
@@ -14,34 +14,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Binaries will build cdc-sink for a variety of common platforms.
-name: Binaries
+# Binaries will build cdc-sink for a variety of common platforms and
+# optionally push the results to a GCP bucket.
+name: Golang Binaries
 permissions:
   contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  statuses: write
 on:
-  merge_group: # Build, but don't push
-  push:
-    branches: [ master ]
-    tags: [ 'v*.*.*' ]
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '**/*.go'
-      - '.github/workflows/binaries.yaml'
-  pull_request: # Build, but don't push
-  workflow_dispatch:  # Make it easy to push other branches/tags.
+  workflow_call:
+    inputs:
+      push:
+        default: false
+        description: Upload binaries to GCP bucket
+        required: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      push:
+        default: true
+        description: Upload binaries to GCP bucket
+        type: boolean
 
 jobs:
-  warm-build-cache:
-    uses: ./.github/workflows/warm-build-cache.yaml
-
   binaries:
     name: Binaries
     runs-on: ubuntu-latest
-    needs: warm-build-cache
     strategy:
       matrix:
         include:
@@ -139,14 +136,14 @@ jobs:
         # Only authenticate if we're on the main repo (i.e. have access
         # to the secret) and we're pushing to a branch. Manual runs are
         # also allowed as a convenience.
-        if: ${{ !github.event.pull_request.head.repo.fork && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ inputs.push }}
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.CDC_SINK_BINARIES_KEY }}
 
       - id: upload
         uses: google-github-actions/upload-cloud-storage@v1
-        if: ${{ steps.auth.outcome == 'success' }} # Not skipped
+        if: ${{ inputs.push }}
         with:
           path: ${{ env.DISTRO_NAME }}.tgz
           destination: ${{ vars.CDC_SINK_BUCKET }}/
@@ -154,7 +151,7 @@ jobs:
 
       - id: link
         name: Summary link
-        if: ${{ steps.auth.outcome == 'success' }} # Not skipped
+        if: ${{ inputs.push }}
         run: echo "[${{ env.BUILDNAME }}](https://storage.googleapis.com/${{ vars.CDC_SINK_BUCKET }}/${{ env.DISTRO_NAME }}.tgz)" >> $GITHUB_STEP_SUMMARY
 
   # Aggregate the results of multiple jobs within this workflow into a
@@ -164,8 +161,6 @@ jobs:
   status:
     name: Create status objects
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
     needs: # Update failure case below
       - binaries
     if: ${{ always() }}
@@ -175,6 +170,7 @@ jobs:
       MERGE_SHA: ${{ github.event.merge_group.head_sha }}
       PR_SHA: ${{ github.event.pull_request.head.sha }}
       STATE: success
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Failure
         if: ${{ needs.binaries.result != 'success' }}
@@ -187,12 +183,14 @@ jobs:
             gh api \
                repos/${{ github.repository }}/statuses/$PR_SHA \
                -f "state=$STATE" \
-               -f "context=$CONTEXT"
+               -f "context=$CONTEXT" \
+               -f "target_url=$RUN_URL"
           fi
-          
+
           if [ ! -z "$MERGE_SHA" ]; then
             gh api \
               repos/${{ github.repository }}/statuses/$MERGE_SHA \
               -f "state=$STATE" \
-              -f "context=$CONTEXT"
+              -f "context=$CONTEXT" \
+              -f "target_url=$RUN_URL"
           fi

--- a/.github/workflows/go-build-cache.yaml
+++ b/.github/workflows/go-build-cache.yaml
@@ -23,13 +23,6 @@ permissions:
 on:
   workflow_call:
   workflow_dispatch:
-concurrency:
-  # Using github.workflow here would inherit the name from the caller,
-  # which isn't what we want to do. We want to serialize multiple
-  # callers so that the cache and build happen exactly once.
-  # https://github.com/orgs/community/discussions/30708#discussioncomment-3518412
-  group: warm-cache-${{ github.ref }}
-  cancel-in-progress: false
 jobs:
   warm-build-cache:
     name: Warm build cache

--- a/.github/workflows/go-codeql.yaml
+++ b/.github/workflows/go-codeql.yaml
@@ -14,41 +14,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: CodeQL
+# Run GitHub CodeQL sanity-checks.
+name: Golang CodeQL
 permissions:
   contents: read
   security-events: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 on:
-  pull_request:
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '**/*.go'
-      - '.github/workflows/codeql.yaml'
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '**/*.go'
-      - '.github/workflows/codeql.yaml'
-
+  workflow_call:
+  workflow_dispatch:
 jobs:
-  warm-build-cache:
-    uses: ./.github/workflows/warm-build-cache.yaml
-
-  # This scan is heavy, so it's pulled out into its own job.
   codeql:
     name: CodeQL security scanning
     runs-on: ubuntu-latest
-    needs: warm-build-cache
-    permissions:
-      security-events: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/go-docker.yaml
+++ b/.github/workflows/go-docker.yaml
@@ -25,18 +25,20 @@
 name: Docker
 permissions:
   contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 on:
-  push:
-    branches: [ master ]
-    tags: [ 'v*.*.*' ]
-  # Only build, but don't push, on a PR if it touches the Dockerfile,
-  # since this takes a while to execute.
-  pull_request:
-    paths:
-      - 'Dockerfile'
+  workflow_call:
+    inputs:
+      push:
+        default: false
+        required: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      push:
+        default: true
+        description: Push image
+        required: true
+        type: boolean
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -54,7 +56,7 @@ jobs:
             org.opencontainers.image.title=CDC Sink
             org.opencontainers.image.vendor=Cockroach Labs Inc.
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: ${{ inputs.push }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -64,7 +66,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -14,34 +14,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Golang
+name: Golang Tests
 permissions:
   contents: read
-  packages: write # It is unclear why write access is needed to access private ghcr.io packages.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  packages: read
 on:
-  # Since we use the merge queue to push and there are no observable
-  # side-effects of running a test-only workflow, we don't respond to
-  # push events.
-  merge_group: # Enable merge queue
-  pull_request:
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '**/*.go'
-      - '.github/workflows/golang.yaml'
-
+  workflow_call:
+  workflow_dispatch:
 jobs:
-  warm-build-cache:
-    uses: ./.github/workflows/warm-build-cache.yaml
-
   # Static code-quality checks.
   code-quality:
     name: Code Quality
     runs-on: ubuntu-latest
-    needs: warm-build-cache
     steps:
       - uses: actions/checkout@v4
 
@@ -51,26 +35,26 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: crlfmt returns no deltas
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           DELTA=$(go run github.com/cockroachdb/crlfmt -ignore _gen.go .)
           echo $DELTA
           test -z "$DELTA"
 
       - name: Copyright headers
-        if: ${{ always () }}
+        if: ${{ !cancelled() }}
         run: go run github.com/google/addlicense -c "The Cockroach Authors" -l apache -s -v  -check  -ignore '**/testdata/**/*.sql' .
 
       - name: Lint
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: go run golang.org/x/lint/golint -set_exit_status ./...
 
       - name: Static checks
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: go run honnef.co/go/tools/cmd/staticcheck -checks all ./...
 
       - name: Go Vet
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: go vet ./...
 
       # Check that all dependencies have licenses and that those
@@ -78,18 +62,17 @@ jobs:
       # reachable from the entry point will be bundled and are visible
       # through the licenses subcommand.
       - name: License Checks
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: go run github.com/google/go-licenses check .
 
       - name: Ensure binary starts
-        if: ${{ always () }}
+        if: ${{ !cancelled() }}
         run: go run . help
 
   # Integration matrix tests for all supported CRDB and source DBs.
   tests:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: warm-build-cache
     strategy:
       fail-fast: false
       # Refer to the CRDB support policy when determining how many
@@ -245,6 +228,7 @@ jobs:
       MERGE_SHA: ${{ github.event.merge_group.head_sha }}
       PR_SHA: ${{ github.event.pull_request.head.sha }}
       STATE: success
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Failure
         if: ${{ needs.code-quality.result != 'success' ||  needs.tests.result != 'success' }}
@@ -257,14 +241,16 @@ jobs:
             gh api \
                repos/${{ github.repository }}/statuses/$PR_SHA \
                -f "state=$STATE" \
-               -f "context=$CONTEXT"
+               -f "context=$CONTEXT" \
+               -f "target_url=$RUN_URL"
           fi
 
           if [ ! -z "$MERGE_SHA" ]; then
             gh api \
               repos/${{ github.repository }}/statuses/$MERGE_SHA \
               -f "state=$STATE" \
-              -f "context=$CONTEXT"
+               -f "context=$CONTEXT" \
+               -f "target_url=$RUN_URL"
           fi
 
   # This job downloads the test log files generated in the integration
@@ -273,7 +259,7 @@ jobs:
     name: Test summaries
     runs-on: ubuntu-latest
     needs: tests
-    if: always()
+    if: ${{ always() }}
     steps:
       - name: Download reports
         uses: actions/download-artifact@v3

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,83 @@
+# Copyright 2023 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This is our top-level workflow that kicks off the various go- workflows.
+name: Golang
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  # Since we use the merge queue to push and there are no observable
+  # side-effects of running a test-only workflow, we don't respond to
+  # push events.
+  merge_group: # Enable merge queue
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.go'
+      - '.github/workflows/go*.yaml'
+  push:
+    branches: [ master ]
+    tags: [ 'v*.*.*' ]
+jobs:
+  # Most jobs should depend on this one.
+  go-build-cache:
+    uses: ./.github/workflows/go-build-cache.yaml
+
+  go-binaries:
+    uses: ./.github/workflows/go-binaries.yaml
+    needs:
+      - go-build-cache
+    permissions:
+      contents: read
+      statuses: write
+    secrets: inherit
+    with:
+      # Push if we're in the main repo and are pushing to a branch selected above.
+      push: ${{ !github.event.pull_request.head.repo.fork && github.event_name == 'push' }}
+
+  go-codeql:
+    uses: ./.github/workflows/go-codeql.yaml
+    needs:
+      - go-build-cache
+    permissions:
+      contents: read
+      security-events: write
+    secrets: inherit
+
+  go-docker:
+    uses: ./.github/workflows/go-docker.yaml
+    # Doesn't need the build cache
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      # Push if we're in the main repo and are pushing to a branch selected above.
+      push: ${{ !github.event.pull_request.head.repo.fork && github.event_name == 'push' }}
+
+  go-tests:
+    uses: ./.github/workflows/go-tests.yaml
+    needs:
+      - go-build-cache
+    # We use the merge queue prior to pushing to a branch, so there's no
+    # reason to repeat tests that just ran.
+    if: ${{ github.event_name != 'push' }}
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+    secrets: inherit


### PR DESCRIPTION
Using a concurrency group in a called workflow (i.e. to only warm the go build
cache once) is still showing spontaneous cancellation by the actions platform.
This change rolls all workflows up into a single dispatch event, triggered by a
top-level workflow. The top-level go.yaml then calls the existing, albeit
renamed, workflows after the cache warming has taken place.

An upside to this approach is that there's a relatively simple workflow that
provides a high-level view of the build, while the details of the build can
still be grouped into separate files.

Conditional behaviors, such as pushing to DockerHub or to the GCP bucket, have
been made inputs of their respective workflows, again to make it obvious at the
outset what happens when.

Where applicable, the `${{ !cancelled()}}` idiom is used in place of `${{
always() }}` for steps that don't provide diagnostic information that we may
want to capture out of a cancelled workflow.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/470)
<!-- Reviewable:end -->
