### PR TITLE
cdc: Fully integrate with userscript

### DIFF
--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -40,9 +40,9 @@ var sanitizer = strings.NewReplacer("\n", " ", "\r", " ")
 // Handler is an http.Handler for processing webhook requests
 // from a CockroachDB changefeed.
 type Handler struct {
-	Appliers      types.Appliers      // Update tables within TargetDb.
 	Authenticator types.Authenticator // Access checks.
 	Config        *Config             // Runtime options.
+	Immediate     *Immediate          // Non-transactional mutations.
 	Resolvers     *Resolvers          // Process resolved timestamps.
 	StagingPool   *types.StagingPool  // Access to the staging cluster.
 	Stores        types.Stagers       // Record incoming json blobs.

--- a/internal/source/cdc/immediate.go
+++ b/internal/source/cdc/immediate.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdc
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cdc-sink/internal/source/logical"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// Immediate memoizes instances of [logical.Batcher].
+type Immediate struct {
+	loops *logical.Factory
+
+	mu struct {
+		sync.RWMutex
+		cleanup []func()
+		targets ident.SchemaMap[logical.Batcher]
+	}
+}
+
+// cleanup is called by ProvideImmediate.
+func (f *Immediate) cleanup() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, cleanup := range f.mu.cleanup {
+		cleanup()
+	}
+	f.mu.cleanup = nil
+	f.mu.targets = ident.SchemaMap[logical.Batcher]{}
+}
+
+// Get returns a facade to apply mutations to the target schema.
+func (f *Immediate) Get(ctx context.Context, target ident.Schema) (logical.Batcher, error) {
+	f.mu.RLock()
+	found, ok := f.mu.targets.Get(target)
+	f.mu.RUnlock()
+	if ok {
+		return found, nil
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Double-check.
+	if found, ok := f.mu.targets.Get(target); ok {
+		return found, nil
+	}
+
+	ret, cancel, err := f.loops.Immediate(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	f.mu.cleanup = append(f.mu.cleanup, cancel)
+	f.mu.targets.Put(target, ret)
+	return ret, nil
+}

--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -30,6 +30,7 @@ import (
 // Set is used by Wire.
 var Set = wire.NewSet(
 	wire.Struct(new(Handler), "*"), // Handler is itself trivial.
+	ProvideImmediate,
 	ProvideMetaTable,
 	ProvideResolvers,
 )
@@ -39,6 +40,12 @@ type MetaTable ident.Table
 
 // Table returns the underlying table identifier.
 func (t MetaTable) Table() ident.Table { return ident.Table(t) }
+
+// ProvideImmediate is called by wire.
+func ProvideImmediate(loops *logical.Factory) (*Immediate, func(), error) {
+	imm := &Immediate{loops: loops}
+	return imm, imm.cleanup, nil
+}
 
 // ProvideMetaTable is called by wire. It returns the
 // "_cdc_sink.public.resolved_timestamps" table per the flags.

--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -342,6 +342,7 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 		Targets:     targets,
 	}
 
+	source := scriptSource(r.target)
 	flush := func(toApply *ident.TableMap[[]types.Mutation], final bool) error {
 		flushStart := time.Now()
 
@@ -361,7 +362,7 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 				if len(muts) == 0 {
 					continue
 				}
-				if err := batch.OnData(ctx, table.Table(), table, muts); err != nil {
+				if err := batch.OnData(ctx, source, table, muts); err != nil {
 					return err
 				}
 			}
@@ -448,6 +449,7 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 			}
 
 			flushCounter++
+			mut.Meta = scriptMeta(tbl, mut)
 			toApply.Put(tbl, append(toApply.GetZero(tbl), mut))
 			epoch = mut.Time
 			return nil

--- a/internal/source/cdc/script_helpers.go
+++ b/internal/source/cdc/script_helpers.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdc
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// scriptSource returns the canonical name of a schema for use with
+// the configureSource() function in the userscript API.
+func scriptSource(target ident.Schematic) ident.Ident {
+	return ident.New(target.Schema().Canonical().Raw())
+}
+
+// scriptMeta create a userscript metadata map for a mutation being
+// applied to a table.
+func scriptMeta(tbl ident.Table, mut types.Mutation) map[string]any {
+	return map[string]any{
+		"cdc":     true,
+		"logical": mut.Time.Logical(),
+		"nanos":   mut.Time.Nanos(),
+		"schema":  tbl.Schema().Raw(),
+		"table":   tbl.Table().Raw(),
+	}
+}

--- a/internal/source/cdc/testdata/main.ts
+++ b/internal/source/cdc/testdata/main.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Cockroach Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as api from "cdc-sink@v1";
+import {Document, Table} from "cdc-sink@v1";
+
+// The sentinel name will be replaced by the test rig. It would normally be
+// "my_db.public" or "my_db" depending on the target product.
+api.configureSource("{{ SCHEMA }}", {
+    dispatch: (doc: Document, meta: Document): Record<Table, Document[]> => {
+        console.log(JSON.stringify(doc), JSON.stringify(meta));
+        let ret: Record<Table, Document> = {};
+        ret[meta.table] = [
+            {
+                pk: doc.pk,
+                ignored: 'by_configuration_below',
+                v_dispatched: doc.v, // Rename the property
+            }
+        ];
+        return ret
+    }
+})
+
+// We introduce an unknown column in the dispatch function above.
+// We'll add an extra configuration here to ignore it.
+// The sentinel name would be replaced by "my_table".
+api.configureTable("{{ TABLE }}", {
+    map: (doc: Document): Document => {
+        console.log("map", JSON.stringify(doc));
+        if (doc.v_dispatched === undefined) {
+            throw "did not find expected property";
+        }
+        doc.v_mapped = doc.v_dispatched;
+        delete doc.v_dispatched; // Avoid schema-drift error due to unknown column.
+        return doc;
+    },
+    ignore: {
+        "ignored": true,
+    }
+})

--- a/internal/source/cdc/webhook_query.go
+++ b/internal/source/cdc/webhook_query.go
@@ -79,5 +79,8 @@ func (h *Handler) webhookForQuery(ctx context.Context, req *request) error {
 		}
 		toProcess.Put(table, append(toProcess.GetZero(table), mut))
 	}
-	return h.processMutations(ctx, toProcess)
+	if h.Config.Immediate {
+		return h.processMutationsImmediate(ctx, table.Schema(), toProcess)
+	}
+	return h.processMutationsDeferred(ctx, toProcess)
 }

