### PR TITLE
cdc: Add sanity-preserving error message if no tables

### DIFF
--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -359,6 +359,10 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 	start := time.Now()
 	targets := r.watcher.Get().Order
 
+	if len(targets) == 0 {
+		return errors.Errorf("no tables known in schema %s; have they been created?", r.target)
+	}
+
 	cursor := &types.SelectManyCursor{
 		Backfill:    rs.Backfill,
 		End:         rs.ProposedTime,


### PR DESCRIPTION
This adds a useful error message if the target schema exists, but has no tables in it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/501)
<!-- Reviewable:end -->
