### PR TITLE
mysql target: getting schema information from database

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,7 @@ github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmoiron/sqlx v1.3.3 h1:j82X0bf7oQ27XeqxicSZsTU5suPwKElg3oyxNn43iTk=
 github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/joonix/log v0.0.0-20200409080653-9c1d2ceb5f1d h1:k+SfYbN66Ev/GDVq39wYOXVW5RNd5kzzairbCe9dK5Q=
 github.com/joonix/log v0.0.0-20200409080653-9c1d2ceb5f1d/go.mod h1:fS54ONkjDV71zS9CDx3V9K21gJg7byKSvI4ajuWFNJw=

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -222,6 +222,17 @@ func TestGetColumns(t *testing.T) {
 				"val", fixture.TargetSchema.Schema().String()+`."MyEnum"[]`,
 			),
 		},
+		// Check enums for mySQL.
+		{
+			products:    []types.Product{types.ProductMySQL},
+			tableSchema: `pk INT PRIMARY KEY, val ENUM('x-small', 'small', 'medium', 'large', 'x-large')`,
+			primaryKeys: []string{"pk"},
+			dataCols:    []string{"val"},
+			types: ident.MapOf[string](
+				"pk", "int",
+				"val", "enum",
+			),
+		},
 		// Check type extraction.
 		{
 			products:    []types.Product{types.ProductOracle},
@@ -238,6 +249,7 @@ func TestGetColumns(t *testing.T) {
 		},
 		// Check default value extraction
 		{
+			products:    []types.Product{types.ProductCockroachDB, types.ProductMySQL, types.ProductPostgreSQL, types.ProductOracle},
 			tableSchema: "a INT PRIMARY KEY, b VARCHAR(2048) DEFAULT 'Hello World!'",
 			primaryKeys: []string{"a"},
 			dataCols:    []string{"b"},
@@ -276,20 +288,25 @@ func TestGetColumns(t *testing.T) {
 		},
 	}
 
-	// Enum with a boring name.
-	if _, err := fixture.TargetPool.ExecContext(ctx, fmt.Sprintf(
-		`CREATE TYPE %s.boring_enum AS ENUM ('foo', 'bar')`,
-		fixture.TargetSchema.Schema()),
-	); !a.NoError(err) {
-		return
-	}
+	switch fixture.TargetPool.Product {
+	case types.ProductMySQL:
+		// MySQL does not support TYPES
+	default:
+		// Enum with a boring name.
+		if _, err := fixture.TargetPool.ExecContext(ctx, fmt.Sprintf(
+			`CREATE TYPE %s.boring_enum AS ENUM ('foo', 'bar')`,
+			fixture.TargetSchema.Schema()),
+		); !a.NoError(err) {
+			return
+		}
 
-	// Verify user-defined types with mixed-case name.
-	if _, err := fixture.TargetPool.ExecContext(ctx, fmt.Sprintf(
-		`CREATE TYPE %s."MyEnum" AS ENUM ('foo', 'bar')`,
-		fixture.TargetSchema.Schema()),
-	); !a.NoError(err) {
-		return
+		// Verify user-defined types with mixed-case name.
+		if _, err := fixture.TargetPool.ExecContext(ctx, fmt.Sprintf(
+			`CREATE TYPE %s."MyEnum" AS ENUM ('foo', 'bar')`,
+			fixture.TargetSchema.Schema()),
+		); !a.NoError(err) {
+			return
+		}
 	}
 
 	for i, test := range testcases {

--- a/internal/target/schemawatch/dependencies.go
+++ b/internal/target/schemawatch/dependencies.go
@@ -27,6 +27,85 @@ import (
 	"github.com/pkg/errors"
 )
 
+// depOrderTemplateMySQL computes the "referential depth" of tables based on
+// foreign-key constraints.
+//
+// The query is structured as follows:
+//   - tables: Tables in the schema.
+//   - refs: Maps referring tables (child) to referenced tables
+//     (parent). Table self-references are excluded from this query.
+//   - roots: Tables with no FK references.
+//   - depths: Recursively computes the depth of each table from the root, walking
+//     the foreign keys constraints.
+//   - cycle_detect: ensure that all tables have a depth, by injecting a default depth.
+//     Finally, compute the maximum depth for each table in the given schema.
+
+const depOrderTemplateMySQL = `
+WITH RECURSIVE
+  tables
+    AS (
+      SELECT
+        table_catalog, table_schema, table_name
+      FROM
+        information_schema.tables
+    ),
+  refs
+    AS (
+        SELECT
+            constraint_catalog AS child_catalog,
+            constraint_schema AS child_schema,
+            table_name AS child_table_name,
+            unique_constraint_catalog AS parent_catalog,
+            unique_constraint_schema AS parent_schema,
+            referenced_table_name AS parent_table_name
+            FROM information_schema.referential_constraints
+       WHERE
+        (constraint_catalog, constraint_schema, table_name)
+        != (unique_constraint_catalog, unique_constraint_schema,referenced_table_name)
+    ),
+  roots
+    AS (
+      SELECT
+        tables.table_catalog, tables.table_schema, tables.table_name
+      FROM
+        tables
+      WHERE
+        (tables.table_catalog, tables.table_schema, tables.table_name)
+        NOT IN (SELECT child_catalog, child_schema, child_table_name FROM refs)
+    ),
+  depths
+    AS (
+      SELECT table_catalog, table_schema, table_name, 0 AS depth FROM roots
+      UNION ALL
+        SELECT
+          refs.child_catalog,
+          refs.child_schema,
+          refs.child_table_name,
+          depths.depth + 1
+        FROM
+          depths, refs
+        WHERE
+          refs.parent_catalog = depths.table_catalog
+          AND refs.parent_schema = depths.table_schema
+          AND refs.parent_table_name = depths.table_name
+    ),
+  cycle_detect
+    AS (
+      SELECT table_catalog, table_schema, table_name, -1 AS depth FROM tables
+      UNION ALL
+        SELECT table_catalog, table_schema, table_name, depth FROM depths
+    )
+SELECT
+  table_name, max(depth) AS depth
+FROM
+  cycle_detect
+WHERE
+   table_schema = ?
+GROUP BY
+  table_name
+ORDER BY
+  depth, table_name`
+
 // depOrderTemplateOra computes the "referential depth" of tables based on
 // foreign-key constraints.
 //
@@ -251,9 +330,19 @@ func getDependencyOrder(
 			args = []any{parts[0].Raw(), parts[1].Raw()}
 		}
 
+	case types.ProductMySQL:
+		parts := db.Idents(make([]ident.Ident, 0, 1))
+		if len(parts) != 1 {
+			return nil, errors.Errorf("expecting one schema parts, had %d", len(parts))
+		}
+		stmt = depOrderTemplateMySQL
+		args = []any{parts[0].Raw()}
+
 	case types.ProductOracle:
 		stmt = depOrderTemplateOra
 		args = []any{sql.Named("owner", db.Raw())}
+	default:
+		return nil, errors.Errorf("getDependencyOrder unimplemented product: %s", tx.Product)
 	}
 
 	var cycles []ident.Table

--- a/internal/target/schemawatch/parse_helpers.go
+++ b/internal/target/schemawatch/parse_helpers.go
@@ -80,6 +80,8 @@ func parseHelper(product types.Product, typeName string) func(string) (any, bool
 	switch product {
 	case types.ProductCockroachDB, types.ProductPostgreSQL:
 		// Just pass through, since we have similar representations.
+	case types.ProductMySQL:
+		// TODO (silvano): add ad-hoc MySQL type representation, if needed.
 	case types.ProductOracle:
 		for _, helper := range oraParseHelpers {
 			if helper.pattern.MatchString(typeName) {

--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -220,6 +220,11 @@ SELECT table_catalog, table_schema, table_name
  WHERE table_catalog = $1
    AND table_schema ILIKE $2
    AND table_type = 'BASE TABLE'`
+	tableTemplateMySQL = `
+SELECT table_schema, NULL, table_name
+FROM information_schema.tables
+WHERE table_schema = ?
+AND table_type = 'BASE TABLE'`
 	tableTemplateOracle = `
 SELECT OWNER, NULL, TABLE_NAME FROM ALL_TABLES WHERE UPPER(OWNER) = UPPER(:owner)`
 )
@@ -251,6 +256,8 @@ func (w *watcher) getTables(ctx context.Context, tx *types.TargetPool) (*types.S
 
 			rows, err = tx.QueryContext(ctx, fmt.Sprintf(tableTemplateCrdb, dbName), dbName, parts[1].Raw())
 
+		case types.ProductMySQL:
+			rows, err = tx.QueryContext(ctx, tableTemplateMySQL, w.schema.Raw())
 		case types.ProductOracle:
 			rows, err = tx.QueryContext(ctx, tableTemplateOracle, w.schema.Raw())
 

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -95,7 +95,9 @@ func TestWatch(t *testing.T) {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			r.NoError(retry.Execute(ctx, fixture.TargetPool,
 				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v VARCHAR", tblInfo.Name())))
-
+		case types.ProductMySQL:
+			r.NoError(retry.Execute(ctx, fixture.TargetPool,
+				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v VARCHAR(10)", tblInfo.Name())))
 		case types.ProductOracle:
 			r.NoError(retry.Execute(ctx, fixture.TargetPool,
 				fmt.Sprintf("ALTER TABLE %s ADD (v INT)", tblInfo.Name())))

--- a/internal/types/product_string.go
+++ b/internal/types/product_string.go
@@ -10,13 +10,14 @@ func _() {
 	var x [1]struct{}
 	_ = x[ProductUnknown-0]
 	_ = x[ProductCockroachDB-1]
-	_ = x[ProductOracle-2]
-	_ = x[ProductPostgreSQL-3]
+	_ = x[ProductMySQL-2]
+	_ = x[ProductOracle-3]
+	_ = x[ProductPostgreSQL-4]
 }
 
-const _Product_name = "UnknownCockroachDBOraclePostgreSQL"
+const _Product_name = "UnknownCockroachDBMySQLOraclePostgreSQL"
 
-var _Product_index = [...]uint8{0, 7, 18, 24, 34}
+var _Product_index = [...]uint8{0, 7, 18, 23, 29, 39}
 
 func (i Product) String() string {
 	if i < 0 || i >= Product(len(_Product_index)-1) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -251,6 +251,7 @@ type Product int
 const (
 	ProductUnknown Product = iota
 	ProductCockroachDB
+	ProductMySQL
 	ProductOracle
 	ProductPostgreSQL
 )
@@ -279,7 +280,7 @@ func (p Product) ExpandSchema(s ident.Schema) (ident.Schema, error) {
 			return ident.Schema{}, errors.Errorf("unexpected number of schema parts: %d", numParts)
 		}
 
-	case ProductOracle:
+	case ProductMySQL, ProductOracle:
 		if numParts != 1 {
 			return ident.Schema{}, errors.Errorf("expecting exactly one schema part, had %d", numParts)
 		}

--- a/internal/util/stdpool/target.go
+++ b/internal/util/stdpool/target.go
@@ -18,6 +18,7 @@ package stdpool
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -36,6 +37,10 @@ func OpenTarget(
 	}
 
 	switch strings.ToLower(u.Scheme) {
+	case "mysql":
+		conn := fmt.Sprintf("%s@%s?%s", u.User.String(), u.Host,
+			strings.TrimPrefix(u.Path, "/"))
+		return OpenMySQLAsTarget(ctx, conn, options...)
 	case "pg", "pgx", "postgres", "postgresql":
 		return OpenPgxAsTarget(ctx, connectString, options...)
 	case "ora", "oracle":


### PR DESCRIPTION
This is the initial work to support mysql as a target, focusing on getting the schema information. 
Subsequent PRs will address the logic to apply mutations and  completing the backed connection support (with TLS, and better error handling).

Summary of changes:

- Added mysql connection pool. Not supporting TLS yet.
- Added templates for querying column information and constraint dependencies.
- Updated dependencies test to be compatible with mysql syntax.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/506)
<!-- Reviewable:end -->