--- a/internal/source/logical/dialect.go
+++ b/internal/source/logical/dialect.go
@@ -97,12 +97,16 @@ func IsRollback(m Message) bool {
 
 // Events extends State to drive the state of the replication loop.
 type Events interface {
+	Batcher
 	State
 	// Backfill will execute a single pass of the given Backfiller in a
 	// blocking fashion. This is useful when sources are discovered
 	// dynamically.
 	Backfill(ctx context.Context, loopName string, backfiller Backfiller) error
+}
 
+// A Batcher processes batches of mutations.
+type Batcher interface {
 	// OnBegin denotes the beginning of a (transactional) batch in the
 	// underlying logical feed.
 	OnBegin(ctx context.Context) (Batch, error)

--- a/internal/source/logical/fake_dialect.go
+++ b/internal/source/logical/fake_dialect.go
@@ -1,0 +1,45 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logical
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/pkg/errors"
+)
+
+// See discussion in Factory.Immediate.
+type fakeDialect struct{}
+
+func (f *fakeDialect) ReadInto(_ context.Context, _ chan<- Message, _ State) error {
+	return errors.New("fake")
+}
+
+func (f *fakeDialect) Process(_ context.Context, _ <-chan Message, _ Events) error {
+	return errors.New("fake")
+}
+
+func (f *fakeDialect) ZeroStamp() stamp.Stamp {
+	return &fakeStamp{}
+}
+
+type fakeStamp struct{}
+
+func (f *fakeStamp) Less(_ stamp.Stamp) bool {
+	return false
+}

--- a/internal/source/logical/script_events.go
+++ b/internal/source/logical/script_events.go
@@ -65,11 +65,15 @@ func (e *scriptBatch) OnData(
 		return e.sendToTarget(ctx, source, target, muts)
 	}
 	for _, mut := range muts {
-		// For deletes, we won't have anything more than the original
-		// key, so the best that we can do is to route the deletion to a
-		// table and allow FK's to perform the cascade.
+		// For deletes, we will allow the user to specify an alternate
+		// table to send the delete to. Depending on the setup, we may
+		// or may not have a default table that's specified by a payload
+		// or other configuration.
 		if mut.IsDelete() {
 			deletesTo := cfg.DeletesTo
+			if deletesTo.Empty() {
+				deletesTo = target
+			}
 			if deletesTo.Empty() {
 				return errors.Errorf(
 					"cannot apply delete from %s because there is no "+


### PR DESCRIPTION
Note that this is stacked on PR #477 

This change unifies the processing for immediate-mode CDC feeds with the
existing logical loop pipeline. This will ensure that immediate-mode payloads
can use all facilities available to logical loops. Tests for userscript
integration are added to verify that the script is invoke in both immediate and
deferred modes.

The logical package is updated to allow the immediate-mode HTTP handler to make
use of the mutation pipeline. A fake loop is constructed and the event handler
is extracted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/478)
<!-- Reviewable:end -->
