### PR TITLE
Userscript integration for xylogical packages

### DIFF
--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -77,7 +77,7 @@ type Target struct {
 	applycfg.Config
 	// A user-provided function to modify or filter mutations bound for
 	// the target table.
-	Map Map
+	Map Map `json:"-"`
 }
 
 // UserScript encapsulates a user-provided configuration expressed as a

--- a/internal/sinktest/scripttest/scripttest.go
+++ b/internal/sinktest/scripttest/scripttest.go
@@ -1,0 +1,82 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package scripttest contains reusable test helpers for
+// logical-replication tests.
+package scripttest
+
+import (
+	"embed"
+	"io"
+	"io/fs"
+	"strings"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// ScriptFS contains the contents of the testdata directory.
+//
+//go:embed testdata/*
+var ScriptFS embed.FS
+
+// ScriptFSFor returns a wrapped version of ScriptFS that will
+// substitute the table and its schema into the returned files.
+func ScriptFSFor(tbl ident.Table) fs.FS {
+	return &SubstitutingFS{
+		FS: ScriptFS,
+		Replacer: strings.NewReplacer(
+			"{{ SCHEMA }}", tbl.Schema().Raw(),
+			"{{ TABLE }}", tbl.Raw(),
+		),
+	}
+}
+
+// SubstitutingFS performs string substitution on returned files.
+// This is used to replace sentinel values in the userscript with
+// dynamically generated values.
+type SubstitutingFS struct {
+	fs.FS
+	Replacer *strings.Replacer
+}
+
+// Open implements fs.FS.
+func (f *SubstitutingFS) Open(path string) (fs.File, error) {
+	file, err := f.FS.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	buf, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	s := f.Replacer.Replace(string(buf))
+	return &substitutingFile{info, io.NopCloser(strings.NewReader(s))}, nil
+}
+
+type substitutingFile struct {
+	fs.FileInfo
+	io.ReadCloser
+}
+
+var _ fs.File = (*substitutingFile)(nil)
+
+func (s *substitutingFile) Stat() (fs.FileInfo, error) {
+	return s.FileInfo, nil
+}

--- a/internal/sinktest/scripttest/testdata/logical_test.ts
+++ b/internal/sinktest/scripttest/testdata/logical_test.ts
@@ -23,7 +23,7 @@ import {Document, Table} from "cdc-sink@v1";
 // "my_db.public" or "my_db" depending on the target product.
 api.configureSource("{{ SCHEMA }}", {
     dispatch: (doc: Document, meta: Document): Record<Table, Document[]> => {
-        console.log(JSON.stringify(doc), JSON.stringify(meta));
+        console.trace(JSON.stringify(doc), JSON.stringify(meta));
         let ret: Record<Table, Document> = {};
         ret[meta.table] = [
             {
@@ -41,7 +41,7 @@ api.configureSource("{{ SCHEMA }}", {
 // The sentinel name would be replaced by "my_table".
 api.configureTable("{{ TABLE }}", {
     map: (doc: Document): Document => {
-        console.log("map", JSON.stringify(doc));
+        console.trace("map", JSON.stringify(doc));
         if (doc.v_dispatched === undefined) {
             throw "did not find expected property";
         }

--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
@@ -86,7 +87,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request, parser parseMutation
 		if err != nil {
 			return err
 		}
-		source := scriptSource(target)
+		source := script.SourceName(target)
 		// Push the data into the pipeline.
 		flush = func(muts []types.Mutation) error {
 			for idx := range muts {
@@ -94,7 +95,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request, parser parseMutation
 				// create metadata in the scan phase, because this
 				// computation is only relevant to immediate mode. It's
 				// going to be re-computed in deferred mode.
-				muts[idx].Meta = scriptMeta(target, muts[idx])
+				script.AddMeta("cdc", target, &muts[idx])
 			}
 			return batch.OnData(ctx, source, target, muts)
 		}

--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
@@ -342,7 +343,7 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 		Targets:     targets,
 	}
 
-	source := scriptSource(r.target)
+	source := script.SourceName(r.target)
 	flush := func(toApply *ident.TableMap[[]types.Mutation], final bool) error {
 		flushStart := time.Now()
 
@@ -449,7 +450,7 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 			}
 
 			flushCounter++
-			mut.Meta = scriptMeta(tbl, mut)
+			script.AddMeta("cdc", tbl, &mut)
 			toApply.Put(tbl, append(toApply.GetZero(tbl), mut))
 			epoch = mut.Time
 			return nil

--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -144,11 +145,11 @@ func (h *Handler) processMutationsImmediate(
 	}
 	defer func() { _ = batch.OnRollback(ctx) }()
 
-	source := scriptSource(target)
+	source := script.SourceName(target)
 	if err := toProcess.Range(func(tbl ident.Table, muts []types.Mutation) error {
 		for idx := range muts {
 			// Index needed since it's not a pointer type.
-			muts[idx].Meta = scriptMeta(tbl, muts[idx])
+			script.AddMeta("cdc", tbl, &muts[idx])
 		}
 		return batch.OnData(ctx, source, tbl, muts)
 	}); err != nil {

--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -382,7 +383,8 @@ func (c *conn) onDataTuple(
 				return err
 			}
 		}
-		err = batch.OnData(ctx, tbl.Table(), tbl, []types.Mutation{mut})
+		script.AddMeta("mylogical", tbl, &mut)
+		err = batch.OnData(ctx, script.SourceName(tbl), tbl, []types.Mutation{mut})
 		if err != nil {
 			return err
 		}

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -374,8 +375,9 @@ func (c *conn) onDataTuple(
 	if err != nil {
 		return err
 	}
+	script.AddMeta("pglogical", tbl, &mut)
 
-	return batch.OnData(ctx, tbl.Table(), tbl, []types.Mutation{mut})
+	return batch.OnData(ctx, script.SourceName(tbl), tbl, []types.Mutation{mut})
 }
 
 // learn updates the source database namespace mappings.


### PR DESCRIPTION
This is a follow-up to #478 which aligns the behaviors in the `pglogical` and `mylogical` packages with the script wiring in the `cdc` package. Some common test code is extracted from the `cdc` package into a `sinktest/scripttest` helper package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/488)
<!-- Reviewable:end -->
