### PR TITLE
stage: Support storing a Mutation.Before field

### DIFF
--- a/internal/staging/stage/gzip.go
+++ b/internal/staging/stage/gzip.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stage
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// gzipMinSize disables compression for reasonable amounts of data. We
+// don't expect this to be called very often, but it should provide us
+// with some benefit for tables that have very wide rows or values.
+const gzipMinSize = 1024
+
+// maybeGZip compresses the given data if it is larger than gzipMinSize.
+func maybeGZip(data []byte) ([]byte, error) {
+	if len(data) <= gzipMinSize {
+		return data, nil
+	}
+
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	if _, err := gzWriter.Write(data); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if buf.Len() < len(data) {
+		return buf.Bytes(), nil
+	}
+	return data, nil
+}
+
+// maybeGunzip looks for GZip magic numbers and decompresses the data if
+// they're present. The magic numbers would not be present in JSON.
+func maybeGunzip(data []byte) ([]byte, error) {
+	if len(data) < 2 || data[0] != 0x1f || data[1] != 0x8b {
+		return data, nil
+	}
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return io.ReadAll(r)
+}

--- a/internal/staging/stage/gzip_test.go
+++ b/internal/staging/stage/gzip_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stage
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This isn't in stage_test, since that file is in the stage_testing
+// package and cannot access the private symbols.
+func TestGzipHelpers(t *testing.T) {
+	r := require.New(t)
+
+	tcs := []struct {
+		length int
+	}{
+		{0},
+		{1},
+		{gzipMinSize - 1},
+		{gzipMinSize},
+		{gzipMinSize + 1},
+		{2 * gzipMinSize},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", tc.length), func(t *testing.T) {
+			var buf bytes.Buffer
+			for i := 0; buf.Len() < tc.length; i = (i + 1) % 10 {
+				_, _ = fmt.Fprintf(&buf, "%d", i)
+			}
+			data := buf.Bytes()
+			zipped, err := maybeGZip(data)
+			r.NoError(err)
+			if tc.length <= gzipMinSize {
+				r.Equal(data, zipped)
+			}
+			t.Logf("%d -> %d", len(data), len(zipped))
+
+			unzipped, err := maybeGunzip(zipped)
+			r.NoError(err)
+			r.Equal(data, unzipped)
+		})
+	}
+}

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -75,6 +75,10 @@ func TestPutAndDrain(t *testing.T) {
 			Key:  []byte(fmt.Sprintf(`[%d]`, i)),
 			Time: hlc.New(int64(1000*i)+2, i),
 		}
+		// Don't assume that all mutations have a Before value.
+		if i%10 == 0 {
+			muts[i].Before = []byte("before")
+		}
 	}
 	maxTime := muts[len(muts)-1].Time
 
@@ -248,27 +252,31 @@ func TestSelectMany(t *testing.T) {
 		muts = append(muts,
 			// Batch at t=1
 			types.Mutation{
-				Data: []byte(fmt.Sprintf(`{"pk":%d}`, i)),
-				Key:  []byte(fmt.Sprintf(`[ %d ]`, i)),
-				Time: hlc.New(1, 0),
+				Before: []byte("null"),
+				Data:   []byte(fmt.Sprintf(`{"pk":%d}`, i)),
+				Key:    []byte(fmt.Sprintf(`[ %d ]`, i)),
+				Time:   hlc.New(1, 0),
 			},
 			// Individual with varying timestamps
 			types.Mutation{
-				Data: []byte(fmt.Sprintf(`{"pk":%d}`, i)),
-				Key:  []byte(fmt.Sprintf(`[ %d ]`, i)),
-				Time: hlc.New(int64(2*entries+i), 0),
+				Before: []byte(`{"pk":%d}`),
+				Data:   []byte(fmt.Sprintf(`{"pk":%d}`, i)),
+				Key:    []byte(fmt.Sprintf(`[ %d ]`, i)),
+				Time:   hlc.New(int64(2*entries+i), 0),
 			},
 			// Batch at t=10*entries
 			types.Mutation{
-				Data: []byte(fmt.Sprintf(`{"pk":%d}`, i)),
-				Key:  []byte(fmt.Sprintf(`[ %d ]`, i)),
-				Time: hlc.New(10*entries, 0),
+				Before: []byte(`{"pk":%d}`),
+				Data:   []byte(fmt.Sprintf(`{"pk":%d}`, i)),
+				Key:    []byte(fmt.Sprintf(`[ %d ]`, i)),
+				Time:   hlc.New(10*entries, 0),
 			},
 			// More individual entries with varying timestamps
 			types.Mutation{
-				Data: []byte(fmt.Sprintf(`{"pk":%d}`, i)),
-				Key:  []byte(fmt.Sprintf(`[ %d ]`, i)),
-				Time: hlc.New(int64(12*entries+i), 0),
+				Before: []byte(`{"pk":%d}`),
+				Data:   []byte(fmt.Sprintf(`{"pk":%d}`, i)),
+				Key:    []byte(fmt.Sprintf(`[ %d ]`, i)),
+				Time:   hlc.New(int64(12*entries+i), 0),
 			})
 	}
 	r.Len(muts, 4*entries)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -119,10 +119,11 @@ type Memo interface {
 // is, it is a collection of column values to apply to a row in some
 // table.
 type Mutation struct {
-	Data json.RawMessage // An encoded JSON object: { "key" : "hello" }
-	Key  json.RawMessage // An encoded JSON array: [ "hello" ]
-	Time hlc.Time        // The effective time of the mutation
-	Meta map[string]any  // Dialect-specific data, may be nil
+	Before json.RawMessage // Optional encoded JSON object
+	Data   json.RawMessage // An encoded JSON object: { "key" : "hello" }
+	Key    json.RawMessage // An encoded JSON array: [ "hello" ]
+	Meta   map[string]any  // Dialect-specific data, may be nil, not persisted
+	Time   hlc.Time        // The effective time of the mutation
 }
 
 var nullBytes = []byte("null")


### PR DESCRIPTION
This change is part of #487 to support three-way merges. It adds a before field to types.Mutation and allows this data to be persisted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/517)
<!-- Reviewable:end -->
