### PR TITLE
cdc: Remove resolver.loop field

### DIFF
--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -121,17 +121,17 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 		if htc.immediate {
 			return nil
 		}
-		resolver, err := h.Resolvers.get(ctx, target.Schema())
+		loop, resolver, err := h.Resolvers.get(ctx, target.Schema())
 		if err != nil {
 			return err
 		}
 		waitFor := &resolvedStamp{CommittedTime: expect}
 		resolver.marked.Notify()
 		// Wait for the consistent point to advance.
-		for cp, updated := resolver.loop.GetConsistentPoint(); cp.Less(waitFor); {
+		for cp, updated := loop.GetConsistentPoint(); cp.Less(waitFor); {
 			select {
 			case <-updated:
-				cp, updated = resolver.loop.GetConsistentPoint()
+				cp, updated = loop.GetConsistentPoint()
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -272,16 +272,16 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 		if cfg.immediate {
 			return nil
 		}
-		resolver, err := h.Resolvers.get(ctx, target.Schema())
+		loop, resolver, err := h.Resolvers.get(ctx, target.Schema())
 		if err != nil {
 			return err
 		}
 		waitFor := &resolvedStamp{CommittedTime: expect}
 		resolver.marked.Notify()
-		for cp, updated := resolver.loop.GetConsistentPoint(); cp.Less(waitFor); {
+		for cp, updated := loop.GetConsistentPoint(); cp.Less(waitFor); {
 			select {
 			case <-updated:
-				cp, updated = resolver.loop.GetConsistentPoint()
+				cp, updated = loop.GetConsistentPoint()
 			case <-ctx.Done():
 				return ctx.Err()
 			}

--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -77,7 +77,7 @@ func ProvideResolvers(
 		stagers:   stagers,
 		watchers:  watchers,
 	}
-	ret.mu.instances = &ident.SchemaMap[*resolver]{}
+	ret.mu.instances = &ident.SchemaMap[*logical.Loop]{}
 
 	// Resume from previous state.
 	schemas, err := ScanForTargetSchemas(ctx, pool, ret.metaTable)
@@ -85,7 +85,7 @@ func ProvideResolvers(
 		return nil, nil, err
 	}
 	for _, schema := range schemas {
-		if _, err := ret.get(ctx, schema); err != nil {
+		if _, _, err := ret.get(ctx, schema); err != nil {
 			return nil, nil, errors.Wrapf(err, "could not bootstrap resolver for schema %s", schema)
 		}
 	}

--- a/internal/source/cdc/resolved.go
+++ b/internal/source/cdc/resolved.go
@@ -63,7 +63,7 @@ func parseResolvedTimestamp(timestamp string, logical string) (hlc.Time, error) 
 
 // resolved acts upon a resolved timestamp message.
 func (h *Handler) resolved(ctx context.Context, req *request) error {
-	resolver, err := h.Resolvers.get(ctx, req.target.Schema())
+	_, resolver, err := h.Resolvers.get(ctx, req.target.Schema())
 	if err != nil {
 		return err
 	}

--- a/internal/source/cdc/resolver_test.go
+++ b/internal/source/cdc/resolver_test.go
@@ -55,7 +55,7 @@ func TestResolverDeQueue(t *testing.T) {
 
 	// Disable call to loop.Start().
 	fixture.Resolvers.noStart = true
-	resolver, err := fixture.Resolvers.get(ctx, tbl.Name().Schema())
+	_, resolver, err := fixture.Resolvers.get(ctx, tbl.Name().Schema())
 	r.NoError(err)
 
 	for i := int64(0); i < rowCount; i++ {


### PR DESCRIPTION
The resolver.loop field is unnecessary. A reference to the logical.Loop is implicitly available via the Dialect API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/496)
<!-- Reviewable:end -->
