### PR TITLE
apply: Allow templates to be loaded from disk

### DIFF
--- a/internal/cmd/dumptemplates/dumptemplates.go
+++ b/internal/cmd/dumptemplates/dumptemplates.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dumptemplates contains a hidden command that will write
+// the apply templates to disk. It is for in-the-field debugging use
+// only and does not constitute a stable API.
+package dumptemplates
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/util/fscopy"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the dumptemplates command.
+func Command() *cobra.Command {
+	var path string
+	cmd := &cobra.Command{
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		Use:    "dumptemplates",
+		Short:  "write the query templates to disk (debugging use only)",
+		Long: fmt.Sprintf(`This command writes the apply templates to disk.
+
+When running cdc-sink, set the %[1]s environment variable to the directory
+that is passed to the --path flag. The indicated directory must contain
+a subdirectory named %[2]s.
+
+cdc-sink dumptemplates --path .
+%[1]s=. cdc-sink start ....
+`, apply.TemplateOverrideEnv, apply.QueryDir),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fscopy.Copy(apply.EmbeddedTemplates, path)
+		},
+	}
+	cmd.Flags().StringVar(&path, "path", ".",
+		"the directory to write the query templates to")
+	return cmd
+}

--- a/internal/util/fscopy/fscopy.go
+++ b/internal/util/fscopy/fscopy.go
@@ -1,0 +1,71 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fscopy contains a utility for copying the contents of an
+// [fs.FS] into the OS filesystem.
+package fscopy
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// Copy writes the contents of the given FS to files within the given
+// output path in the OS filesystem.
+func Copy(from fs.FS, toPath string) error {
+	absPath, err := filepath.Abs(toPath)
+	if err != nil {
+		return errors.Wrap(err, toPath)
+	}
+	return fs.WalkDir(from, ".",
+		func(path string, d fs.DirEntry, err error) error {
+			// The error argument is non-nil if WalkDir cannot traverse
+			// into the given directory. We'll return it to stop.
+			if err != nil {
+				return err
+			}
+			outPath := filepath.Join(absPath, path)
+			// Ensure that directories exist.
+			if d.IsDir() {
+				return errors.Wrap(os.MkdirAll(outPath, 0755), path)
+			}
+			// Ignore anything else that's not a regular file.
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			// Open the source file.
+			in, err := from.Open(path)
+			if err != nil {
+				return errors.Wrap(err, path)
+			}
+			// Overwrite the target file.
+			out, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+			if err != nil {
+				return errors.Wrap(err, outPath)
+			}
+
+			if _, err := io.Copy(out, in); err != nil {
+				_ = out.Close()
+				return errors.Wrapf(err, "%s -> %s", path, outPath)
+			}
+
+			return errors.Wrap(out.Close(), outPath)
+		})
+}

--- a/internal/util/fscopy/fscopy_test.go
+++ b/internal/util/fscopy/fscopy_test.go
@@ -1,0 +1,41 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fscopy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopy(t *testing.T) {
+	r := require.New(t)
+
+	root, err := os.MkdirTemp("", "TestCopy")
+	r.NoError(err)
+	defer func() {
+		r.NoError(os.RemoveAll(root))
+	}()
+
+	r.NoError(Copy(os.DirFS("./testdata/"), root))
+
+	buf, err := os.ReadFile(filepath.Join(root, "a/b/c/hello.txt"))
+	r.NoError(err)
+	r.Equal([]byte("Hello World!\n"), buf)
+}

--- a/internal/util/fscopy/testdata/a/b/c/hello.txt
+++ b/internal/util/fscopy/testdata/a/b/c/hello.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/cmd/dumphelp"
+	"github.com/cockroachdb/cdc-sink/internal/cmd/dumptemplates"
 	"github.com/cockroachdb/cdc-sink/internal/cmd/fslogical"
 	"github.com/cockroachdb/cdc-sink/internal/cmd/licenses"
 	"github.com/cockroachdb/cdc-sink/internal/cmd/mkjwt"
@@ -101,6 +102,7 @@ func main() {
 
 	root.AddCommand(
 		dumphelp.Command(),
+		dumptemplates.Command(),
 		fslogical.Command(),
 		licenses.Command(),
 		mkjwt.Command(),


### PR DESCRIPTION
This change adds an environment variable that allows the golang templates to be loaded from the filesystem, instead of using the ones embedded in the binary. A hidden `cdc-sink dumptemplates` command is added to copy the templates to disk.

The indended use-case for this change is to support in-the-field adjuments to the query templates, without the need to recompile the binary. No long-term compatibility guarantees can be made about the contents and structure of the template files, since they are tightly coupled with internal cdc-sink datastructures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/515)
<!-- Reviewable:end -->
