### PR TITLE
merge: Implement a standard merge function

### DIFF
--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -100,6 +100,9 @@ func ProvideLoader(cfg *Config) (*Loader, error) {
 	if err := apiModule.Set("setOptions", l.setOptions); err != nil {
 		return nil, err
 	}
+	if err := apiModule.Set("standardMerge", l.standardMerge); err != nil {
+		return nil, err
+	}
 
 	// Load the main script into the runtime.
 	main := url.URL{Scheme: "file", Path: cfg.MainPath}

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -86,7 +86,7 @@ func TestScript(t *testing.T) {
 	}, TargetSchema(schema))
 	r.NoError(err)
 	a.Equal(3, s.Sources.Len())
-	a.Equal(4, s.Targets.Len())
+	a.Equal(5, s.Targets.Len())
 	a.Equal(map[string]string{"hello": "world"}, opts.data)
 
 	tbl1 := ident.NewTable(schema, ident.New("table1"))
@@ -163,8 +163,8 @@ func TestScript(t *testing.T) {
 		if merger := cfg.Merger; a.NotNil(merger) {
 			result, err := merger.Merge(context.Background(), &merge.Conflict{
 				Before:   merge.NewBagOf(nil, nil, "val", 1),
-				Existing: merge.NewBagOf(nil, nil, "val", 40),
 				Proposed: merge.NewBagOf(nil, nil, "val", 3),
+				Target:   merge.NewBagOf(nil, nil, "val", 40),
 			})
 			a.NoError(err)
 			if a.NotNil(result.Apply) {
@@ -191,8 +191,8 @@ func TestScript(t *testing.T) {
 		if merger := cfg.Merger; a.NotNil(merger) {
 			result, err := merger.Merge(context.Background(), &merge.Conflict{
 				Before:   merge.NewBagOf(nil, nil, "val", 1),
-				Existing: merge.NewBagOf(nil, nil, "val", 0),
 				Proposed: merge.NewBagOf(nil, nil, "val", 2),
+				Target:   merge.NewBagOf(nil, nil, "val", 0),
 			})
 			a.NoError(err)
 			a.Equal(&merge.Resolution{DLQ: "dead"}, result)
@@ -205,11 +205,25 @@ func TestScript(t *testing.T) {
 		if merger := cfg.Merger; a.NotNil(merger) {
 			result, err := merger.Merge(context.Background(), &merge.Conflict{
 				Before:   merge.NewBagOf(nil, nil, "val", 1),
-				Existing: merge.NewBagOf(nil, nil, "val", 0),
 				Proposed: merge.NewBagOf(nil, nil, "val", 2),
+				Target:   merge.NewBagOf(nil, nil, "val", 0),
 			})
 			a.NoError(err)
 			a.Equal(&merge.Resolution{Drop: true}, result)
+		}
+	}
+
+	// A merge function that sends to a DLQ on conflict.
+	tbl = ident.NewTable(schema, ident.New("merge_or_dlq"))
+	if cfg := s.Targets.GetZero(tbl); a.NotNil(cfg) {
+		if merger := cfg.Merger; a.NotNil(merger) {
+			result, err := merger.Merge(context.Background(), &merge.Conflict{
+				Before:   merge.NewBagOf(nil, nil, "val", 1),
+				Proposed: merge.NewBagOf(nil, nil, "val", 2),
+				Target:   merge.NewBagOf(nil, nil, "val", 0),
+			})
+			a.NoError(err)
+			a.Equal(&merge.Resolution{DLQ: "dead"}, result)
 		}
 	}
 }

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -537,13 +537,13 @@ func (a *apply) upsertBagsLocked(
 		// The conflict will have at least the blocking data and the
 		// conflicting properties.
 		c := &merge.Conflict{
-			Existing: a.newBagLocked(),
 			Proposed: bags[sourceIdx],
+			Target:   a.newBagLocked(),
 		}
 
 		// Copy the conflicting data from the table into the Conflict.
 		for idx, col := range a.mu.templates.Columns {
-			c.Existing.Put(col.Name, blockingData[idx])
+			c.Target.Put(col.Name, blockingData[idx])
 		}
 
 		// Supply before data if we received it from upstream.

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -1170,22 +1170,22 @@ func TestMergeWiring(t *testing.T) {
 			return &merge.Resolution{DLQ: "dlq"}, nil
 		}
 		valKey := ident.New("val")
-		existing := coerceToInt(r, con.Existing.GetZero(valKey))
+		existing := coerceToInt(r, con.Target.GetZero(valKey))
 		if shouldTwoWay.Load() {
 			if con.Before != nil {
 				return nil, errors.New("expecting nil Before")
 			}
-			val := coerceToInt(r, con.Existing.GetZero(valKey))
+			val := coerceToInt(r, con.Target.GetZero(valKey))
 			val *= 10
-			con.Existing.Put(valKey, val)
+			con.Target.Put(valKey, val)
 		} else {
 			start := coerceToInt(r, con.Before.GetZero(valKey))
 			end := coerceToInt(r, con.Proposed.GetZero(valKey))
-			con.Existing.Put(valKey, end-start+existing)
+			con.Target.Put(valKey, end-start+existing)
 		}
-		con.Existing.Put(ident.New("updated_at"), time.Now())
+		con.Target.Put(ident.New("updated_at"), time.Now())
 
-		return &merge.Resolution{Apply: con.Existing}, nil
+		return &merge.Resolution{Apply: con.Target}, nil
 	})
 	r.NoError(fixture.Configs.Set(tblName, configData))
 

--- a/internal/util/ident/map.go
+++ b/internal/util/ident/map.go
@@ -50,7 +50,12 @@ func MapOf[V any](args ...any) *Map[V] {
 		default:
 			panic(fmt.Sprintf("unsupported type %T at index %d", t, i))
 		}
-		ret.Put(key, args[i+1].(V))
+		// A nil in the input should result in a zero value.
+		var v V
+		if args[i+1] != nil {
+			v = args[i+1].(V)
+		}
+		ret.Put(key, v)
 	}
 	return ret
 }

--- a/internal/util/ident/map_test.go
+++ b/internal/util/ident/map_test.go
@@ -43,6 +43,18 @@ func TestMap(t *testing.T) {
 	r.Equal("FOO", found)
 }
 
+// Ensure that a nil in the input to [MapOf] translates correctly into a
+// zero value for the type.
+func TestMapOfNil(t *testing.T) {
+	r := require.New(t)
+
+	m := MapOf[string](Ident{}, nil)
+	r.Equal(1, m.Len())
+	v, ok := m.Get(Ident{})
+	r.True(ok)
+	r.Equal("", v)
+}
+
 func TestMapJSON(t *testing.T) {
 	r := require.New(t)
 

--- a/internal/util/merge/standard.go
+++ b/internal/util/merge/standard.go
@@ -1,0 +1,211 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package merge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sort"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+// Standard implements a basic three-way merge operator.
+type Standard struct {
+	// The Fallback will be invoked if there were properties that could
+	// not be merged.
+	Fallback Merger
+}
+
+var _ Merger = (*Standard)(nil)
+
+// Merge implements Merger.
+func (s *Standard) Merge(ctx context.Context, con *Conflict) (*Resolution, error) {
+	if err := merge(con); err != nil {
+		return nil, err
+	}
+
+	// Ideal case, we were able to automatically merge the properties.
+	if len(con.Unmerged) == 0 {
+		return &Resolution{Apply: con.Target}, nil
+	}
+
+	// Ensure stable ordering.
+	sort.Sort(ident.Idents(con.Unmerged))
+
+	// If a fallback merger is available, delegate to it.
+	if s.Fallback != nil {
+		return s.Fallback.Merge(ctx, con)
+	}
+
+	// The merge failed and there's nowhere to store the data.
+	return nil, ConflictError(con)
+}
+
+// canonicalEquals returns true if the JSON encoding of the two values
+// are equal. This is not a maximally efficient way to determine
+// arbitrary value equality since it consumes memory and cannot
+// early-out, so we should revisit this if cdc-sink gets a proper Datum
+// type.
+func canonicalEquals(a, b any) (bool, error) {
+	aBytes, err := json.Marshal(a)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	bBytes, err := json.Marshal(b)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	return bytes.Equal(aBytes, bBytes), nil
+}
+
+// undefined is a sentinel value that represents the absence of a
+// value. We want to be able to distinguish between a property not
+// being set and a property being set to a nil / NULL value.
+type undefined struct{}
+
+func (undefined) MarshalJSON() ([]byte, error) {
+	return []byte(`{"__undefined__":true}`), nil
+}
+
+// merge computes the properties that have changed between
+// [Conflict.Before] and [Conflict.Proposed]. These changes are then
+// applied to [Conflict.Target], which will represent the state of row
+// to apply to the target. If there are properties that cannot be
+// merged, they will be added to [Conflict.Unmerged].
+func merge(con *Conflict) error {
+	// This case shouldn't happen, since we wouldn't have a conflict
+	// unless there were an existing row. As an exercise in
+	// completeness, we'll cover this case, since it's a trivial one.
+	if con.Target == nil || con.Target.Len() == 0 {
+		con.Target = con.Proposed
+		return nil
+	}
+	if con.Proposed == nil {
+		return errors.New("no proposed data")
+	}
+	// Before will be null if the conflict arose due to an insert. In
+	// this case, the best that we can do is to present all proposed
+	// properties as unresolved to the fallback merge function.
+	if con.Before == nil {
+		con.Before = NewBagFrom(con.Proposed)
+	}
+
+	// We want to iterate over all mapped and unmapped properties
+	// that are defined within the Conflict.
+	return allProperties(con).Range(func(prop ident.Ident, _ struct{}) error {
+		// We want to be able to distinguish the tri-state of unset
+		// versus set-to-null.
+		before, beforeExists := con.Before.Get(prop)
+		if !beforeExists {
+			before = undefined{}
+		}
+		target, targetExists := con.Target.Get(prop)
+		if !targetExists {
+			target = undefined{}
+		}
+		proposed, proposedExists := con.Proposed.Get(prop)
+		if !proposedExists {
+			proposed = undefined{}
+		}
+
+		// We'll compare before and proposed to determine an action that
+		// we may take. We need to use a somewhat fuzzy approach to
+		// equality, since we could have varying in memory type from the
+		// json package versus the database. For example, we could see
+		// an untyped int versus an int64.
+		isUnchanged, err := canonicalEquals(before, proposed)
+		if err != nil {
+			return errors.Wrapf(err, "property: %s", prop)
+		}
+
+		// If the before and proposed values are the same, then we don't
+		// need to do anything else with this property.
+		if isUnchanged {
+			return nil
+		}
+
+		// If the proposed value already exists within the target, then
+		// we can treat the update as a no-op.
+		isIdempotent, err := canonicalEquals(target, proposed)
+		if err != nil {
+			return errors.Wrapf(err, "property: %s", prop)
+		}
+		if isIdempotent {
+			return nil
+		}
+
+		// Now we need to determine if the proposed value is "safe" to
+		// apply. The change will be safe if the target doesn't yet
+		// define the property or if the target value matches the before
+		// value.
+		var isSafe bool
+		if !targetExists {
+			isSafe = true
+		} else {
+			isSafe, err = canonicalEquals(before, target)
+			if err != nil {
+				return err
+			}
+		}
+
+		// If the before and target values don't match, we'll record the
+		// property name for later and keep processing.
+		if !isSafe {
+			con.Unmerged = append(con.Unmerged, prop)
+			return nil
+		}
+
+		// We have a change that's safe to make.
+		if proposedExists {
+			con.Target.Put(prop, proposed)
+		} else {
+			con.Target.Delete(prop)
+		}
+		return nil
+	})
+}
+
+// allProperties accumulates a set of all actionable properties
+// contained in the bags.
+//
+// The mapped properties are a function of the target database and will
+// be the same between all bags. Unmapped properties could be disjoint,
+// so we need to process all bags in the conflict.
+//
+// Primary key columns are ignored, since those values define the row
+// identity. Ignored columns are ignored because ignorance is bliss.
+func allProperties(con *Conflict) *ident.Map[struct{}] {
+	ret := &ident.Map[struct{}]{}
+	for _, col := range con.Proposed.Columns {
+		if col.Primary || col.Ignored {
+			continue
+		}
+		ret.Put(col.Name, struct{}{})
+	}
+
+	add := func(prop ident.Ident, _ any) error {
+		ret.Put(prop, struct{}{})
+		return nil
+	}
+	_ = con.Proposed.Unmapped.Range(add)
+	_ = con.Before.Unmapped.Range(add)
+	_ = con.Target.Unmapped.Range(add)
+	return ret
+}

--- a/internal/util/merge/standard_test.go
+++ b/internal/util/merge/standard_test.go
@@ -1,0 +1,394 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package merge
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStandardMerge is a test for coverage.
+func TestStandardMerge(t *testing.T) {
+	cols := []types.ColData{
+		{
+			Name:    ident.New("pk0"),
+			Primary: true,
+			Type:    "INT8",
+		},
+		{
+			Name:    ident.New("pk1"),
+			Primary: true,
+			Type:    "INT8",
+		},
+		{
+			Name: ident.New("col0"),
+			Type: "INT8",
+		},
+		{
+			Name: ident.New("col1"),
+			Type: "INT8",
+		},
+	}
+
+	tcs := []struct {
+		merger    Merger
+		con       *Conflict
+		expect    *Resolution
+		expectErr string
+	}{
+		{
+			// Trivial case.
+			merger: &Standard{},
+			con: &Conflict{
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+		},
+		{
+			// Empty blocking row. We don't expect to actually see this
+			// case, since there won't be a blocking row in the table.
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+				Target: NewBagOf(cols, nil),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+		},
+		{
+			// Delete col1.
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 1,
+				),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 1,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+				),
+			},
+		},
+		{
+			// Set col1 explicitly to nil.
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 1,
+				),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", nil,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 1,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", nil,
+				),
+			},
+		},
+		{
+			// col1 has changed in the input.
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 1,
+				),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 1,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 42,
+				),
+			},
+		},
+		{
+			// There is a conflict in col0
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 99,
+					"col1", 1,
+				),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 1,
+				),
+			},
+			expectErr: `"Unmerged":["col0"]`,
+		},
+		{
+			// Merge unmapped properties.
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 1,
+					"unmapped", false,
+				),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+					"unmapped", true,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 1,
+					"existing_unmapped", true,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 42,
+					"unmapped", true,
+					"existing_unmapped", true,
+				),
+			},
+		},
+		{
+			// There is a conflict in col0 and a DLQ defined.
+			merger: &Standard{
+				Fallback: DLQ("dead"),
+			},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 99,
+					"col1", 1,
+				),
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 1000,
+					"col1", 1,
+				),
+			},
+			expect: &Resolution{DLQ: "dead"},
+		},
+		{
+			// No before data, which will happen in an insert case.
+			merger: &Standard{},
+			con: &Conflict{
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 99,
+					"col1", 101,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+			expectErr: `"Unmerged":["col0","col1"]`,
+		},
+		{
+			// No before data, but the update is a no-op.
+			merger: &Standard{},
+			con: &Conflict{
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+		},
+		{
+			// No before data, but the update is a no-op for overlapping properties.
+			merger: &Standard{},
+			con: &Conflict{
+				Proposed: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+					"foo", 99,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+					"bar", 101,
+				),
+			},
+			expect: &Resolution{
+				Apply: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+					"foo", 99,
+					"bar", 101,
+				),
+			},
+		},
+		{
+			// Silly error: No proposed data.
+			merger: &Standard{},
+			con: &Conflict{
+				Before: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+				Target: NewBagOf(cols, nil,
+					"pk0", 0,
+					"pk1", 1,
+					"col0", 0,
+					"col1", 42,
+				),
+			},
+			expectErr: "no proposed data",
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			a := assert.New(t)
+			res, err := tc.merger.Merge(context.Background(), tc.con)
+			if tc.expectErr != "" {
+				a.ErrorContains(err, tc.expectErr)
+			} else if a.NoError(err) {
+				eq, err := canonicalEquals(tc.expect, res)
+				if a.NoError(err) {
+					a.Truef(eq, "expected: %#v \n\n actual: %#v", tc.expect, res)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds merge.Standard and exposes it to the userscript. The merge function identifies the properties which have changed between the before and proposed bags. If the value of the property in the before bag equals the value of the property in the target, the change is applied.

Property equivalency is presently defined as "serializes to the same JSON bytes". The golang json serializer is deterministic and we have a rather fluid typesystem, so this seems like a reasonable initial implementation.

A fallback merge function can be composed with merge.Standard to handle properties with application-specific semantics. The script test shows the composition of the standard merge with a counter-like field that is only ever incremented. Properties which cannot be automatically merged are indicated by a new Conflict.Unmerged field and corresponding userscript binding. This fallback function can also be used to "merge or else" by using a trivial fallback that always returns the name of a dlq. This, too, is demonstrated in the test script.

The merge.Conflict.Existing field is renamed to Target. It either contains the existing state of the row in the target database, or it contains the data that merge.Standard determines should be stored in the target. The change in sort order improves readability in the tests: Before, Proposed, Target -> Expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/547)
<!-- Reviewable:end -->
