### PR TITLE
sinktest: Generate names that must be quoted

### DIFF
--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -362,7 +362,9 @@ func CreateSchema[P types.AnyPool](
 	// Each package tests run in a separate binary, so we need a
 	// "globally" unique ID.  While PIDs do recycle, they're highly
 	// unlikely to do so during a single run of the test suite.
-	name := ident.New(fmt.Sprintf("%s_%d_%d", prefix, os.Getpid(), dbNum))
+	// We use dashes in the name to ensure that the identifier is always
+	// correctly quoted when sent in SQL commands.
+	name := ident.New(fmt.Sprintf("%s-%d-%d", prefix, os.Getpid(), dbNum))
 
 	cancel := func() {
 		err := retry.Execute(ctx, pool, fmt.Sprintf("DROP DATABASE IF EXISTS %s CASCADE", name))
@@ -415,7 +417,9 @@ func CreateTable[P types.AnyPool](
 	ctx context.Context, pool P, enclosing ident.Schema, schemaSpec string,
 ) (TableInfo[P], error) {
 	tableNum := tempTable.Add(1)
-	tableName := ident.New(fmt.Sprintf("tbl_%d", tableNum))
+	// We use a dash here to ensure that the table name must be
+	// correctly quoted when sent as a SQL command.
+	tableName := ident.New(fmt.Sprintf("tbl-%d", tableNum))
 	table := ident.NewTable(enclosing, tableName)
 	err := retry.Execute(ctx, pool, fmt.Sprintf(schemaSpec, table))
 	return TableInfo[P]{pool, table}, errors.WithStack(err)

--- a/internal/source/cdc/request.go
+++ b/internal/source/cdc/request.go
@@ -37,9 +37,14 @@ const maxPathSegments = 8
 
 // See https://www.cockroachlabs.com/docs/stable/create-changefeed.html#general-file-format
 // Example: /2020-04-02/202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-test_table-1.ndjson
-// Filename format is: [endpoint]/[date]/[timestamp]-[uniquer]-[topic]-[schema-id]
+// Filename format is: [endpoint]/[date]/[timestamp + uniquer]-[topic]-[schema-id]
+//
+// When we look at the filename, there are five hyphen-delimited groups
+// in the timestamp+uniquer segment of the filename. The topic (name of
+// the table) may itself contain dashes, so it has an open match to
+// consume anything that isn't the final, CRDB-internal schema id.
 var (
-	ndjsonRegex = regexp.MustCompile(`^(?P<date>\d{4}-\d{2}-\d{2})/(?P<uniquer>.+)-(?P<topic>[^-]+)-(?P<schema_id>[^-]+).ndjson$`)
+	ndjsonRegex = regexp.MustCompile(`^(?P<date>\d{4}-\d{2}-\d{2})/(?P<prelude>([^-]+-){5})(?P<topic>.+)-(?P<schema_id>[^-]+).ndjson$`)
 	ndjsonTopic = ndjsonRegex.SubexpIndex("topic")
 )
 

--- a/internal/source/cdc/url_test.go
+++ b/internal/source/cdc/url_test.go
@@ -38,9 +38,9 @@ func TestParseChangefeedURL(t *testing.T) {
 	schemaName := nameParts[1].Raw()
 	tableName := nameParts[2].Raw()
 	ndjsonDate := `2020-04-02`
-	ndjsonTimestampWithExtras := `202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-REAL-1.ndjson`
+	ndjsonTimestampWithExtras := `202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-REAL-42-1.ndjson`
 	ndjson := strings.Join([]string{ndjsonDate, ndjsonTimestampWithExtras}, "/")
-	ndjsonFull := `2020-04-02/202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-ignored_db.ignored_schema.REAL-1.ndjson`
+	ndjsonFull := `2020-04-02/202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-ignored_db.ignored_schema.REAL-42-1.ndjson`
 	resolvedDate := `2020-04-04`
 	resolvedTimestamp := `202004042351304139680000000000000.RESOLVED`
 	resolved := strings.Join([]string{resolvedDate, resolvedTimestamp}, "/")
@@ -126,13 +126,13 @@ func TestParseChangefeedURL(t *testing.T) {
 		{
 			name:     "ndjson to schema",
 			decision: "ndjson schema",
-			target:   ident.NewTable(schemaIdent, ident.New("REAL")), // Use topic name from query.
+			target:   ident.NewTable(schemaIdent, ident.New("REAL-42")), // Use topic name from query.
 			url:      strings.Join([]string{"", dbName, schemaName, ndjson}, "/"),
 		},
 		{
 			name:     "ndjson full to schema",
 			decision: "ndjson schema",
-			target:   ident.NewTable(schemaIdent, ident.New("REAL")), // Use topic name from query.
+			target:   ident.NewTable(schemaIdent, ident.New("REAL-42")), // Use topic name from query.
 			url:      strings.Join([]string{"", dbName, schemaName, ndjsonFull}, "/"),
 		},
 		{

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -551,7 +551,10 @@ func setupMYPool(config *Config) (*client.Pool, func(), error) {
 	}
 	defer baseConn.Close()
 
-	if _, err := baseConn.Execute(fmt.Sprintf("CREATE DATABASE %s", database.Raw())); err != nil {
+	// Once we create the database using the default pool, we'll
+	// reconnect, so the database name just becomes an ambient attribute
+	// of the underlying connection.
+	if _, err := baseConn.Execute(fmt.Sprintf("CREATE DATABASE `%s`", database.Raw())); err != nil {
 		return nil, func() {}, err
 	}
 


### PR DESCRIPTION
This change updates the CreateTable and CreateSchema functions to generate
names that contain dashes. This helps to ensure that all identifiers are
correctly quoted when we generate SQL commands.

This change additionally corrects some test failures around parsing ndjson URLs
that contain dashes. There is also a correction made to a schema introspection
query that was not correctly using a quoted ident type. There are a few
naming-related changes in the pglogical and mylogical packages, which are
explained by surrounding comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/538)
<!-- Reviewable:end -->
