### PR TITLE
dlq: Add dead-letter queue package

### DIFF
--- a/internal/sinktest/all/provider.go
+++ b/internal/sinktest/all/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
+	"github.com/cockroachdb/cdc-sink/internal/target/dlq"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/google/wire"
 )
@@ -34,10 +35,17 @@ var TestSet = wire.NewSet(
 	staging.Set,
 	target.Set,
 
+	ProvideDLQConfig,
 	ProvideWatcher,
 
 	wire.Struct(new(Fixture), "*"),
 )
+
+// ProvideDLQConfig emits a default configuration.
+func ProvideDLQConfig() (*dlq.Config, error) {
+	cfg := &dlq.Config{}
+	return cfg, cfg.Preflight()
+}
 
 // ProvideWatcher is called by Wire to construct a Watcher
 // bound to the testing database.

--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/stage"
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/dlq"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -130,6 +131,22 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
+	config, err := ProvideDLQConfig()
+	if err != nil {
+		cleanup11()
+		cleanup10()
+		cleanup9()
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	dlQs := dlq.ProvideDLQs(config, targetPool, watchers)
 	memoMemo, err := memo.ProvideMemo(context, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup11()
@@ -167,6 +184,8 @@ func NewFixture() (*Fixture, func(), error) {
 		Appliers:       appliers,
 		Configs:        configs,
 		Diagnostics:    diagnostics,
+		DLQConfig:      config,
+		DLQs:           dlQs,
 		Memo:           memoMemo,
 		Stagers:        stagers,
 		VersionChecker: checker,

--- a/internal/target/dlq/config.go
+++ b/internal/target/dlq/config.go
@@ -1,0 +1,43 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dlq
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/spf13/pflag"
+)
+
+const defaultTableName = "cdc_sink_dlq"
+
+// Config controls the DLQ behavior.
+type Config struct {
+	TableName ident.Ident // Default name within the target schema.
+}
+
+// Bind adds configuration flags to the set.
+func (c *Config) Bind(f *pflag.FlagSet) {
+	f.Var(ident.NewValue(defaultTableName, &c.TableName), "dlqTableName",
+		"the name of a table in the target schema for storing dead-letter entries")
+}
+
+// Preflight validates the configuration.
+func (c *Config) Preflight() error {
+	if c.TableName.Empty() {
+		c.TableName = ident.New(defaultTableName)
+	}
+	return nil
+}

--- a/internal/target/dlq/dlq.go
+++ b/internal/target/dlq/dlq.go
@@ -1,0 +1,155 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dlq writes unhandled mutations to dead-letter queues in the
+// target database.
+package dlq
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+const dlqTableMissing = `the dead-letter queue table %[1]s must be created in the target database.
+Consider using the following schema:
+
+`
+
+type dlq struct {
+	name string
+	stmt *sql.Stmt
+}
+
+var _ types.DLQ = (*dlq)(nil)
+
+// Enqueue implements [types.DLQ].
+func (d *dlq) Enqueue(ctx context.Context, tx types.TargetQuerier, mut types.Mutation) error {
+	stmt := d.stmt
+	// Bind the prepared statement to the current transaction.
+	if sqlTx, ok := tx.(*sql.Tx); ok {
+		stmt = sqlTx.Stmt(stmt)
+	}
+	// We're using JSON-type columns. To avoid ambiguity, we prefer
+	// them to be NOT NULL and contain a literal null token if there's
+	// no data there.
+	after := string(mut.Data)
+	if len(after) == 0 {
+		after = "null"
+	}
+	before := string(mut.Before)
+	if len(before) == 0 {
+		before = "null"
+	}
+	_, err := stmt.ExecContext(ctx, d.name, mut.Time.Nanos(), mut.Time.Logical(), after, before)
+	return errors.WithStack(err)
+}
+
+type dlqs struct {
+	cfg        *Config
+	targetPool *types.TargetPool
+	watchers   types.Watchers
+
+	mu struct {
+		sync.RWMutex
+		validated ident.TableMap[*dlq]
+	}
+}
+
+var _ types.DLQs = (*dlqs)(nil)
+
+// Get implements [types.DLQs]. It will perform a one-time validation
+// that the DLQ table has been defined in the target schema.
+func (d *dlqs) Get(ctx context.Context, target ident.Schema, name string) (types.DLQ, error) {
+	tbl := ident.NewTable(target, d.cfg.TableName)
+
+	d.mu.RLock()
+	found, ok := d.mu.validated.Get(tbl)
+	d.mu.RUnlock()
+	if ok {
+		return found, nil
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Double-check idiom.
+	if found, ok := d.mu.validated.Get(tbl); ok {
+		return found, nil
+	}
+
+	watcher, err := d.watchers.Get(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	cols, ok := watcher.Get().Columns.Get(tbl)
+	if !ok {
+		msg := dlqTableMissing + BasicSchemas[d.targetPool.Product]
+		return nil, errors.Errorf(msg, tbl)
+	}
+
+	knownCols := ident.Map[struct{}]{}
+	for _, col := range cols {
+		knownCols.Put(col.Name, struct{}{})
+	}
+
+	var missing strings.Builder
+	for _, name := range expectedColumns {
+		if _, found := knownCols.Get(name); !found {
+			if missing.Len() > 0 {
+				missing.WriteString(", ")
+			}
+			missing.WriteString(name.Raw())
+		}
+	}
+	if missing.Len() > 0 {
+		return nil, errors.Errorf("dlq table %s was found, but it is missing the following columns: %s",
+			tbl, missing.String())
+	}
+
+	// The query differs only in the argument syntax.
+	var q string
+	switch d.targetPool.Product {
+	case types.ProductCockroachDB, types.ProductPostgreSQL:
+		q = qBase + argsPG
+	case types.ProductOracle:
+		q = qBase + argsOra
+	case types.ProductMySQL:
+		q = qBase + argsMySQL
+	default:
+		return nil, errors.Errorf("dlq unimplemented for product %s", d.targetPool.Product)
+	}
+
+	// Attach a prepared statement to the pool. It will be bound to a
+	// future transaction as necessary.
+	stmt, err := d.targetPool.PrepareContext(ctx, fmt.Sprintf(q, tbl))
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not prepare DLQ statement: %s", q)
+	}
+
+	ret := &dlq{
+		name: name,
+		stmt: stmt,
+	}
+	d.mu.validated.Put(tbl, ret)
+	return ret, nil
+}

--- a/internal/target/dlq/dlq_schema.go
+++ b/internal/target/dlq/dlq_schema.go
@@ -1,0 +1,90 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dlq
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// cdc-sink doesn't create the DLQ table. Instead, we just validate that
+// it contains a minimum set of expected columns. As a rule, cdc-sink
+// does not create or modify schema elements in the target database.
+// Futhermore, the DLQ-processing workflow can be arbitrarily complex
+// and we can't predict how the user intends to operate on this data.
+var expectedColumns = []ident.Ident{
+	ident.New("dlq_name"),
+	ident.New("source_nanos"),
+	ident.New("source_logical"),
+	ident.New("data_after"),
+	ident.New("data_before"),
+}
+
+const (
+	qBase     = `INSERT INTO %s (dlq_name, source_nanos, source_logical, data_after, data_before) VALUES `
+	argsPG    = `($1, $2, $3, $4, $5)`
+	argsMySQL = `(?, ?, ?, ?, ?)`
+	argsOra   = `(:1, :2, :3, :4, :5)`
+)
+
+// These constants define a plausible reference schema that can be used
+// to create a DLQ table. These strings are exported, since the tests
+// are declared in the dlq_test package.
+const (
+	basicCRDBSchema = `CREATE TABLE %[1]s (
+event UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+dlq_name TEXT NOT NULL,
+source_nanos INT8 NOT NULL,
+source_logical INT8 NOT NULL,
+data_after JSONB NOT NULL,
+data_before JSONB NOT NULL
+)`
+	basicMySQLSchema = `CREATE TABLE %[1]s (
+event binary(16) DEFAULT (uuid()) PRIMARY KEY,
+dlq_name TEXT NOT NULL,
+source_nanos INT8 NOT NULL,
+source_logical INT8 NOT NULL,
+data_after JSON NOT NULL,
+data_before JSON NOT NULL
+)`
+	basicOraSchema = `CREATE TABLE %[1]s (
+event INTEGER GENERATED ALWAYS AS IDENTITY,
+dlq_name VARCHAR(256) NOT NULL,
+source_nanos INTEGER NOT NULL,
+source_logical INTEGER NOT NULL,
+data_after CLOB NOT NULL,
+data_before CLOB NOT NULL
+)`
+	basicPGSchema = `CREATE TABLE %[1]s (
+event SERIAL PRIMARY KEY,
+dlq_name TEXT NOT NULL,
+source_nanos INT8 NOT NULL,
+source_logical INT8 NOT NULL,
+data_after JSONB NOT NULL,
+data_before JSONB NOT NULL
+)`
+)
+
+// BasicSchemas is a collection of suggested schemas for the DLQ table.
+// It is exported so that tests which require the DLQ can use the
+// suggested schemas. See [all.Fixture.CreateDLQTable].
+var BasicSchemas = map[types.Product]string{
+	types.ProductCockroachDB: basicCRDBSchema,
+	types.ProductPostgreSQL:  basicPGSchema,
+	types.ProductMySQL:       basicMySQLSchema,
+	types.ProductOracle:      basicOraSchema,
+}

--- a/internal/target/dlq/dlq_test.go
+++ b/internal/target/dlq/dlq_test.go
@@ -1,0 +1,110 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dlq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDLQ verifies that the suggested DLQ schema can be created and
+// inserts a few rows to smoke-check the query.
+func TestDLQ(t *testing.T) {
+	r := require.New(t)
+
+	fixture, cancel, err := all.NewFixture()
+	r.NoError(err)
+	defer cancel()
+
+	ctx := fixture.Context
+
+	// We need to create the DLQ table. This is something that could be
+	// done automatically, but see the discussion in dlq_schema.go.
+	dlTable, err := fixture.CreateDLQTable(ctx)
+	r.NoError(err)
+
+	out, err := fixture.DLQs.Get(ctx, fixture.TargetSchema.Schema(), "my_dlq")
+	r.NoError(err)
+
+	muts := []types.Mutation{
+		{
+			Before: []byte(`{"pk":0, "before":true}`),
+			Data:   []byte(`{"pk":0, "after":true}`),
+			Key:    []byte("[ 0 ]"),
+			Time:   hlc.New(123, 456),
+		},
+		{
+			Data: []byte(`{"pk":0, "after":true}`),
+			Key:  []byte("[ 1 ]"),
+			Time: hlc.New(123, 456),
+		},
+	}
+
+	for _, mut := range muts {
+		r.NoError(out.Enqueue(ctx, fixture.TargetPool.DB, mut))
+	}
+
+	var ct int
+	r.NoError(fixture.TargetPool.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %s", dlTable)).Scan(&ct))
+	r.Equal(len(muts), ct)
+}
+
+// TestMissingColumns verifies the error-reporting behavior if the DLQ
+// table exists, but does not contain the required columns.
+func TestMissingColumns(t *testing.T) {
+	r := require.New(t)
+
+	fixture, cancel, err := all.NewFixture()
+	r.NoError(err)
+	defer cancel()
+
+	ctx := fixture.Context
+
+	// We need to create the DLQ table. This is something that could be
+	// done automatically, but see the discussion in dlq_schema.go.
+	_, err = fixture.TargetPool.ExecContext(ctx,
+		fmt.Sprintf("CREATE TABLE %s (pk INT PRIMARY KEY)",
+			ident.NewTable(fixture.TargetSchema.Schema(), fixture.DLQConfig.TableName)))
+	r.NoError(err)
+	r.NoError(fixture.Watcher.Refresh(ctx, fixture.TargetPool))
+
+	_, err = fixture.DLQs.Get(ctx, fixture.TargetSchema.Schema(), "foo")
+
+	r.ErrorContains(err, "missing the following columns: "+
+		"dlq_name, source_nanos, source_logical, data_after, data_before")
+}
+
+// TestMissingTable verifies the error-reporting behavior if the DLQ
+// table does not exist at all.
+func TestMissingTable(t *testing.T) {
+	r := require.New(t)
+
+	fixture, cancel, err := all.NewFixture()
+	r.NoError(err)
+	defer cancel()
+
+	ctx := fixture.Context
+	_, err = fixture.DLQs.Get(ctx, fixture.TargetSchema.Schema(), "foo")
+
+	r.ErrorContains(err, "must be created")
+}

--- a/internal/target/dlq/provider.go
+++ b/internal/target/dlq/provider.go
@@ -14,21 +14,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package target contains various services for performing operations on
-// the target database cluster.
-package target
+package dlq
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/target/apply"
-	"github.com/cockroachdb/cdc-sink/internal/target/dlq"
-	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/google/wire"
 )
 
-// Set is used by Wire and contains providers for all target
-// sub-packages.
-var Set = wire.NewSet(
-	apply.Set,
-	dlq.Set,
-	schemawatch.Set,
-)
+// Set is used by Wire.
+var Set = wire.NewSet(ProvideDLQs)
+
+// ProvideDLQs is called by Wire to construct the DLQs instance.
+func ProvideDLQs(cfg *Config, pool *types.TargetPool, watchers types.Watchers) types.DLQs {
+	return &dlqs{
+		cfg:        cfg,
+		targetPool: pool,
+		watchers:   watchers,
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -58,6 +58,17 @@ type Authenticator interface {
 // Deadlines associate a column identifier with a duration.
 type Deadlines = *ident.Map[time.Duration]
 
+// A DLQ is a dead-letter queue that allows mutations to be written
+// to the target for offline reconciliation.
+type DLQ interface {
+	Enqueue(ctx context.Context, tx TargetQuerier, mut Mutation) error
+}
+
+// DLQs provides named dead-letter queues in the target schema.
+type DLQs interface {
+	Get(ctx context.Context, target ident.Schema, name string) (DLQ, error)
+}
+
 var (
 	// ErrCancelSingleton may be returned by callbacks passed to
 	// leases.Singleton to shut down cleanly.


### PR DESCRIPTION
Review notes: This is being sent in parallel to #540, which will only need a minor PR to call this API when they're both added. If we decide that cdc-sink should create schemas in the target data (why not is outlined below), we already have known-usable schemas in this PR for testing.

This change is part of #487 to support three-way merges.

This change adds, but does not integrate, support for a per-target-schema DLQ. cdc-sink, as a design rule, does not perform any schema changes in the target database. If the user wants to use the DLQ, they will need to create the destination table. The only requirements on the DLQ table are that it contain certain well-known column names with appropriate types. A basic schema is suggested by cdc-sink, and this suggested schema is used by the DLQ tests.

The justification for this hand-waving is that the DLQ becomes, in essence, a part of the user's application and will likely need to be part of a schema-management system. We cannot predict how the DLQ entries will be used, indexed, etc. so integration with a minimum number of well-known columns seems like it should give the user maximum flexibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/543)
<!-- Reviewable:end -->
