### PR TITLE
apply: Use prepared statements in the hot path

### DIFF
--- a/internal/sinktest/base/wire_gen.go
+++ b/internal/sinktest/base/wire_gen.go
@@ -59,8 +59,10 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	targetSchema, cleanup8, err := ProvideTargetSchema(context, diagnostics, targetPool)
+	targetStatements, cleanup8 := ProvideTargetStatements(targetPool)
+	targetSchema, cleanup9, err := ProvideTargetSchema(context, diagnostics, targetPool, targetStatements)
 	if err != nil {
+		cleanup8()
 		cleanup7()
 		cleanup6()
 		cleanup5()
@@ -76,10 +78,12 @@ func NewFixture() (*Fixture, func(), error) {
 		SourceSchema: sourceSchema,
 		StagingPool:  stagingPool,
 		StagingDB:    stagingSchema,
+		TargetCache:  targetStatements,
 		TargetPool:   targetPool,
 		TargetSchema: targetSchema,
 	}
 	return fixture, func() {
+		cleanup9()
 		cleanup8()
 		cleanup7()
 		cleanup6()

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
 	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
+	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/google/wire"
 )
@@ -41,11 +42,12 @@ func newTestFixture(*all.Fixture, *Config) (*testFixture, func(), error) {
 		Set,
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
-			"Appliers", "Configs", "Fixture", "Memo", "Stagers", "VersionChecker", "Watchers"),
+			"Configs", "Fixture", "Memo", "Stagers", "VersionChecker"),
 		diag.New,
 		leases.Set,
 		logical.Set,
 		script.Set,
+		target.Set,
 		trust.New, // Is valid to use as a provider.
 		wire.Struct(new(testFixture), "*"),
 		wire.Bind(new(logical.Config), new(*Config)),

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -56,12 +56,14 @@ func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, func(), erro
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),
-			"Appliers", "Diagnostics", "Fixture", "Configs", "Memo", "VersionChecker", "Watchers"),
+			"Fixture", "Configs", "Memo", "VersionChecker"),
 		ProvideFirestoreClient,
 		ProvideLoops,
 		ProvideScriptTarget,
 		ProvideTombstones,
+		diag.New,
 		logical.Set,
 		script.Set,
+		target.Set,
 	))
 }

--- a/internal/source/logical/config.go
+++ b/internal/source/logical/config.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
-	defaultApplyTimeout   = 30 * time.Second
-	defaultBackfillWindow = 10 * time.Minute
-	defaultFanShards      = 16
-	defaultRetryDelay     = 10 * time.Second
-	defaultStandbyTimeout = 5 * time.Second
-	defaultTargetDBConns  = 1024
-	defaultBytesInFlight  = 10 * 1024 * 1024
+	defaultApplyTimeout    = 30 * time.Second
+	defaultBackfillWindow  = 10 * time.Minute
+	defaultFanShards       = 16
+	defaultRetryDelay      = 10 * time.Second
+	defaultStandbyTimeout  = 5 * time.Second
+	defaultTargetCacheSize = 128 // Statements may have a non-trivial cost in the db.
+	defaultTargetDBConns   = 1024
+	defaultBytesInFlight   = 10 * 1024 * 1024
 )
 
 // Config is implemented by dialects. This interface exists to allow coordination of
@@ -89,6 +90,11 @@ type BaseConfig struct {
 	// The number of connections to the target database. If zero, a
 	// default value will be used.
 	TargetDBConns int
+	// The number of prepared statements to retain in the target
+	// database connection pool. Depending on the database in question,
+	// there may be more or fewer available resources to retain
+	// statements.
+	TargetStatementCacheSize int
 }
 
 // Base returns the BaseConfig.
@@ -132,6 +138,8 @@ func (c *BaseConfig) Bind(f *pflag.FlagSet) {
 		"the target database's connection string; always required")
 	f.IntVar(&c.TargetDBConns, "targetDBConns", defaultTargetDBConns,
 		"the maximum pool size to the target cluster")
+	f.IntVar(&c.TargetStatementCacheSize, "targetStatementCacheSize", defaultTargetCacheSize,
+		"the maximum number of prepared statements to retain")
 }
 
 // Copy returns a deep copy of the Config.
