### PR TITLE
apply: Finish DLQ wiring

### DIFF
--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -104,6 +104,19 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
+	config, err := ProvideDLQConfig()
+	if err != nil {
+		cleanup9()
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	watchers, cleanup10, err := schemawatch.ProvideFactory(targetPool, diagnostics)
 	if err != nil {
 		cleanup9()
@@ -117,36 +130,21 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	appliers, cleanup11, err := apply.ProvideFactory(targetStatements, configs, diagnostics, targetPool, watchers)
-	if err != nil {
-		cleanup10()
-		cleanup9()
-		cleanup8()
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
-	}
-	config, err := ProvideDLQConfig()
-	if err != nil {
-		cleanup11()
-		cleanup10()
-		cleanup9()
-		cleanup8()
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
-	}
 	dlQs := dlq.ProvideDLQs(config, targetPool, watchers)
+	appliers, cleanup11, err := apply.ProvideFactory(targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
+	if err != nil {
+		cleanup10()
+		cleanup9()
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
 	memoMemo, err := memo.ProvideMemo(context, stagingPool, stagingSchema)
 	if err != nil {
 		cleanup11()

--- a/internal/source/fslogical/wire_gen.go
+++ b/internal/source/fslogical/wire_gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/dlq"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -79,7 +80,9 @@ func Start(contextContext context.Context, config *Config) (*FSLogical, func(), 
 		cleanup()
 		return nil, nil, err
 	}
-	appliers, cleanup6, err := apply.ProvideFactory(targetStatements, configs, diagnostics, targetPool, watchers)
+	dlqConfig := logical.ProvideDLQConfig(baseConfig)
+	dlQs := dlq.ProvideDLQs(dlqConfig, targetPool, watchers)
+	appliers, cleanup6, err := apply.ProvideFactory(targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
 	if err != nil {
 		cleanup5()
 		cleanup4()
@@ -225,7 +228,9 @@ func startLoopsFromFixture(fixture *all.Fixture, config *Config) ([]*logical.Loo
 		cleanup()
 		return nil, nil, err
 	}
-	appliers, cleanup6, err := apply.ProvideFactory(targetStatements, configs, diagnostics, targetPool, watchers)
+	dlqConfig := logical.ProvideDLQConfig(baseConfig)
+	dlQs := dlq.ProvideDLQs(dlqConfig, targetPool, watchers)
+	appliers, cleanup6, err := apply.ProvideFactory(targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
 	if err != nil {
 		cleanup5()
 		cleanup4()

--- a/internal/source/logical/provider.go
+++ b/internal/source/logical/provider.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
+	"github.com/cockroachdb/cdc-sink/internal/target/dlq"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -37,6 +38,7 @@ import (
 var Set = wire.NewSet(
 	ProvideFactory,
 	ProvideBaseConfig,
+	ProvideDLQConfig,
 	ProvideStagingDB,
 	ProvideStagingPool,
 	ProvideTargetPool,
@@ -54,6 +56,11 @@ func ProvideBaseConfig(config Config, _ *script.Loader) (*BaseConfig, error) {
 		return nil, err
 	}
 	return config.Base(), nil
+}
+
+// ProvideDLQConfig is called by Wire.
+func ProvideDLQConfig(config *BaseConfig) *dlq.Config {
+	return &config.DLQConfig
 }
 
 // ProvideFactory returns a utility which can create multiple logical

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
 	"github.com/cockroachdb/cdc-sink/internal/staging/version"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
+	"github.com/cockroachdb/cdc-sink/internal/target/dlq"
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -62,6 +63,7 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
+	dlqConfig := logical.ProvideDLQConfig(baseConfig)
 	watchers, cleanup4, err := schemawatch.ProvideFactory(targetPool, diagnostics)
 	if err != nil {
 		cleanup3()
@@ -69,7 +71,8 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	appliers, cleanup5, err := apply.ProvideFactory(targetStatements, configs, diagnostics, targetPool, watchers)
+	dlQs := dlq.ProvideDLQs(dlqConfig, targetPool, watchers)
+	appliers, cleanup5, err := apply.ProvideFactory(targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
 	if err != nil {
 		cleanup4()
 		cleanup3()

--- a/internal/target/apply/factory.go
+++ b/internal/target/apply/factory.go
@@ -31,6 +31,7 @@ import (
 type factory struct {
 	cache    *types.TargetStatements
 	configs  *applycfg.Configs
+	dlqs     types.DLQs
 	product  types.Product
 	watchers types.Watchers
 	mu       struct {
@@ -84,7 +85,7 @@ func (f *factory) getOrCreateUnlocked(product types.Product, table ident.Table) 
 	if ret := f.mu.instances.GetZero(table); ret != nil {
 		return ret, nil
 	}
-	ret, cancel, err := newApply(f.cache, product, table, f.configs, f.watchers)
+	ret, cancel, err := f.newApply(product, table)
 	if err == nil {
 		f.mu.cleanup = append(f.mu.cleanup, cancel)
 		f.mu.instances.Put(table, ret)

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -36,12 +36,14 @@ func ProvideFactory(
 	cache *types.TargetStatements,
 	configs *applycfg.Configs,
 	diags *diag.Diagnostics,
+	dlqs types.DLQs,
 	target *types.TargetPool,
 	watchers types.Watchers,
 ) (types.Appliers, func(), error) {
 	f := &factory{
 		cache:    cache,
 		configs:  configs,
+		dlqs:     dlqs,
 		product:  target.Product,
 		watchers: watchers,
 	}


### PR DESCRIPTION
This change is part of #487 to support three-way merges.

PR #540 and #543 were submitted separately, so the apply code did not support writing to the DLQ. This change completes the wiring and allows conflicts to be written to the queue.

The unexported apply.newApply() function was made a method on the factory type, to decrease the number of arguments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/546)
<!-- Reviewable:end -->
