### PR TITLE
apply: Add support for PostgreSQL

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -122,6 +122,23 @@ jobs:
             runs-on: ubuntu-latest-8-core
             target: oracle-v21.3
             targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
+
+          # Test CRDB -> PostgreSQL for migration backfill use cases.
+          - cockroachdb: v23.1
+            target: postgresql-v11
+            targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
+          - cockroachdb: v23.1
+            target: postgresql-v12
+            targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
+          - cockroachdb: v23.1
+            target: postgresql-v13
+            targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
+          - cockroachdb: v23.1
+            target: postgresql-v14
+            targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
+          - cockroachdb: v23.1
+            target: postgresql-v15
+            targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
     env:
       COVER_OUT: coverage-${{ strategy.job-index }}.out
       DOCKER_LOGS_OUT: docker-${{ strategy.job-index }}.log

--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -277,6 +277,7 @@ func ProvideTargetSchema(
 			cancel()
 			return sinktest.TargetSchema{}, nil, err
 		}
+		pool.ConnectionString = conn
 		pool.DB = next.DB
 		cancel = func() {
 			dropSchema()

--- a/internal/target/apply/queries/crdb/common.tmpl
+++ b/internal/target/apply/queries/crdb/common.tmpl
@@ -1,0 +1,57 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+
+{{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
+{{- define "names" -}}
+    {{- range $idx, $col := . }}
+        {{- if $idx -}},{{- end -}}
+        {{$col.Name}}
+    {{- end -}}
+{{- end -}}
+
+{{- /*
+exprs produces a comma-separated list of substitution params tuples with
+adds explicit typecasts: ($1::STRING, $2::INT), (...), (...), ...
+
+If the target column has a SQL DEFAULT expression, we add an additional
+validity check using a CASE expression:
+  CASE WHEN $1::BOOLEAN THEN $2::STRING ELSE 'Default Value' END
+The validity check allows us to distinguish null vs. unset in the payload.
+*/ -}}
+{{- define "exprs" -}}
+    {{- range $groupIdx, $pairs := $.Vars -}}
+        {{- if $groupIdx -}},{{- nl -}}{{- end -}}
+        (
+        {{- range $pairIdx, $pair := $pairs -}}
+            {{- if $pairIdx -}},{{- end -}}
+
+            {{- if $pair.ValidityParam -}}
+                CASE WHEN ${{ $pair.ValidityParam }}::BOOLEAN THEN {{- sp -}}
+            {{- end -}}
+
+            {{- if $pair.Expr -}}
+                ({{ $pair.Expr }})::{{ $pair.Column.Type }}
+            {{- else if isUDTArray $pair.Column -}}
+                ${{ $pair.Param }}::TEXT[]::{{ $pair.Column.Type }}
+            {{- else if eq $pair.Column.Type "GEOGRAPHY" -}}
+                st_geogfromgeojson(${{ $pair.Param }}::JSONB)
+            {{- else if eq $pair.Column.Type "GEOMETRY" -}}
+                st_geomfromgeojson(${{ $pair.Param }}::JSONB)
+            {{- else -}}
+                ${{ $pair.Param }}::{{ $pair.Column.Type }}
+            {{- end -}}
+
+            {{- if $pair.ValidityParam -}}
+                {{- sp -}} ELSE {{ $pair.Column.DefaultExpr }} END
+            {{- end -}}
+        {{- end -}}
+        )
+    {{- end -}}
+{{- end -}}
+
+{{- /* join creates a comma-separated list of its input: a, b, c, ... */ -}}
+{{- define "join" -}}
+    {{- range $idx, $val := . }}
+        {{- if $idx -}},{{- end -}}
+        {{- $val -}}
+    {{- end -}}
+{{- end -}}

--- a/internal/target/apply/queries/crdb/conditional.tmpl
+++ b/internal/target/apply/queries/crdb/conditional.tmpl
@@ -78,26 +78,11 @@ WHERE current.{{ (index .PK 0).Name }}{{/* >= v21.2 lets us say "current IS NULL
 The main clause is to then upsert the actionable rows into the
 target table.
 
-INSERT INTO table (pk0, pk1, ....)
-SELECT * FROM dataSource
-ON CONFLICT (pk0, pk1)
-DO UPDATE SET (col0, col1) = ROW(excluded.col0, excluded.col1)
+UPSERT INTO table (pk0, pk1, ....)
+  SELECT * FROM dataSource
 */ -}}
 {{- nl -}}
-INSERT INTO {{ .TableName }} (
-{{- template "names" .Columns -}}
-)
-{{- nl -}}
+UPSERT INTO {{ .TableName }} ({{ template "names" .Columns }})
 SELECT * FROM {{ $dataSource }}
-{{- nl -}}
-{{- /* For a PK-only table, there would be nothing to update */ -}}
-{{- if .Data -}}
-ON CONFLICT ( {{ template "names" .PK }} ) {{- nl -}}
-DO UPDATE SET ( {{- template "names" .Data -}} ) = ROW(
-{{- template "join" (qualify "excluded" .Data) -}}
-)
-{{- else -}}
-ON CONFLICT DO NOTHING
-{{- end -}}
 
 {{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/crdb/delete.tmpl
+++ b/internal/target/apply/queries/crdb/delete.tmpl
@@ -1,0 +1,11 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*
+DELETE FROM "database"."schema"."table"
+WHERE ("pk0","pk1") IN (($1,$2), (...), ...)
+*/ -}}
+DELETE FROM {{ .TableName }} WHERE (
+    {{- template "names" .PKDelete -}}
+)IN(
+    {{- template "exprs" . -}}
+)
+{{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/crdb/upsert.tmpl
+++ b/internal/target/apply/queries/crdb/upsert.tmpl
@@ -1,0 +1,15 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*
+UPSERT INTO "database"."schema"."table"
+ ("pk0","pk1","val0","val1","geom","geog")
+ VALUES (
+$1::STRING,
+st_geomfromgeojson($2::JSONB),
+st_geogfromgeojson($3::JSONB))
+*/ -}}
+UPSERT INTO {{ .TableName }} (
+{{ template "names" .Columns }}
+) VALUES
+{{ template "exprs" . }}
+
+{{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/pg/upsert.tmpl
+++ b/internal/target/apply/queries/pg/upsert.tmpl
@@ -1,15 +1,32 @@
 {{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
 {{- /*
-UPSERT INTO "database"."schema"."table"
+UPSERT, using INSERT ON CONFLICT DO UPDATE
+
+INSESRT INTO "database"."schema"."table"
  ("pk0","pk1","val0","val1","geom","geog")
  VALUES (
 $1::STRING,
 st_geomfromgeojson($2::JSONB),
 st_geogfromgeojson($3::JSONB))
+ON CONFLICT ("pk0", "pk1)
+DO UPDATE SET ("val0", "val1") = ROW(excluded."val0", excluded."val1")
 */ -}}
-UPSERT INTO {{ .TableName }} (
-{{ template "names" .Columns }}
-) VALUES
-{{ template "exprs" . }}
+INSERT INTO {{ .TableName }} (
+  {{- nl -}}
+  {{- template "names" .Columns -}}
+  {{- nl -}}
+) VALUES {{- nl -}}
+{{- template "exprs" . -}}
+{{- nl -}}
+
+{{- /* For a PK-only table, there would be nothing to update */ -}}
+{{- if .Data -}}
+ON CONFLICT ( {{ template "names" .PK }} ) {{- nl -}}
+DO UPDATE SET ( {{- template "names" .Data -}} ) = ROW(
+{{- template "join" (qualify "excluded" .Data) -}}
+)
+{{- else -}}
+ON CONFLICT DO NOTHING
+{{- end -}}
 
 {{- /* Trim whitespace */ -}}

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -79,8 +79,9 @@ var (
 		},
 	}
 
-	tmplOra = template.Must(template.New("").Funcs(tmplFuncs).ParseFS(queries, "queries/ora/*.tmpl"))
-	tmplPG  = template.Must(template.New("").Funcs(tmplFuncs).ParseFS(queries, "queries/pg/*.tmpl"))
+	tmplCRDB = template.Must(template.New("").Funcs(tmplFuncs).ParseFS(queries, "queries/crdb/*.tmpl"))
+	tmplOra  = template.Must(template.New("").Funcs(tmplFuncs).ParseFS(queries, "queries/ora/*.tmpl"))
+	tmplPG   = template.Must(template.New("").Funcs(tmplFuncs).ParseFS(queries, "queries/pg/*.tmpl"))
 )
 
 // A templateCache stores variations of the delete and upsert commands
@@ -118,15 +119,20 @@ func newTemplates(mapping *columnMapping) (*templates, error) {
 	}
 
 	switch mapping.Product {
-	case types.ProductCockroachDB, types.ProductPostgreSQL:
-		ret.conditional = tmplPG.Lookup("conditional.tmpl")
-		ret.delete = tmplPG.Lookup("delete.tmpl")
-		ret.upsert = tmplPG.Lookup("upsert.tmpl")
+	case types.ProductCockroachDB:
+		ret.conditional = tmplCRDB.Lookup("conditional.tmpl")
+		ret.delete = tmplCRDB.Lookup("delete.tmpl")
+		ret.upsert = tmplCRDB.Lookup("upsert.tmpl")
 
 	case types.ProductOracle:
 		ret.delete = tmplOra.Lookup("delete.tmpl")
 		ret.upsert = tmplOra.Lookup("upsert.tmpl")
 		ret.conditional = ret.upsert
+
+	case types.ProductPostgreSQL:
+		ret.conditional = tmplPG.Lookup("conditional.tmpl")
+		ret.delete = tmplPG.Lookup("delete.tmpl")
+		ret.upsert = tmplPG.Lookup("upsert.tmpl")
 
 	default:
 		return nil, errors.Errorf("unsupported product %s", mapping.Product)

--- a/internal/target/apply/testdata/crdb/base.delete.sql
+++ b/internal/target/apply/testdata/crdb/base.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/base.upsert.sql
+++ b/internal/target/apply/testdata/crdb/base.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog","enum","has_default"
+) VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/crdb/cas.delete.sql
+++ b/internal/target/apply/testdata/crdb/cas.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/cas.upsert.sql
+++ b/internal/target/apply/testdata/crdb/cas.upsert.sql
@@ -2,8 +2,16 @@ WITH data("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
 VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
 ($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
-deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL))
-INSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
-SELECT * FROM deadlined
-ON CONFLICT ( "pk0","pk1" )
-DO UPDATE SET ("val0","val1","geom","geog","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."geom",excluded."geog",excluded."enum",excluded."has_default")
+current AS (
+SELECT "pk0","pk1", "table"."val1","table"."val0"
+FROM "database"."schema"."table"
+JOIN data
+USING ("pk0","pk1")),
+action AS (
+SELECT data.* FROM data
+LEFT JOIN current
+USING ("pk0","pk1")
+WHERE current."pk0" IS NULL OR
+(data."val1",data."val0") > (current."val1",current."val0"))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+SELECT * FROM action

--- a/internal/target/apply/testdata/crdb/casDeadline.delete.sql
+++ b/internal/target/apply/testdata/crdb/casDeadline.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/casDeadline.upsert.sql
+++ b/internal/target/apply/testdata/crdb/casDeadline.upsert.sql
@@ -2,18 +2,17 @@ WITH data("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
 VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
 ($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
+deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL)),
 current AS (
 SELECT "pk0","pk1", "table"."val1","table"."val0"
 FROM "database"."schema"."table"
-JOIN data
+JOIN deadlined
 USING ("pk0","pk1")),
 action AS (
-SELECT data.* FROM data
+SELECT deadlined.* FROM deadlined
 LEFT JOIN current
 USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
-(data."val1",data."val0") > (current."val1",current."val0"))
-INSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+(deadlined."val1",deadlined."val0") > (current."val1",current."val0"))
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
 SELECT * FROM action
-ON CONFLICT ( "pk0","pk1" )
-DO UPDATE SET ("val0","val1","geom","geog","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."geom",excluded."geog",excluded."enum",excluded."has_default")

--- a/internal/target/apply/testdata/crdb/deadline.delete.sql
+++ b/internal/target/apply/testdata/crdb/deadline.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/deadline.upsert.sql
+++ b/internal/target/apply/testdata/crdb/deadline.upsert.sql
@@ -3,7 +3,5 @@ VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
 ($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
 deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL))
-INSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
 SELECT * FROM deadlined
-ON CONFLICT ( "pk0","pk1" )
-DO UPDATE SET ("val0","val1","geom","geog","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."geom",excluded."geog",excluded."enum",excluded."has_default")

--- a/internal/target/apply/testdata/crdb/expr.delete.sql
+++ b/internal/target/apply/testdata/crdb/expr.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,($2+$2)::INT8,$3::STRING),
+($4::STRING,($5+$5)::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/expr.upsert.sql
+++ b/internal/target/apply/testdata/crdb/expr.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","enum","has_default"
+) VALUES
+($1::STRING,($2+$2)::INT8,('fixed')::STRING,($3||'foobar')::STRING,$4::"database"."schema"."MyEnum",CASE WHEN $5::BOOLEAN THEN $6::INT8 ELSE expr() END),
+($7::STRING,($8+$8)::INT8,('fixed')::STRING,($9||'foobar')::STRING,$10::"database"."schema"."MyEnum",CASE WHEN $11::BOOLEAN THEN $12::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/crdb/ignore.delete.sql
+++ b/internal/target/apply/testdata/crdb/ignore.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/ignore.upsert.sql
+++ b/internal/target/apply/testdata/crdb/ignore.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","enum","has_default"
+) VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,$5::"database"."schema"."MyEnum",CASE WHEN $6::BOOLEAN THEN $7::INT8 ELSE expr() END),
+($8::STRING,$9::INT8,$10::STRING,$11::STRING,$12::"database"."schema"."MyEnum",CASE WHEN $13::BOOLEAN THEN $14::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/crdb/source_names.delete.sql
+++ b/internal/target/apply/testdata/crdb/source_names.delete.sql
@@ -1,0 +1,2 @@
+DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/source_names.upsert.sql
+++ b/internal/target/apply/testdata/crdb/source_names.upsert.sql
@@ -1,0 +1,5 @@
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog","enum","has_default"
+) VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)

--- a/internal/target/apply/testdata/pg/base.upsert.sql
+++ b/internal/target/apply/testdata/pg/base.upsert.sql
@@ -1,5 +1,7 @@
-UPSERT INTO "database"."schema"."table" (
+INSERT INTO "database"."schema"."table" (
 "pk0","pk1","val0","val1","geom","geog","enum","has_default"
 ) VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
 ($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)
+ON CONFLICT ( "pk0","pk1" )
+DO UPDATE SET ("val0","val1","geom","geog","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."geom",excluded."geog",excluded."enum",excluded."has_default")

--- a/internal/target/apply/testdata/pg/casDeadline.upsert.sql
+++ b/internal/target/apply/testdata/pg/casDeadline.upsert.sql
@@ -14,5 +14,7 @@ LEFT JOIN current
 USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
 (deadlined."val1",deadlined."val0") > (current."val1",current."val0"))
-UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+INSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
 SELECT * FROM action
+ON CONFLICT ( "pk0","pk1" )
+DO UPDATE SET ("val0","val1","geom","geog","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."geom",excluded."geog",excluded."enum",excluded."has_default")

--- a/internal/target/apply/testdata/pg/expr.upsert.sql
+++ b/internal/target/apply/testdata/pg/expr.upsert.sql
@@ -1,5 +1,7 @@
-UPSERT INTO "database"."schema"."table" (
+INSERT INTO "database"."schema"."table" (
 "pk0","pk1","val0","val1","enum","has_default"
 ) VALUES
 ($1::STRING,($2+$2)::INT8,('fixed')::STRING,($3||'foobar')::STRING,$4::"database"."schema"."MyEnum",CASE WHEN $5::BOOLEAN THEN $6::INT8 ELSE expr() END),
 ($7::STRING,($8+$8)::INT8,('fixed')::STRING,($9||'foobar')::STRING,$10::"database"."schema"."MyEnum",CASE WHEN $11::BOOLEAN THEN $12::INT8 ELSE expr() END)
+ON CONFLICT ( "pk0","pk1" )
+DO UPDATE SET ("val0","val1","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."enum",excluded."has_default")

--- a/internal/target/apply/testdata/pg/ignore.upsert.sql
+++ b/internal/target/apply/testdata/pg/ignore.upsert.sql
@@ -1,5 +1,7 @@
-UPSERT INTO "database"."schema"."table" (
+INSERT INTO "database"."schema"."table" (
 "pk0","pk1","val0","val1","enum","has_default"
 ) VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,$5::"database"."schema"."MyEnum",CASE WHEN $6::BOOLEAN THEN $7::INT8 ELSE expr() END),
 ($8::STRING,$9::INT8,$10::STRING,$11::STRING,$12::"database"."schema"."MyEnum",CASE WHEN $13::BOOLEAN THEN $14::INT8 ELSE expr() END)
+ON CONFLICT ( "pk0","pk1" )
+DO UPDATE SET ("val0","val1","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."enum",excluded."has_default")

--- a/internal/target/apply/testdata/pg/source_names.upsert.sql
+++ b/internal/target/apply/testdata/pg/source_names.upsert.sql
@@ -1,5 +1,7 @@
-UPSERT INTO "database"."schema"."table" (
+INSERT INTO "database"."schema"."table" (
 "pk0","pk1","val0","val1","geom","geog","enum","has_default"
 ) VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
 ($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)
+ON CONFLICT ( "pk0","pk1" )
+DO UPDATE SET ("val0","val1","geom","geog","enum","has_default") = ROW(excluded."val0",excluded."val1",excluded."geom",excluded."geog",excluded."enum",excluded."has_default")

--- a/internal/util/stdpool/timeout.go
+++ b/internal/util/stdpool/timeout.go
@@ -18,6 +18,7 @@ package stdpool
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -31,6 +32,7 @@ type withTransactionTimeout struct{ d time.Duration }
 
 func (o *withTransactionTimeout) option() {}
 func (o *withTransactionTimeout) pgxPoolConfig(_ context.Context, cfg *pgxpool.Config) error {
-	cfg.ConnConfig.RuntimeParams["idle_in_transaction_session_timeout"] = o.d.String()
+	cfg.ConnConfig.RuntimeParams["idle_in_transaction_session_timeout"] =
+		fmt.Sprintf("%d", o.d.Milliseconds())
 	return nil
 }


### PR DESCRIPTION
This change adds support to the apply package for applying mutations to a
PostgreSQL database. It also enables CI testing for PostgreSQL v11 through v15.

Review notes:
- The primary change required is to use INSERT ON CONFLICT DO UPDATE instead of
  the CockroachDB-specific UPSERT command. One note here is that CockroachDB
  does not allow the ROW keyword when performing a multi-column update, whereas
  PostgreSQL requires it.
- The golden-output template tests now compare CRDB vs. PG.
- ProvideTargetSchema() updates the TargetPool's connection string. This value
  is used by logical-loop tests to create their own connection pool.
- The idle_in_transaction_session_timeout connection variable must be set to an
  integer number of milliseconds in earlier version of PostgreSQL.

X-Ref: https://github.com/cockroachdb/cockroach/issues/79081

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/475)
<!-- Reviewable:end -->