@@ -180,6 +188,9 @@ func (c *BaseConfig) Preflight() error {
 	}
 	if c.TargetDBConns == 0 {
 		c.TargetDBConns = defaultTargetDBConns
+	}
+	if c.TargetStatementCacheSize == 0 {
+		c.TargetStatementCacheSize = defaultTargetCacheSize
 	}
 	return nil
 }

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -167,7 +167,7 @@ func testLogicalSmoke(t *testing.T, mode *logicalTestMode) {
 
 	var chaosProb float32
 	if mode.chaos {
-		chaosProb = 0.1
+		chaosProb = 0.01
 	}
 
 	cfg := &logical.BaseConfig{

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -44,31 +44,25 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	stagingPool, cleanup2, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
+	targetPool, cleanup2, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
-	if err != nil {
-		cleanup2()
-		cleanup()
-		return nil, nil, err
-	}
-	configs, cleanup3, err := applycfg.ProvideConfigs(ctx, diagnostics, stagingPool, stagingSchema)
+	targetStatements, cleanup3, err := logical.ProvideTargetStatements(baseConfig, targetPool, diagnostics)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	targetPool, cleanup4, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
+	stagingPool, cleanup4, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
 	if err != nil {
 		cleanup3()
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	watchers, cleanup5, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
 		cleanup4()
 		cleanup3()
@@ -76,8 +70,26 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	appliers, cleanup6, err := apply.ProvideFactory(configs, diagnostics, targetPool, watchers)
+	configs, cleanup5, err := applycfg.ProvideConfigs(ctx, diagnostics, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	watchers, cleanup6, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	if err != nil {
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	appliers, cleanup7, err := apply.ProvideFactory(targetStatements, configs, diagnostics, targetPool, watchers)
+	if err != nil {
+		cleanup6()
 		cleanup5()
 		cleanup4()
 		cleanup3()
@@ -87,6 +99,7 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 	}
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -98,6 +111,7 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 	checker := version.ProvideChecker(stagingPool, memoMemo)
 	factory, err := logical.ProvideFactory(ctx, appliers, configs, baseConfig, diagnostics, memoMemo, loader, stagingPool, targetPool, watchers, checker)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -106,8 +120,9 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	loop, cleanup7, err := ProvideLoop(config, dialect, factory)
+	loop, cleanup8, err := ProvideLoop(config, dialect, factory)
 	if err != nil {
+		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()
@@ -121,6 +136,7 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		Loop:        loop,
 	}
 	return pgLogical, func() {
+		cleanup8()
 		cleanup7()
 		cleanup6()
 		cleanup5()

--- a/internal/target/apply/factory.go
+++ b/internal/target/apply/factory.go
@@ -29,6 +29,7 @@ import (
 
 // factory vends singleton instance of apply.
 type factory struct {
+	cache    *types.TargetStatements
 	configs  *applycfg.Configs
 	product  types.Product
 	watchers types.Watchers
@@ -83,7 +84,7 @@ func (f *factory) getOrCreateUnlocked(product types.Product, table ident.Table) 
 	if ret := f.mu.instances.GetZero(table); ret != nil {
 		return ret, nil
 	}
-	ret, cancel, err := newApply(product, table, f.configs, f.watchers)
+	ret, cancel, err := newApply(f.cache, product, table, f.configs, f.watchers)
 	if err == nil {
 		f.mu.cleanup = append(f.mu.cleanup, cancel)
 		f.mu.instances.Put(table, ret)

--- a/internal/target/apply/metrics.go
+++ b/internal/target/apply/metrics.go
@@ -36,14 +36,6 @@ var (
 		Name: "apply_errors_total",
 		Help: "the number of times an error was encountered while applying mutations",
 	}, metrics.TableLabels)
-	applyTemplateHits = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "apply_template_hits_total",
-		Help: "the number of times the apply template cache hit",
-	}, []string{"name"})
-	applyTemplateMisses = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "apply_template_misses_total",
-		Help: "the number of times the apply template cache missed",
-	}, []string{"name"})
 	applyUpserts = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "apply_upserts_total",
 		Help: "the number of rows upserted",

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -33,12 +33,14 @@ var Set = wire.NewSet(
 // function will, in turn, destroy the per-schema types.Applier
 // instances.
 func ProvideFactory(
+	cache *types.TargetStatements,
 	configs *applycfg.Configs,
 	diags *diag.Diagnostics,
 	target *types.TargetPool,
 	watchers types.Watchers,
 ) (types.Appliers, func(), error) {
 	f := &factory{
+		cache:    cache,
 		configs:  configs,
 		product:  target.Product,
 		watchers: watchers,

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -20,14 +20,11 @@ import (
 	"embed"
 	"fmt"
 	"strings"
-	"sync"
 	"text/template"
 
 	"github.com/cockroachdb/cdc-sink/internal/staging/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/golang/groupcache/lru"
 	"github.com/pkg/errors"
 )
 
@@ -84,19 +81,9 @@ var (
 	tmplPG   = template.Must(template.New("").Funcs(tmplFuncs).ParseFS(queries, "queries/pg/*.tmpl"))
 )
 
-// A templateCache stores variations of the delete and upsert commands
-// at varying batch sizes. The map keys are just ints representing the
-// number of rows that the statement should process.
-type templateCache struct {
-	sync.Mutex
-	deletes *lru.Cache
-	upserts *lru.Cache
-}
-
 type templates struct {
 	*columnMapping
 
-	cache       *templateCache // Memoize calls to delete() and upsert().
 	conditional *template.Template
 	delete      *template.Template
 	upsert      *template.Template
@@ -110,13 +97,7 @@ type templates struct {
 // pre-computations to identify primary keys and to filter out ignored
 // columns.
 func newTemplates(mapping *columnMapping) (*templates, error) {
-	ret := &templates{
-		columnMapping: mapping,
-		cache: &templateCache{
-			deletes: lru.New(batches.Size()),
-			upserts: lru.New(batches.Size()),
-		},
-	}
+	ret := &templates{columnMapping: mapping}
 
 	switch mapping.Product {
 	case types.ProductCockroachDB:
@@ -214,16 +195,6 @@ func (t *templates) Vars() ([][]varPair, error) {
 }
 
 func (t *templates) deleteExpr(rowCount int) (string, error) {
-	// Fast lookup
-	t.cache.Lock()
-	found, ok := t.cache.deletes.Get(rowCount)
-	t.cache.Unlock()
-	if ok {
-		applyTemplateHits.WithLabelValues("delete").Inc()
-		return found.(string), nil
-	}
-	applyTemplateMisses.WithLabelValues("delete").Inc()
-
 	// Make a copy that we can tweak.
 	cpy := *t
 	cpy.ForDelete = true
@@ -231,25 +202,10 @@ func (t *templates) deleteExpr(rowCount int) (string, error) {
 
 	var buf strings.Builder
 	err := t.delete.Execute(&buf, &cpy)
-	ret, err := buf.String(), errors.WithStack(err)
-	if err == nil {
-		t.cache.Lock()
-		t.cache.deletes.Add(rowCount, ret)
-		t.cache.Unlock()
-	}
-	return ret, err
+	return buf.String(), errors.WithStack(err)
 }
 
 func (t *templates) upsertExpr(rowCount int) (string, error) {
-	t.cache.Lock()
-	found, ok := t.cache.upserts.Get(rowCount)
-	t.cache.Unlock()
-	if ok {
-		applyTemplateHits.WithLabelValues("upsert").Inc()
-		return found.(string), nil
-	}
-	applyTemplateMisses.WithLabelValues("upsert").Inc()
-
 	// Make a copy that we can tweak.
 	cpy := *t
 	cpy.RowCount = rowCount
@@ -261,11 +217,5 @@ func (t *templates) upsertExpr(rowCount int) (string, error) {
 	} else {
 		err = t.conditional.Execute(&buf, &cpy)
 	}
-	ret, err := buf.String(), errors.WithStack(err)
-	if err == nil {
-		t.cache.Lock()
-		t.cache.upserts.Add(rowCount, ret)
-		t.cache.Unlock()
-	}
-	return ret, err
+	return buf.String(), errors.WithStack(err)
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stmtcache"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -368,6 +369,7 @@ type SourcePool struct {
 type TargetPool struct {
 	*sql.DB
 	PoolInfo
+
 	_ noCopy
 }
 
@@ -382,6 +384,12 @@ var (
 	_ TargetQuerier = (*sql.DB)(nil)
 	_ TargetQuerier = (*sql.Tx)(nil)
 )
+
+// TargetStatements is an injection point for a cache of prepared
+// statements associated with the TargetPool.
+type TargetStatements struct {
+	*stmtcache.Cache[string]
+}
 
 // TargetTx is implemented by [sql.Tx].
 type TargetTx interface {

--- a/internal/util/stmtcache/metrics.go
+++ b/internal/util/stmtcache/metrics.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stmtcache
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	stmtCacheHits = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "stmtcache_hits_total",
+		Help: "the number of prepared-statement cache hits",
+	})
+	stmtCacheMisses = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "stmtcache_misses_total",
+		Help: "the number of prepared-statement cache misses",
+	})
+)

--- a/internal/util/stmtcache/stmtcache.go
+++ b/internal/util/stmtcache/stmtcache.go
@@ -1,0 +1,121 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stmtcache provides a cache for prepared statements.
+package stmtcache
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// stmtAdopter is implemented by *sql.Tx. We'll prepare the statements
+// against the pool and, if necessary, bind the statement to a specific
+// transaction for execution.
+type stmtAdopter interface {
+	StmtContext(context.Context, *sql.Stmt) *sql.Stmt
+}
+
+// Cache holds prepared statements which are retrieved by a comparable
+// key. Since prepared statements may have a non-trivial cost or be a
+// limited resource in the target database, so we want the Cache to have
+// a one-to-one lifetime with the underlying database pool.
+type Cache[T comparable] struct {
+	db *sql.DB
+
+	hits   prometheus.Counter
+	misses prometheus.Counter
+
+	mu struct {
+		sync.Mutex // Not RW since the LRU list moves elements.
+		cache      *lru.Cache
+	}
+}
+
+// New constructs a Cache for the pool.
+func New[T comparable](db *sql.DB, size int) *Cache[T] {
+	ret := &Cache[T]{
+		db:     db,
+		hits:   stmtCacheHits,
+		misses: stmtCacheMisses,
+	}
+	ret.mu.cache = lru.New(size)
+	ret.mu.cache.OnEvicted = func(_ lru.Key, value interface{}) {
+		_ = value.(*sql.Stmt).Close()
+	}
+
+	return ret
+}
+
+// Close is called to remove and close all existing statements.
+func (c *Cache[T]) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.mu.cache.Clear()
+}
+
+// Diagnostic implements [diag.Diagnostic]. It returns the capacity and
+// size of the cache.
+func (c *Cache[T]) Diagnostic(_ context.Context) any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return map[string]int{
+		"cap": c.mu.cache.MaxEntries,
+		"len": c.mu.cache.Len(),
+	}
+}
+
+// Prepare returns or constructs a new prepared statement. If db is a
+// [*sql.Tx], the statement will be attached to the transaction.
+func (c *Cache[T]) Prepare(
+	ctx context.Context, db any, key T, gen func() (string, error),
+) (*sql.Stmt, error) {
+	stmt, err := c.get(ctx, key, gen)
+	if err != nil {
+		return nil, err
+	}
+	if tx, ok := db.(stmtAdopter); ok {
+		stmt = tx.StmtContext(ctx, stmt)
+	}
+	return stmt, nil
+}
+
+func (c *Cache[T]) get(ctx context.Context, key T, gen func() (string, error)) (*sql.Stmt, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if found, ok := c.mu.cache.Get(key); ok {
+		return found.(*sql.Stmt), nil
+	}
+
+	q, err := gen()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt, err := c.db.PrepareContext(ctx, q)
+	if err != nil {
+		return nil, errors.Wrap(err, q)
+	}
+	c.mu.cache.Add(key, stmt)
+	return stmt, nil
+}


### PR DESCRIPTION
This change adds prepared statements to the apply package to support targets
that don't use the pgx library. pgx automatically retains prepared statements
without user intervention, so this was never necessary before.

This measurably improves throughput when using Oracle Database as a target and
would be useful for other targets in the future. This change also identified a
dependency issue in some of the test rigs, where the Appliers and Watchers were
attached to the bootstrap stack instead of the per-test stack. This led to
cross sql.DB use between prepared statements.

Since we have a cache around prepared statement, the apply template code no
longer has its own cache of SQL expressions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/494)
<!-- Reviewable:end -->
