### PR TITLE
cdc: Allow staged data to be retained for longer

### DIFF
--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -552,6 +552,10 @@ func (r *resolver) retireLoop(ctx context.Context) {
 					log.WithError(err).Warnf("could not acquire stager for %s", table)
 					return nil
 				}
+				// Retain staged data for an extra amount of time.
+				if off := r.cfg.RetireOffset; off > 0 {
+					next = hlc.New(next.Nanos()-off.Nanoseconds(), next.Logical())
+				}
 				if err := stager.Retire(ctx, r.pool, next); err != nil {
 					if errors.Is(err, context.Canceled) {
 						return err


### PR DESCRIPTION
This change adds a new configuration value that allows staged data to be retained after it has been applied. This could be used to allow resolved timestamps to be unwound and re-applied or to perform post-hoc analysis of what was staged versus what was applied.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/472)
<!-- Reviewable:end -->
