### PR TITLE
apply: make the parser helper more generic.

### DIFF
--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -353,11 +353,13 @@ func (a *apply) upsertLocked(
 			// exceeds the precision or scale for the target column.
 			if num, ok := value.(json.Number); ok {
 				value = removeExponent(num).String()
-			} else if str, ok := value.(string); ok && targetColumn.Parse != nil {
-				value, ok = targetColumn.Parse(str)
-				if !ok {
-					return errors.Errorf("could not parse %q as a %s", str, targetColumn.Type)
+			} else if value != nil && targetColumn.Parse != nil {
+				v, err := targetColumn.Parse(value)
+				if err != nil {
+					return errors.Wrapf(err, "could not parse %v as a %s",
+						value, targetColumn.Type)
 				}
+				value = v
 			}
 
 			// This loop is driven by the fields in the incoming

--- a/internal/target/schemawatch/parse_helpers_test.go
+++ b/internal/target/schemawatch/parse_helpers_test.go
@@ -32,7 +32,7 @@ func TestOraParseHelpers(t *testing.T) {
 
 	tcs := []struct {
 		typ      string
-		input    string
+		input    any
 		expected any
 	}{
 		{
@@ -65,11 +65,42 @@ func TestOraParseHelpers(t *testing.T) {
 	for idx, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
 			r := require.New(t)
-
 			helper := parseHelper(types.ProductOracle, tc.typ)
 			r.NotNil(helper)
-			ret, ok := helper(tc.input)
-			r.True(ok)
+			ret, err := helper(tc.input)
+			r.NoError(err)
+			r.Equal(tc.expected, ret)
+		})
+	}
+}
+
+func TestMyParseHelpers(t *testing.T) {
+	tcs := []struct {
+		typ      string
+		input    any
+		expected []byte
+	}{
+		{
+			typ: "json",
+			input: map[string]any{
+				"k": "a",
+				"v": 1,
+			},
+			expected: []byte(`{"k":"a","v":1}`),
+		},
+		{
+			typ:      "json",
+			input:    []int{1, 2, 3},
+			expected: []byte(`[1,2,3]`),
+		},
+	}
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			r := require.New(t)
+			helper := parseHelper(types.ProductMySQL, tc.typ)
+			r.NotNil(helper)
+			ret, err := helper(tc.input)
+			r.NoError(err)
 			r.Equal(tc.expected, ret)
 		})
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -200,10 +200,10 @@ type ColData struct {
 	DefaultExpr string
 	Ignored     bool
 	Name        ident.Ident
-	// A Parse function may be supplied to allow a string representation
-	// of a complex datatype to be converted into a type more readily
+	// A Parse function may be supplied to allow a datatype
+	// to be converted into a type more readily
 	// used by a target database driver.
-	Parse   func(string) (any, bool) `json:"-"`
+	Parse   func(any) (any, error) `json:"-"`
 	Primary bool
 	// Type of the column.
 	Type string


### PR DESCRIPTION
Changing the ColData.Parse to accept any type, rather than strings.

The MySQL driver wants serializable json, this change allows the apply logic to call a custom parser that serializes the internal json object before it is sent to the driver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/522)
<!-- Reviewable:end -->
