### PR TITLE
workflow: Add a simple linter for CockroachDB license keys

### DIFF
--- a/.github/workflows/crdb-key-lint.yaml
+++ b/.github/workflows/crdb-key-lint.yaml
@@ -1,0 +1,37 @@
+# Copyright 2023 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow checks for key patterns not otherwise matched by GitHub
+# secret scanning.
+name: CRDB Key Linter
+permissions:
+  contents: read
+on:
+  merge_group:
+  push:
+jobs:
+  lint:
+    name: License Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Check for CRDB license keys
+        run: |
+          echo "CockroachDB license keys found in the following files:"
+          git grep -lE 'crl-[[:digit:]]+-[[:alnum:]]+' || exit 0
+          exit 1


### PR DESCRIPTION
This change adds a workflow that runs on push to look for strings that appear to be CockroachDB license keys.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/548)
<!-- Reviewable:end -->
