### PR TITLE
Testing output to RedShift

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -172,3 +172,21 @@ services:
       - -c
       - wal_level=logical
 
+  #redshift:
+  #  image: guildeducation/docker-amazon-redshift
+  #  environment:
+  #    POSTGRES_PASSWORD: SoupOrSecret
+    # ports:
+    #   - "5432:5432"
+    # user: postgres
+    # command:
+    #   - postgres
+
+  redshift:
+    image: ghcr.io/hearthsim/docker-pgredshift
+    environment:
+      POSTGRES_PASSWORD: SoupOrSecret
+    ports:
+      - "5432:5432"
+    command:
+      - postgres

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -104,6 +104,7 @@ jobs:
             integration: postgresql-v14
           - cockroachdb: v23.1
             integration: postgresql-v15
+
           # Run a test with a separate CockroachDB source and target
           # instance to ensure there are no accidental dependencies
           # between the source, staging, and target schemas.
@@ -148,6 +149,10 @@ jobs:
           #   target: mysql-mariadb-v10
           #   targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql"
 
+          # Test CRDB -> Redshift (postgres 8.0.2)
+          - cockroachdb: v23.1
+            target: redshift
+            targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
     env:
       COVER_OUT: coverage-${{ strategy.job-index }}.out
       DOCKER_LOGS_OUT: docker-${{ strategy.job-index }}.log

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -1464,8 +1464,11 @@ func TestRepeatedKeysWithIgnoredColumns(t *testing.T) {
 	}
 	defer cancel()
 
-	if strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11") {
-		t.Skip("PostgreSQL v11 doesn't support generated columns")
+	if strings.Contains(fixture.TargetPool.Version, "PostgreSQL 8") ||
+		strings.Contains(fixture.TargetPool.Version, "PostgreSQL 9") ||
+		strings.Contains(fixture.TargetPool.Version, "PostgreSQL 10") ||
+		strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11") {
+		t.Skipf("%s doesn't support generated columns", fixture.TargetPool.Version)
 	}
 
 	ctx := fixture.Context
@@ -1637,8 +1640,11 @@ func TestVirtualColumns(t *testing.T) {
 		testVirtualColumnsMySQL(t, fixture)
 		return
 	}
-	if strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11") {
-		t.Skip("PostgreSQL v11 doesn't support generated columns")
+	if strings.Contains(fixture.TargetPool.Version, "PostgreSQL 8") ||
+		strings.Contains(fixture.TargetPool.Version, "PostgreSQL 9") ||
+		strings.Contains(fixture.TargetPool.Version, "PostgreSQL 10") ||
+		strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11") {
+		t.Skipf("%s doesn't support generated columns", fixture.TargetPool.Version)
 	}
 
 	ctx := fixture.Context

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -124,7 +124,11 @@ func TestGetColumns(t *testing.T) {
 			primaryKeys: []string{"a", "b"},
 			dataCols:    []string{"ignored_c"},
 			// Generated columns first added in PG12
-			skip: strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11"),
+			skip: fixture.TargetPool.Product == types.ProductPostgreSQL &&
+				(strings.Contains(fixture.TargetPool.Version, "PostgreSQL 8") ||
+					strings.Contains(fixture.TargetPool.Version, "PostgreSQL 9") ||
+					strings.Contains(fixture.TargetPool.Version, "PostgreSQL 10") ||
+					strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11")),
 		},
 		// Ensure that computed pk columns are retained.
 		{
@@ -147,7 +151,10 @@ func TestGetColumns(t *testing.T) {
 			primaryKeys: []string{"a", "b"},
 			dataCols:    []string{"ignored_c", "ignored_d"},
 			skip: fixture.TargetPool.Product == types.ProductPostgreSQL &&
-				strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11"),
+				(strings.Contains(fixture.TargetPool.Version, "PostgreSQL 8") ||
+					strings.Contains(fixture.TargetPool.Version, "PostgreSQL 9") ||
+					strings.Contains(fixture.TargetPool.Version, "PostgreSQL 10") ||
+					strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11")),
 		},
 		// Ensure that the PK constraint may have an arbitrary name.
 		{


### PR DESCRIPTION
This adds postgres v8 to the test suite to test compatibility with RedShift.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/545)
<!-- Reviewable:end -->
