### PR TITLE
workflow: Move wiki maintenance into main workflow

### DIFF
--- a/.github/workflows/go-wiki.yaml
+++ b/.github/workflows/go-wiki.yaml
@@ -17,16 +17,20 @@
 name: Wiki Maintenance
 permissions:
   contents: write
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 on:
+  workflow_call:
+    inputs:
+      push:
+        default: false
+        required: true
+        type: boolean
   workflow_dispatch:
-  push:
-    branches: [ master ]
-  pull_request:
-    paths:
-      - .github/workflows/wiki.yaml
+    inputs:
+      push:
+        default: true
+        description: Push updates to wiki repository
+        required: true
+        type: boolean
 
 jobs:
   wiki:
@@ -53,8 +57,9 @@ jobs:
       - name: Refresh wiki files
         run: go run ./internal/cmd/marksub ./wiki
 
-      - name: Maybe push
-        id: detect
+      - name: Push
+        id: push
+        if: ${{ inputs.push }}
         run: |
           cd wiki
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -81,3 +81,14 @@ jobs:
       packages: read
       statuses: write
     secrets: inherit
+
+  go-wiki:
+    uses: ./.github/workflows/go-wiki.yaml
+    needs:
+      - go-build-cache
+    permissions:
+      contents: write
+    secrets: inherit
+    with:
+      # Only update the wiki if we're pushing to the master branch.
+      push: ${{ github.event.push.ref == 'refs/heads/master' }}


### PR DESCRIPTION
This change brings the wiki-maintenance workflow into the unified golang workflow. This allows the workflow to take advantage of the cache-warming behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/473)
<!-- Reviewable:end -->
