### PR TITLE
mysql: adding support for mysql types.

### DIFF
--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -170,7 +171,7 @@ func TestApply(t *testing.T) {
 			case types.ProductOracle:
 				a.ErrorContains(err, "ORA-01400: cannot insert NULL into")
 			default:
-				a.Fail("unimplemented")
+				a.Fail("unimplemented", err)
 			}
 		}
 	})
@@ -279,9 +280,243 @@ type dataTypeTestCase struct {
 	sqlValue   string // (Required) Expression that the source database can turn into JSON.
 	expectJSON string // (Optional) JSON expression to expect. Defaults to toJSON(sqlValue).
 	indexable  bool   // (Optional) Use the type as a primary key column.
+	readBackQ  string // (Optional) Ad-hoc query to get a string value from the target database.
 }
 
 var (
+	myDataTypeTests = []dataTypeTestCase{
+		// MySQL data types: https://dev.mysql.com/doc/refman/8.0/en/data-types.html
+		// 11.1.2 Integer Types (Exact Value) - INTEGER, INT, SMALLINT, TINYINT, MEDIUMINT, BIGINT
+		// 11.1.3 Fixed-Point Types (Exact Value) - DECIMAL, NUMERIC
+		// 11.1.4 Floating-Point Types (Approximate Value) - FLOAT, DOUBLE
+		// 11.1.5 Bit-Value Type - BIT
+		// 11.2.2 The DATE, DATETIME, and TIMESTAMP Types
+		// 11.2.3 The TIME Type
+		// 11.2.4 The YEAR Type
+		// 11.3.2 The CHAR and VARCHAR Types
+		// 11.3.3 The BINARY and VARBINARY Types
+		// 11.3.4 The BLOB and TEXT Types
+		// 11.3.5 The ENUM Type
+		// 11.3.6 The SET Type
+		// 11.4 Spatial Data Types
+		// 11.5 The JSON Data Type
+
+		{name: `bigint_null`, columnType: `BIGINT`},
+		{name: `bigint`, columnType: `BIGINT`, sqlValue: `9223372036854775807`},
+		{name: `binary_null`, sourceType: `bytes`, columnType: `BINARY(6)`},
+		{
+			name:       `binary`,
+			sourceType: `bytes`,
+			columnType: `BINARY(6)`,
+			sqlValue:   `a1b2c3`,
+			indexable:  true,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `bit_null`, columnType: `BIT(8)`},
+		{
+			name:       `bit`,
+			sourceType: `varbit`,
+			columnType: `BIT(8)`,
+			sqlValue:   `10010101`,
+			expectJSON: `"10010101"`,
+			readBackQ:  `SELECT bin(val) FROM %s`,
+		},
+		{name: `blob_null`, sourceType: `bytes`, columnType: `BLOB(100)`},
+		{
+			name:       `blob`,
+			sourceType: `bytes`,
+			columnType: `BLOB(100)`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `char_null`, columnType: `CHAR(255)`},
+		{name: `char`, columnType: `CHAR(255)`, sqlValue: `a1b2c3`, indexable: true},
+		{name: `date_null`, columnType: `DATE`},
+		{name: `date`, columnType: `DATE`, sqlValue: `2016-01-25`, indexable: true},
+		{name: `datetime_null`, sourceType: `timestamp`, columnType: `DATETIME`},
+		{
+			name:       `datetime`,
+			sourceType: `timestamp`,
+			columnType: `DATETIME`,
+			sqlValue:   `2016-01-25 01:01:00`,
+			expectJSON: `"2016-01-25 01:01:00.000000"`,
+			indexable:  true,
+		},
+		{name: `decimal_eng_6,0`, columnType: `DECIMAL(6,0)`, sqlValue: `4e+2`, indexable: true, expectJSON: "400"},
+		{name: `decimal_eng_6,2`, columnType: `DECIMAL(6,2)`, sqlValue: `4.98765e+2`, indexable: true, expectJSON: "498.77"},
+		{name: `decimal_null`, columnType: `DECIMAL`},
+		{name: `decimal`, columnType: `DECIMAL(10,4)`, sqlValue: `1.2345`, indexable: true},
+		{name: `double_null`, sourceType: `float`, columnType: `DOUBLE`},
+		{name: `double`, sourceType: `float`, columnType: `DOUBLE`, sqlValue: `1.2345`, indexable: true},
+		{name: `enum_null`, sourceType: `string`, columnType: `ENUM('a','b','c')`},
+		{name: `enum`, sourceType: `string`, columnType: `ENUM('a','b','c')`, sqlValue: `a`, indexable: true},
+		{name: `float_null`, columnType: `FLOAT`},
+		// This fails with lower precision:
+		// select json_array(cast(1.2345 as float)) => 1.2345000505447388
+		{name: `float`, sourceType: `float`, columnType: `FLOAT(25)`, sqlValue: `1.2345`},
+		{
+			name:       `geography`,
+			sourceType: `GEOGRAPHY`,
+			columnType: `GEOMETRY`,
+			sqlValue:   `0101000020E6100000000000000000F03F0000000000000040`,
+			expectJSON: `{"coordinates":[1.0,2.0],"type":"Point"}`,
+		},
+		{name: `geometry`, columnType: `GEOMETRY`, sqlValue: `010100000075029A081B9A5DC0F085C954C1F84040`},
+		{name: `int_null`, columnType: `INT`},
+		{name: `int`, columnType: `INT`, sqlValue: `2147483647`},
+		{name: `integer_null`, columnType: `INTEGER`},
+		{name: `integer`, columnType: `INTEGER`, sqlValue: `2147483647`},
+		{name: `jsonb_null`, sourceType: `jsonb`, columnType: `JSON`},
+		{
+			name:       `json`,
+			sourceType: `jsonb`,
+			columnType: `JSON`,
+			sqlValue: `
+			{
+				"string": "Lola",
+				"bool": true,
+				"number": 547,
+				"float": 123.456,
+				"array": [
+					"lola",
+					true,
+					547,
+					123.456,
+					[
+						"lola",
+						true,
+						547,
+						123.456
+					],
+					{
+						"string": "Lola",
+						"bool": true,
+						"number": 547,
+						"float": 123.456,
+						"array": [
+							"lola",
+							true,
+							547,
+							123.456,
+							[
+								"lola",
+								true,
+								547,
+								123.456
+							]
+						]
+					}
+				],
+				"map": {
+					"string": "Lola",
+					"bool": true,
+					"number": 547,
+					"float": 123.456,
+					"array": [
+						"lola",
+						true,
+						547,
+						123.456,
+						[
+							"lola",
+							true,
+							547,
+							123.456
+						],
+						{
+							"string": "Lola",
+							"bool": true,
+							"number": 547,
+							"float": 123.456,
+							"array": [
+								"lola",
+								true,
+								547,
+								123.456,
+								[
+									"lola",
+									true,
+									547,
+									123.456
+								]
+							]
+						}
+					]
+				}
+			}
+			`,
+		},
+		{name: `longblob_null`, sourceType: `bytes`, columnType: `LONGBLOB`},
+		{
+			name:       `longblob`,
+			sourceType: `bytes`,
+			columnType: `LONGBLOB`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `longtext_null`, sourceType: `string`, columnType: `LONGTEXT`},
+		{name: `longtext`, sourceType: `string`, columnType: `LONGTEXT`, sqlValue: `a1b2c3`},
+		{name: `mediumblob_null`, sourceType: `bytes`, columnType: `MEDIUMBLOB`},
+		{
+			name:       `mediumblob`,
+			sourceType: `bytes`,
+			columnType: `MEDIUMBLOB`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `mediumint_null`, sourceType: `int4`, columnType: `MEDIUMINT`},
+		{name: `mediumint`, sourceType: `int4`, columnType: `MEDIUMINT`, sqlValue: `8388607`},
+		{name: `mediumtext_null`, sourceType: `string`, columnType: `MEDIUMTEXT`},
+		{name: `mediumtext`, sourceType: `string`, columnType: `MEDIUMTEXT`, sqlValue: `a1b2c3`},
+		{name: `mumeric_null`, columnType: `DECIMAL`},
+		{name: `numeric`, columnType: `DECIMAL(10,4)`, sqlValue: `1.2345`, indexable: true},
+		{name: `smallint_null`, sourceType: `int2`, columnType: `SMALLINT`},
+		{name: `smallint`, sourceType: `int2`, columnType: `SMALLINT`, sqlValue: `32767`},
+		{name: `set_null`, sourceType: `string`, columnType: `SET('a','b','c')`},
+		{name: `set`, sourceType: `string`, columnType: `SET('a','b','c')`, sqlValue: `a,b`, indexable: true},
+		{name: `text_null`, sourceType: `string`, columnType: `TEXT(100)`},
+		{name: `text`, sourceType: `string`, columnType: `TEXT(100)`, sqlValue: `a1b2c3`},
+		{name: `time_null`, columnType: `TIME`},
+		{name: `time`, columnType: `TIME(6)`, sqlValue: `01:23:45.123456`, indexable: true},
+		{name: `timestamp_null`, columnType: `TIMESTAMP`},
+		{
+			name:       `timestamp`,
+			columnType: `TIMESTAMP`,
+			sqlValue:   `2016-01-25 10:10:10`,
+			expectJSON: `"2016-01-25 10:10:10.000000"`,
+			indexable:  true,
+		},
+		{name: `tinyblob_null`, sourceType: `bytes`, columnType: `TINYBLOB`},
+		{
+			name:       `tinyblob`,
+			sourceType: `bytes`,
+			columnType: `TINYBLOB`,
+			sqlValue:   `ab`,
+			expectJSON: `"ab"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `tinyint_null`, sourceType: `int2`, columnType: `TINYINT`},
+		{name: `tinyint`, sourceType: `int2`, columnType: `TINYINT`, sqlValue: `127`},
+		{name: `tinytext_null`, sourceType: `string`, columnType: `TINYTEXT`},
+		{name: `tinytext`, sourceType: `string`, columnType: `TINYTEXT`, sqlValue: `a1b2c3`},
+		{name: `varbinary_null`, sourceType: `bytes`, columnType: `VARBINARY(255)`},
+		{
+			name:       `varbinary`,
+			sourceType: `bytes`,
+			columnType: `VARBINARY(255)`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `varchar_null`, columnType: `VARCHAR(255)`},
+		{name: `varchar`, columnType: `VARCHAR(255)`, sqlValue: `a1b2c3`, indexable: true},
+		{name: `year_null`, sourceType: `string`, columnType: `YEAR`},
+		{name: `year`, sourceType: `string`, columnType: `YEAR`, sqlValue: `2016`, expectJSON: `2016`, indexable: true},
+	}
 	oraDataTypeTests = []dataTypeTestCase{
 		{
 			// Dates are returned with a midnight time.
@@ -487,6 +722,9 @@ func TestAllDataTypes(t *testing.T) {
 					sqlValue:   `2016-01-25 10:10:10-05:00`,
 					indexable:  true})
 			readBackQ = "SELECT COALESCE(to_json(val)::VARCHAR(2048), 'null') FROM %s"
+		case types.ProductMySQL:
+			testcases = myDataTypeTests
+			readBackQ = "SELECT COALESCE(json_extract(json_array(val),'$[0]'), 'null') FROM %s"
 		case types.ProductOracle:
 			testcases = oraDataTypeTests
 			// JSON_QUERY in older versions refuses to return raw scalars.
@@ -573,24 +811,30 @@ func TestAllDataTypes(t *testing.T) {
 			}
 			r.NoError(app.Apply(ctx, fixture.TargetPool, []types.Mutation{mut}))
 
-			var readBack string
-			r.NoError(fixture.TargetPool.QueryRowContext(ctx,
-				fmt.Sprintf(readBackQ, tbl),
-			).Scan(&readBack))
-
-			// See note in readBackQ
-			if expectArrayWrapper {
-				readBack = readBack[1 : len(readBack)-1]
-			}
 			expectJSON := jsonValue
 			if tc.expectJSON != "" {
 				expectJSON = tc.expectJSON
 			}
-
 			// Normalize the JSON representations before comparing them.
 			expectJSON, err = normalizeJSON(expectJSON)
 			r.NoError(err)
-
+			var readBack string
+			if tc.readBackQ != "" {
+				r.NoError(fixture.TargetPool.QueryRowContext(ctx,
+					fmt.Sprintf(tc.readBackQ, tbl),
+				).Scan(&readBack))
+				// since readBack is a string, need to quote before
+				// we normalize it to JSON.
+				readBack = strconv.Quote(readBack)
+			} else {
+				r.NoError(fixture.TargetPool.QueryRowContext(ctx,
+					fmt.Sprintf(readBackQ, tbl),
+				).Scan(&readBack))
+				// See note in readBackQ
+				if expectArrayWrapper {
+					readBack = readBack[1 : len(readBack)-1]
+				}
+			}
 			readBack, err = normalizeJSON(readBack)
 			r.NoError(err)
 			r.Equal(expectJSON, readBack)
@@ -640,6 +884,7 @@ func testConditions(t *testing.T, cas, deadline bool) {
 
 	tbl, err := fixture.CreateTargetTable(ctx,
 		"CREATE TABLE %s (pk INT PRIMARY KEY, ver INT, ts TIMESTAMP WITH TIME ZONE)")
+
 	if !a.NoError(err) {
 		return
 	}

--- a/internal/target/apply/queries/my/common.tmpl
+++ b/internal/target/apply/queries/my/common.tmpl
@@ -1,0 +1,47 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+
+{{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
+{{- define "names" -}}
+    {{- range $idx, $col := . }}
+        {{- if $idx -}},{{- end -}}
+        {{$col.Name}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "exprs" -}}
+    {{- range $groupIdx, $pairs := $.Vars -}}
+        {{- if $groupIdx -}},{{- nl -}}{{- end -}}
+        (
+        {{- range $pairIdx, $pair := $pairs -}}
+            {{- if $pairIdx -}},{{- end -}}
+             {{- if $pair.ValidityParam -}}
+                CASE WHEN ? THEN {{- sp -}}
+              {{- end -}}
+            {{- if eq $pair.Column.Type "geometry" -}}
+                st_geomfromgeojson(?)
+            {{- else -}}
+               ?
+            {{- end -}}
+            {{- if $pair.ValidityParam -}}
+                {{- sp -}} ELSE {{ $pair.Column.DefaultExpr }} END
+            {{- end -}}
+        {{- end -}}
+        )
+    {{- end -}}
+{{- end -}}
+
+{{- /* join creates a comma-separated list of its input: a, b, c, ... */ -}}
+{{- define "join" -}}
+    {{- range $idx, $val := . }}
+        {{- if $idx -}},{{- end -}}
+        {{- $val -}}
+    {{- end -}}
+{{- end -}}
+
+
+{{- define "valuelist" -}}
+    {{- range $idx, $val := . }}
+        {{- if $idx -}},{{- end -}}
+        {{- $val.Name -}}=VALUES({{- $val.Name -}})
+    {{- end -}}
+{{- end -}}

--- a/internal/target/apply/queries/my/conditional.tmpl
+++ b/internal/target/apply/queries/my/conditional.tmpl
@@ -1,0 +1,5 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*
+TODO (silvano)
+*/ -}}
+{{- $dataSource := "data" -}}

--- a/internal/target/apply/queries/my/delete.tmpl
+++ b/internal/target/apply/queries/my/delete.tmpl
@@ -1,0 +1,11 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*
+DELETE FROM "database"."schema"."table"
+WHERE ("pk0","pk1") IN ((?,?), (...), ...)
+*/ -}}
+DELETE FROM {{ .TableName.Raw }} WHERE (
+    {{- template "names" .PKDelete -}}
+)IN(
+    {{- template "exprs" . -}}
+)
+{{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/my/upsert.tmpl
+++ b/internal/target/apply/queries/my/upsert.tmpl
@@ -1,0 +1,22 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*
+
+INSERT INTO "schema"."table" 
+  ("pk0","pk1","val0","val1","geom") 
+  VALUES (cast (? as signed), cast( ? as char), cast(? as decimal), 
+          cast(? as signed), st_geomfromgeojson(?))
+  ON DUPLICATE KEY UPDATE val0=VALUES(val0),  val1=VALUES(val1),  geom=VALUES(geom);
+
+*/ -}}
+
+INSERT INTO {{ .TableName.Raw }} 
+{{- if not .Data -}} IGNORE {{- end -}}
+({{ template "names" .Columns }}) 
+VALUES
+{{ template "exprs" . }}
+{{- if .Data }}
+ON DUPLICATE KEY UPDATE 
+{{ template "valuelist" .Data }}
+{{- end -}}
+
+{{- /* Trim whitespace */ -}}

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -94,6 +94,7 @@ var (
 
 	tmplCRDB *template.Template
 	tmplOra  *template.Template
+	tmplMy   *template.Template
 	tmplPG   *template.Template
 )
 
@@ -141,6 +142,10 @@ func loadTemplates(from fs.FS, override string) error {
 	if err != nil {
 		return err
 	}
+	tmplMy, err = load("my")
+	if err != nil {
+		return err
+	}
 	tmplOra, err = load("ora")
 	if err != nil {
 		return err
@@ -179,6 +184,11 @@ func newTemplates(mapping *columnMapping) (*templates, error) {
 		ret.conditional = tmplCRDB.Lookup("conditional.tmpl")
 		ret.delete = tmplCRDB.Lookup("delete.tmpl")
 		ret.upsert = tmplCRDB.Lookup("upsert.tmpl")
+
+	case types.ProductMySQL:
+		ret.conditional = tmplMy.Lookup("conditional.tmpl")
+		ret.delete = tmplMy.Lookup("delete.tmpl")
+		ret.upsert = tmplMy.Lookup("upsert.tmpl")
 
 	case types.ProductOracle:
 		// Bulk execution of DELETE not supported. See:
@@ -257,6 +267,8 @@ func (t *templates) Vars() ([][]varPair, error) {
 				switch t.Product {
 				case types.ProductCockroachDB, types.ProductPostgreSQL:
 					reference = fmt.Sprintf("$%d", vp.Param)
+				case types.ProductMySQL:
+					reference = "?"
 				case types.ProductOracle:
 					reference = fmt.Sprintf(":ref%d", vp.Param)
 				default:

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -224,13 +224,45 @@ func TestGetColumns(t *testing.T) {
 		},
 		// Check enums for mySQL.
 		{
-			products:    []types.Product{types.ProductMySQL},
-			tableSchema: `pk INT PRIMARY KEY, val ENUM('x-small', 'small', 'medium', 'large', 'x-large')`,
+			products: []types.Product{types.ProductMySQL},
+			tableSchema: `pk INT PRIMARY KEY, a ENUM('x-small', 'small', 'medium', 'large', 'x-large'), 
+			              b SET('x-small', 'small', 'medium', 'large', 'x-large')`,
 			primaryKeys: []string{"pk"},
-			dataCols:    []string{"val"},
+			dataCols:    []string{"a", "b"},
 			types: ident.MapOf[string](
 				"pk", "int",
-				"val", "enum",
+				"a", "enum",
+				"b", "set",
+			),
+		},
+		// Check other mySQL types.
+		{
+			products: []types.Product{types.ProductMySQL},
+			tableSchema: `
+			pk INT PRIMARY KEY, 
+			a BIGINT,
+			b TIMESTAMP,
+			c DATETIME,
+			d NUMERIC,
+			e DECIMAL,
+			f DECIMAL(10,2),
+			g VARCHAR(10),
+			h FLOAT(8),
+		    i CHAR(1)
+			`,
+			primaryKeys: []string{"pk"},
+			dataCols:    []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"},
+			types: ident.MapOf[string](
+				"pk", "int",
+				"a", "bigint",
+				"b", "timestamp",
+				"c", "datetime",
+				"d", "decimal(10,0)",
+				"e", "decimal(10,0)",
+				"f", "decimal(10,2)",
+				"g", "varchar(10)",
+				"h", "float",
+				"i", "char(1)",
 			),
 		},
 		// Check type extraction.

--- a/internal/target/schemawatch/parse_helpers.go
+++ b/internal/target/schemawatch/parse_helpers.go
@@ -27,8 +27,10 @@ package schemawatch
 // correct treatment of timezones.
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
@@ -37,67 +39,86 @@ import (
 	ora "github.com/sijms/go-ora/v2"
 )
 
-// These are evaluated in order.
-var oraParseHelpers = []struct {
-	pattern *regexp.Regexp
-	parser  func(any) (any, error)
-}{
-	{
-		// This is a special-case for UUIDs in the source being stored
-		// as a 16-byte raw value in the destination.
-		pattern: regexp.MustCompile(`^RAW\(16\)$`),
-		parser: func(a any) (any, error) {
-			s, ok := a.(string)
-			if !ok {
-				return nil, errors.Errorf("expecting string, got %T", a)
-			}
-			u, err := uuid.Parse(s)
-			return u[:], err
+var (
+	// These are evaluated in order.
+	oraParseHelpers = []struct {
+		pattern *regexp.Regexp
+		parser  func(any) (any, error)
+	}{
+		{
+			// This is a special-case for UUIDs in the source being stored
+			// as a 16-byte raw value in the destination.
+			pattern: regexp.MustCompile(`^RAW\(16\)$`),
+			parser: func(a any) (any, error) {
+				s, ok := a.(string)
+				if !ok {
+					return nil, errors.Errorf("expecting string, got %T", a)
+				}
+				u, err := uuid.Parse(s)
+				return u[:], err
+			},
 		},
-	},
-	{
-		pattern: regexp.MustCompile(`^TIMESTAMP\(\d+\) WITH TIME ZONE$`),
-		parser: func(a any) (any, error) {
-			s, ok := a.(string)
-			if !ok {
-				return nil, errors.Errorf("expecting string, got %T", a)
-			}
-			t, err := time.ParseInLocation(time.RFC3339Nano, s, time.UTC)
-			return ora.TimeStampTZ(t), err
+		{
+			pattern: regexp.MustCompile(`^TIMESTAMP\(\d+\) WITH TIME ZONE$`),
+			parser: func(a any) (any, error) {
+				s, ok := a.(string)
+				if !ok {
+					return nil, errors.Errorf("expecting string, got %T", a)
+				}
+				t, err := time.ParseInLocation(time.RFC3339Nano, s, time.UTC)
+				return ora.TimeStampTZ(t), err
+			},
 		},
-	},
-	{
-		// Try parsing with and without a timezone specifier.
-		pattern: regexp.MustCompile(`^TIMESTAMP\(\d+\)$`),
-		parser: func(a any) (any, error) {
-			s, ok := a.(string)
-			if !ok {
-				return nil, errors.Errorf("expecting string, got %T", a)
-			}
-			if t, err := time.ParseInLocation(time.RFC3339Nano, s, time.UTC); err == nil {
-				return ora.TimeStamp(t), nil
-			}
-			t, err := time.ParseInLocation("2006-01-02T15:04:05", s, time.UTC)
-			return ora.TimeStamp(t), err
+		{
+			// Try parsing with and without a timezone specifier.
+			pattern: regexp.MustCompile(`^TIMESTAMP\(\d+\)$`),
+			parser: func(a any) (any, error) {
+				s, ok := a.(string)
+				if !ok {
+					return nil, errors.Errorf("expecting string, got %T", a)
+				}
+				if t, err := time.ParseInLocation(time.RFC3339Nano, s, time.UTC); err == nil {
+					return ora.TimeStamp(t), nil
+				}
+				t, err := time.ParseInLocation("2006-01-02T15:04:05", s, time.UTC)
+				return ora.TimeStamp(t), err
+			},
 		},
-	},
-	{
-		pattern: regexp.MustCompile(`^DATE$`),
-		parser: func(a any) (any, error) {
-			s, ok := a.(string)
-			if !ok {
-				return nil, errors.Errorf("expecting string, got %T", a)
-			}
-			t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
-			return ora.TimeStamp(t), err
+		{
+			pattern: regexp.MustCompile(`^DATE$`),
+			parser: func(a any) (any, error) {
+				s, ok := a.(string)
+				if !ok {
+					return nil, errors.Errorf("expecting string, got %T", a)
+				}
+				t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
+				return ora.TimeStamp(t), err
+			},
 		},
-	},
+	}
+)
+
+// coerce a bit-string into a integer
+func coerceInt(a any) (any, error) {
+	s, ok := a.(string)
+	if !ok {
+		return nil, errors.Errorf("expecting a string, got %T", a)
+	}
+	return strconv.ParseInt(s, 2, 64)
 }
-var myParseHelpers = map[string]func(any) (any, error){
-	// mysql expects a serialized json
-	"json": func(a any) (any, error) {
-		return json.Marshal(a)
-	},
+
+// coerce a hex-string to its binary representation, after stripping the "\x" prefix
+func coerceHexString(a any) (any, error) {
+	s, ok := a.(string)
+	if !ok || len(s) < 2 {
+		return nil, errors.Errorf("expecting a hex encoded string, got %T", a)
+	}
+	return hex.DecodeString(s[2:])
+}
+
+// coerce to json
+func coerceJSON(a any) (any, error) {
+	return json.Marshal(a)
 }
 
 func parseHelper(product types.Product, typeName string) func(any) (any, error) {
@@ -105,8 +126,16 @@ func parseHelper(product types.Product, typeName string) func(any) (any, error) 
 	case types.ProductCockroachDB, types.ProductPostgreSQL:
 		// Just pass through, since we have similar representations.
 	case types.ProductMySQL:
-		if parser, ok := myParseHelpers[typeName]; ok {
-			return parser
+		// Coerce types to the what the mysql driver expects.
+		switch typeName {
+		case "binary", "blob", "longblob", "mediumblob", "tinyblob", "varbinary":
+			return coerceHexString
+		case "bit":
+			return coerceInt
+		case "json", "geometry", "geography":
+			return coerceJSON
+		default:
+			return nil
 		}
 	case types.ProductOracle:
 		for _, helper := range oraParseHelpers {


### PR DESCRIPTION
Initial checkin to support apply to a mysql target. Verifying that mutations can be applied using the types supported by MySQL database and the mySQL driver. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/521)
<!-- Reviewable:end -->
