### PR TITLE
stdpool: Use NewConnector API in go-ora 2.7.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/sijms/go-ora/v2 v2.7.17
+	github.com/sijms/go-ora/v2 v2.7.18
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1Io
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
 github.com/sijms/go-ora/v2 v2.7.17 h1:M/pYIqjaMUeBxyzOWp2oj4ntF6fHSBloJWGNH9vbmsU=
 github.com/sijms/go-ora/v2 v2.7.17/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/sijms/go-ora/v2 v2.7.18 h1:xl9CUeBlFi261AOKekiiFnfcp3ojHFEedLxIzsj909E=
+github.com/sijms/go-ora/v2 v2.7.18/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -40,15 +40,7 @@ func OpenOracleAsTarget(
 	}
 
 	return returnOrStop(ctx, func(ctx *stopper.Context) (*types.TargetPool, error) {
-		unconfigured, err := sql.Open("oracle", "")
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-
-		connector, err := unconfigured.Driver().(*ora.OracleDriver).OpenConnector(connectString)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
+		connector := ora.NewConnector(connectString)
 
 		if err := attachOptions(ctx, connector.(*ora.OracleConnector), options); err != nil {
 			return nil, err


### PR DESCRIPTION
The updated go-ora version provides an API to create a connector without making a throw-away call to sql.Open() and spying on the sql.Driver instance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/503)
<!-- Reviewable:end -->
