### PR TITLE
mariadb: support for target database.

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -143,10 +143,10 @@ jobs:
           - cockroachdb: v23.1
             target: mysql-v8
             targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql"
-          # TODO (silvano) Test CRDB -> MariaDB for migration backfill use cases.
-          # - cockroachdb: v23.1
-          #   target: mysql-mariadb-v10
-          #   targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql"
+          # Test CRDB -> MariaDB for migration backfill use cases.
+          - cockroachdb: v23.1
+            target: mysql-mariadb-v10
+            targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql"
 
     env:
       COVER_OUT: coverage-${{ strategy.job-index }}.out

--- a/internal/cmd/preflight/preflight.go
+++ b/internal/cmd/preflight/preflight.go
@@ -98,8 +98,8 @@ func testTargetConnection(ctx context.Context, connString string) error {
 		if result != 1 {
 			return errors.Errorf("SELECT 1 returned %d instead", result)
 		}
-	case types.ProductMySQL:
-		log.Info("MySQL DB detected")
+	case types.ProductMariaDB, types.ProductMySQL:
+		log.Info("MySQL/MariaDB detected")
 		log.Info("Testing basic query")
 		var result int
 		row := pool.DB.QueryRowContext(ctx, "SELECT 1")

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -60,9 +60,11 @@ func TestScript(t *testing.T) {
 	schema := fixture.TargetSchema.Schema()
 
 	size := 2048
-	if fixture.TargetPool.Product == types.ProductMySQL {
-		// MySQL has restrictions on key length.
+	switch fixture.TargetPool.Product {
+	case types.ProductMariaDB, types.ProductMySQL:
 		size = 512
+	default:
+		// nothing to do.
 	}
 
 	// Create tables that will be referenced by the user-script.

--- a/internal/source/cdc/request.go
+++ b/internal/source/cdc/request.go
@@ -245,7 +245,7 @@ func (r *request) schemaSegmentCount() int {
 	switch r.handler.TargetPool.Product {
 	case types.ProductUnknown:
 		return 0
-	case types.ProductOracle, types.ProductMySQL:
+	case types.ProductOracle, types.ProductMariaDB, types.ProductMySQL:
 		return 1 // e.g. MY_SCHEMA
 	case types.ProductCockroachDB, types.ProductPostgreSQL:
 		return 2 // e.g. MY_DB.MY_SCHEMA

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -373,7 +373,7 @@ api.configureTable("t_2", {
 			switch fixture.TargetPool.Product {
 			case types.ProductCockroachDB, types.ProductPostgreSQL:
 				q = "SELECT count(*) FROM %s WHERE v = $1"
-			case types.ProductMySQL:
+			case types.ProductMariaDB, types.ProductMySQL:
 				q = "SELECT count(*) FROM %s WHERE v = ?"
 			case types.ProductOracle:
 				q = "SELECT count(*) FROM %s WHERE v = :v"

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -70,8 +70,8 @@ func TestApply(t *testing.T) {
 		// control the exact bytes that come back.
 		tableSchema = "CREATE TABLE %s (pk0 INT, pk1 VARCHAR(2048), extras VARCHAR(2048), " +
 			"has_default VARCHAR(2048) NOT NULL DEFAULT 'Hello', PRIMARY KEY (pk0,pk1))"
-	case types.ProductMySQL:
-		// mysql has limitation on the size of the primary key (3072 bytes)
+	case types.ProductMariaDB, types.ProductMySQL:
+		// MySQL/MariaDB have limitation on the size of the primary key (3072 bytes)
 		tableSchema = "CREATE TABLE %s (pk0 INT, pk1 VARCHAR(512), extras VARCHAR(2048), " +
 			"has_default VARCHAR(2048) NOT NULL DEFAULT 'Hello', PRIMARY KEY (pk0,pk1))"
 	case types.ProductOracle:
@@ -93,7 +93,7 @@ func TestApply(t *testing.T) {
 		switch fixture.TargetPool.Product {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			q = "SELECT count(*) FROM %s WHERE has_default=$1"
-		case types.ProductMySQL:
+		case types.ProductMariaDB, types.ProductMySQL:
 			q = "SELECT count(*) FROM %s WHERE has_default=?"
 		case types.ProductOracle:
 			q = "SELECT count(*) FROM %s WHERE has_default=:p1"
@@ -176,7 +176,7 @@ func TestApply(t *testing.T) {
 			switch fixture.TargetPool.Product {
 			case types.ProductCockroachDB, types.ProductPostgreSQL:
 				a.ErrorContains(err, "violates not-null constraint (SQLSTATE 23502)")
-			case types.ProductMySQL:
+			case types.ProductMariaDB, types.ProductMySQL:
 				a.ErrorContains(err, "1048 (23000)")
 			case types.ProductOracle:
 				a.ErrorContains(err, "ORA-01400: cannot insert NULL into")
@@ -267,7 +267,7 @@ func TestApply(t *testing.T) {
 		switch fixture.TargetPool.Product {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			extrasQ = fmt.Sprintf("SELECT extras FROM %s WHERE pk0=$1 AND pk1=$2", tbl.Name())
-		case types.ProductMySQL:
+		case types.ProductMariaDB, types.ProductMySQL:
 			extrasQ = fmt.Sprintf("SELECT extras FROM %s WHERE pk0=? AND pk1=?", tbl.Name())
 		case types.ProductOracle:
 			extrasQ = fmt.Sprintf(`SELECT extras FROM %s WHERE pk0=:p1 AND pk1=:p2`, tbl.Name())
@@ -296,6 +296,232 @@ type dataTypeTestCase struct {
 }
 
 var (
+	mariaDBDataTypeTests = []dataTypeTestCase{
+		// MariaDB types: https://mariadb.com/kb/en/data-types/
+		{name: `bigint_null`, columnType: `BIGINT`},
+		{name: `bigint`, columnType: `BIGINT`, sqlValue: `9223372036854775807`},
+		{name: `binary_null`, sourceType: `bytes`, columnType: `BINARY(6)`},
+		{
+			name:       `binary`,
+			sourceType: `bytes`,
+			columnType: `BINARY(6)`,
+			sqlValue:   `a1b2c3`,
+			indexable:  true,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `bit_null`, columnType: `BIT(8)`},
+		{
+			name:       `bit`,
+			sourceType: `varbit`,
+			columnType: `BIT(8)`,
+			sqlValue:   `10010101`,
+			expectJSON: `"10010101"`,
+			readBackQ:  `SELECT bin(val) FROM %s`,
+		},
+		{name: `blob_null`, sourceType: `bytes`, columnType: `BLOB(100)`},
+		{
+			name:       `blob`,
+			sourceType: `bytes`,
+			columnType: `BLOB(100)`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `char_null`, columnType: `CHAR(255)`},
+		{name: `char`, columnType: `CHAR(255)`, sqlValue: `a1b2c3`, indexable: true},
+		{name: `date_null`, columnType: `DATE`},
+		{name: `date`, columnType: `DATE`, sqlValue: `2016-01-25`, indexable: true},
+		{name: `datetime_null`, sourceType: `timestamp`, columnType: `DATETIME`},
+		{
+			name:       `datetime`,
+			sourceType: `timestamp`,
+			columnType: `DATETIME`,
+			sqlValue:   `2016-01-25 01:01:00`,
+			expectJSON: `"2016-01-25 01:01:00"`,
+			indexable:  true,
+		},
+		{name: `decimal_eng_6,0`, columnType: `DECIMAL(6,0)`, sqlValue: `4e+2`, indexable: true, expectJSON: "400"},
+		{name: `decimal_eng_6,2`, columnType: `DECIMAL(6,2)`, sqlValue: `4.98765e+2`, indexable: true, expectJSON: "498.77"},
+		{name: `decimal_null`, columnType: `DECIMAL`},
+		{name: `decimal`, columnType: `DECIMAL(10,4)`, sqlValue: `1.2345`, indexable: true},
+		{name: `double_null`, sourceType: `float`, columnType: `DOUBLE`},
+		{name: `double`, sourceType: `float`, columnType: `DOUBLE`, sqlValue: `1.2345`, indexable: true},
+		{name: `enum_null`, sourceType: `string`, columnType: `ENUM('a','b','c')`},
+		{name: `enum`, sourceType: `string`, columnType: `ENUM('a','b','c')`, sqlValue: `a`, indexable: true},
+		{name: `float_null`, columnType: `FLOAT`},
+		// This fails with lower precision:
+		// select json_array(cast(1.2345 as float)) => 1.2345000505447388
+		{name: `float`, sourceType: `float`, columnType: `FLOAT(25)`, sqlValue: `1.2345`},
+		{
+			name:       `geography`,
+			sourceType: `GEOGRAPHY`,
+			columnType: `GEOMETRY`,
+			sqlValue:   `0101000020E6100000000000000000F03F0000000000000040`,
+			expectJSON: `"POINT(1 2)"`,
+			readBackQ:  `select ST_AsText(val) from %s`,
+		},
+		{name: `geometry`,
+			columnType: `GEOMETRY`,
+			sqlValue:   `010100000075029A081B9A5DC0F085C954C1F84040`,
+			expectJSON: `"POINT(-118.4079 33.9434)"`,
+			readBackQ:  `select ST_AsText(val) from %s`,
+		},
+		{name: `inet`, sourceType: `INET`, columnType: `INET4`, sqlValue: `192.168.0.1`, indexable: true},
+		{name: `inet_null`, sourceType: `INET`, columnType: `INET4`},
+		{name: `int_null`, columnType: `INT`},
+		{name: `int`, columnType: `INT`, sqlValue: `2147483647`},
+		{name: `integer_null`, columnType: `INTEGER`},
+		{name: `integer`, columnType: `INTEGER`, sqlValue: `2147483647`},
+		{name: `jsonb_null`, sourceType: `jsonb`, columnType: `JSON`},
+		{
+			name:       `json`,
+			sourceType: `jsonb`,
+			columnType: `JSON`,
+			sqlValue: `
+			{
+				"string": "Lola",
+				"bool": true,
+				"number": 547,
+				"float": 123.456,
+				"array": [
+					"lola",
+					true,
+					547,
+					123.456,
+					[
+						"lola",
+						true,
+						547,
+						123.456
+					],
+					{
+						"string": "Lola",
+						"bool": true,
+						"number": 547,
+						"float": 123.456,
+						"array": [
+							"lola",
+							true,
+							547,
+							123.456,
+							[
+								"lola",
+								true,
+								547,
+								123.456
+							]
+						]
+					}
+				],
+				"map": {
+					"string": "Lola",
+					"bool": true,
+					"number": 547,
+					"float": 123.456,
+					"array": [
+						"lola",
+						true,
+						547,
+						123.456,
+						[
+							"lola",
+							true,
+							547,
+							123.456
+						],
+						{
+							"string": "Lola",
+							"bool": true,
+							"number": 547,
+							"float": 123.456,
+							"array": [
+								"lola",
+								true,
+								547,
+								123.456,
+								[
+									"lola",
+									true,
+									547,
+									123.456
+								]
+							]
+						}
+					]
+				}
+			}
+			`,
+		},
+		{name: `longblob_null`, sourceType: `bytes`, columnType: `LONGBLOB`},
+		{
+			name:       `longblob`,
+			sourceType: `bytes`,
+			columnType: `LONGBLOB`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `longtext_null`, sourceType: `string`, columnType: `LONGTEXT`},
+		{name: `longtext`, sourceType: `string`, columnType: `LONGTEXT`, sqlValue: `a1b2c3`},
+		{name: `mediumblob_null`, sourceType: `bytes`, columnType: `MEDIUMBLOB`},
+		{
+			name:       `mediumblob`,
+			sourceType: `bytes`,
+			columnType: `MEDIUMBLOB`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `mediumint_null`, sourceType: `int4`, columnType: `MEDIUMINT`},
+		{name: `mediumint`, sourceType: `int4`, columnType: `MEDIUMINT`, sqlValue: `8388607`},
+		{name: `mediumtext_null`, sourceType: `string`, columnType: `MEDIUMTEXT`},
+		{name: `mediumtext`, sourceType: `string`, columnType: `MEDIUMTEXT`, sqlValue: `a1b2c3`},
+		{name: `mumeric_null`, columnType: `DECIMAL`},
+		{name: `numeric`, columnType: `DECIMAL(10,4)`, sqlValue: `1.2345`, indexable: true},
+		{name: `smallint_null`, sourceType: `int2`, columnType: `SMALLINT`},
+		{name: `smallint`, sourceType: `int2`, columnType: `SMALLINT`, sqlValue: `32767`},
+		{name: `set_null`, sourceType: `string`, columnType: `SET('a','b','c')`},
+		{name: `set`, sourceType: `string`, columnType: `SET('a','b','c')`, sqlValue: `a,b`, indexable: true},
+		{name: `text_null`, sourceType: `string`, columnType: `TEXT(100)`},
+		{name: `text`, sourceType: `string`, columnType: `TEXT(100)`, sqlValue: `a1b2c3`},
+		{name: `time_null`, columnType: `TIME`},
+		{name: `time`, columnType: `TIME(6)`, sqlValue: `01:23:45.123456`, indexable: true},
+		{name: `timestamp_null`, columnType: `TIMESTAMP`},
+		{
+			name:       `timestamp`,
+			columnType: `TIMESTAMP`,
+			sqlValue:   `2016-01-25 10:10:10`,
+			expectJSON: `"2016-01-25 10:10:10"`,
+			indexable:  true,
+		},
+		{name: `tinyblob_null`, sourceType: `bytes`, columnType: `TINYBLOB`},
+		{
+			name:       `tinyblob`,
+			sourceType: `bytes`,
+			columnType: `TINYBLOB`,
+			sqlValue:   `ab`,
+			expectJSON: `"ab"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `tinyint_null`, sourceType: `int2`, columnType: `TINYINT`},
+		{name: `tinyint`, sourceType: `int2`, columnType: `TINYINT`, sqlValue: `127`},
+		{name: `tinytext_null`, sourceType: `string`, columnType: `TINYTEXT`},
+		{name: `tinytext`, sourceType: `string`, columnType: `TINYTEXT`, sqlValue: `a1b2c3`},
+		{name: `varbinary_null`, sourceType: `bytes`, columnType: `VARBINARY(255)`},
+		{
+			name:       `varbinary`,
+			sourceType: `bytes`,
+			columnType: `VARBINARY(255)`,
+			sqlValue:   `a1b2c3`,
+			expectJSON: `"a1b2c3"`,
+			readBackQ:  `SELECT val FROM %s`,
+		},
+		{name: `varchar_null`, columnType: `VARCHAR(255)`},
+		{name: `varchar`, columnType: `VARCHAR(255)`, sqlValue: `a1b2c3`, indexable: true},
+		{name: `year_null`, sourceType: `string`, columnType: `YEAR`},
+		{name: `year`, sourceType: `string`, columnType: `YEAR`, sqlValue: `2016`, expectJSON: `2016`, indexable: true},
+	}
 	myDataTypeTests = []dataTypeTestCase{
 		// MySQL data types: https://dev.mysql.com/doc/refman/8.0/en/data-types.html
 		// 11.1.2 Integer Types (Exact Value) - INTEGER, INT, SMALLINT, TINYINT, MEDIUMINT, BIGINT
@@ -734,6 +960,9 @@ func TestAllDataTypes(t *testing.T) {
 					sqlValue:   `2016-01-25 10:10:10-05:00`,
 					indexable:  true})
 			readBackQ = "SELECT COALESCE(to_json(val)::VARCHAR(2048), 'null') FROM %s"
+		case types.ProductMariaDB:
+			testcases = mariaDBDataTypeTests
+			readBackQ = "SELECT COALESCE(json_extract(json_array(val),'$[0]'), 'null') FROM %s"
 		case types.ProductMySQL:
 			testcases = myDataTypeTests
 			readBackQ = "SELECT COALESCE(json_extract(json_array(val),'$[0]'), 'null') FROM %s"
@@ -898,7 +1127,7 @@ func testConditions(t *testing.T, cas, deadline bool) {
 	switch fixture.TargetPool.Product {
 	case types.ProductCockroachDB, types.ProductOracle, types.ProductPostgreSQL:
 		createStatement = "CREATE TABLE %s (pk INT PRIMARY KEY, ver INT, ts TIMESTAMP WITH TIME ZONE)"
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		createStatement = "CREATE TABLE %s (pk INT PRIMARY KEY, ver INT, ts TIMESTAMP)"
 	default:
 		a.FailNow("product not supported")
@@ -952,7 +1181,7 @@ func testConditions(t *testing.T, cas, deadline bool) {
 		switch fixture.TargetPool.Product {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			q = "SELECT ver, ts FROM %s WHERE pk = $1"
-		case types.ProductMySQL:
+		case types.ProductMariaDB, types.ProductMySQL:
 			// The MySQL driver returns a string for timestamp,
 			// so we need to parse it.
 			var res string
@@ -1145,7 +1374,7 @@ func TestMergeWiring(t *testing.T) {
 	switch fixture.TargetPool.Product {
 	case types.ProductCockroachDB, types.ProductOracle, types.ProductPostgreSQL:
 		createStatement = "CREATE TABLE %s (pk INT PRIMARY KEY, val INT, updated_at TIMESTAMP WITH TIME ZONE)"
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		createStatement = "CREATE TABLE %s (pk INT PRIMARY KEY, val INT, updated_at TIMESTAMP)"
 	default:
 		r.FailNow("product not supported")
@@ -1482,7 +1711,7 @@ func TestRepeatedKeysWithIgnoredColumns(t *testing.T) {
 		tblSchema = "CREATE TABLE %s (pk0 INT PRIMARY KEY, " +
 			"ignored INT GENERATED ALWAYS AS (1) STORED, " +
 			"val VARCHAR(2048))"
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		tblSchema = "CREATE TABLE %s (pk0 INT PRIMARY KEY, " +
 			"ignored INT as (1), " +
 			"val VARCHAR(2048))"
@@ -1539,7 +1768,7 @@ func TestRepeatedKeysWithIgnoredColumns(t *testing.T) {
 		switch fixture.TargetPool.Product {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			q = "SELECT val FROM %s WHERE pk0 = $1"
-		case types.ProductMySQL:
+		case types.ProductMariaDB, types.ProductMySQL:
 			q = "SELECT val FROM %s WHERE pk0 = ?"
 		case types.ProductOracle:
 			q = "SELECT val FROM %s WHERE pk0 = :pk"
@@ -1632,10 +1861,14 @@ func TestVirtualColumns(t *testing.T) {
 	}
 	defer cancel()
 
-	// In MySQL, defining a virtual generated column as primary key is not supported.
-	if fixture.TargetPool.Product == types.ProductMySQL {
+	switch fixture.TargetPool.Product {
+	case types.ProductMariaDB, types.ProductMySQL:
+		// In MySQL/MariaDB, defining a virtual generated column as primary key
+		// is not supported. Handle them separately.
 		testVirtualColumnsMySQL(t, fixture)
 		return
+	default:
+		// Keep going for the rest of the products.
 	}
 	if strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11") {
 		t.Skip("PostgreSQL v11 doesn't support generated columns")
@@ -1715,7 +1948,7 @@ func TestVirtualColumns(t *testing.T) {
 	})
 }
 
-// In MySQL, defining a virtual generated column as primary key is not supported
+// In MySQL and MariaDB, defining a virtual generated column as primary key is not supported
 // Ensure that if columns with generation expressions are present, we
 // don't try to write to them and that we correctly ignore those columns
 // in data payloads.

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -185,7 +185,7 @@ func newTemplates(mapping *columnMapping) (*templates, error) {
 		ret.delete = tmplCRDB.Lookup("delete.tmpl")
 		ret.upsert = tmplCRDB.Lookup("upsert.tmpl")
 
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		ret.conditional = tmplMy.Lookup("conditional.tmpl")
 		ret.delete = tmplMy.Lookup("delete.tmpl")
 		ret.upsert = tmplMy.Lookup("upsert.tmpl")
@@ -267,7 +267,7 @@ func (t *templates) Vars() ([][]varPair, error) {
 				switch t.Product {
 				case types.ProductCockroachDB, types.ProductPostgreSQL:
 					reference = fmt.Sprintf("$%d", vp.Param)
-				case types.ProductMySQL:
+				case types.ProductMariaDB, types.ProductMySQL:
 					reference = "?"
 				case types.ProductOracle:
 					reference = fmt.Sprintf(":ref%d", vp.Param)

--- a/internal/target/dlq/dlq.go
+++ b/internal/target/dlq/dlq.go
@@ -133,7 +133,7 @@ func (d *dlqs) Get(ctx context.Context, target ident.Schema, name string) (types
 		q = qBase + argsPG
 	case types.ProductOracle:
 		q = qBase + argsOra
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		q = qBase + argsMySQL
 	default:
 		return nil, errors.Errorf("dlq unimplemented for product %s", d.targetPool.Product)

--- a/internal/target/dlq/dlq_schema.go
+++ b/internal/target/dlq/dlq_schema.go
@@ -84,7 +84,8 @@ data_before JSONB NOT NULL
 // suggested schemas. See [all.Fixture.CreateDLQTable].
 var BasicSchemas = map[types.Product]string{
 	types.ProductCockroachDB: basicCRDBSchema,
-	types.ProductPostgreSQL:  basicPGSchema,
+	types.ProductMariaDB:     basicMySQLSchema,
 	types.ProductMySQL:       basicMySQLSchema,
 	types.ProductOracle:      basicOraSchema,
+	types.ProductPostgreSQL:  basicPGSchema,
 }

--- a/internal/target/schemawatch/dependencies.go
+++ b/internal/target/schemawatch/dependencies.go
@@ -330,7 +330,7 @@ func getDependencyOrder(
 			args = []any{parts[0].Raw(), parts[1].Raw()}
 		}
 
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		parts := db.Idents(make([]ident.Ident, 0, 1))
 		if len(parts) != 1 {
 			return nil, errors.Errorf("expecting one schema parts, had %d", len(parts))

--- a/internal/target/schemawatch/dependencies_test.go
+++ b/internal/target/schemawatch/dependencies_test.go
@@ -154,7 +154,7 @@ ALTER TABLE %[1]s.cycle_a ADD COLUMN ref int references %[1]s.cycle_b;
 `, fixture.TargetSchema.Schema()))
 		r.NoError(err)
 
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		_, err = pool.ExecContext(ctx, fmt.Sprintf(`
 		CREATE TABLE %[1]s."cycle_a" (pk int primary key)`,
 			fixture.TargetSchema.Schema()))

--- a/internal/target/schemawatch/parse_helpers.go
+++ b/internal/target/schemawatch/parse_helpers.go
@@ -125,7 +125,7 @@ func parseHelper(product types.Product, typeName string) func(any) (any, error) 
 	switch product {
 	case types.ProductCockroachDB, types.ProductPostgreSQL:
 		// Just pass through, since we have similar representations.
-	case types.ProductMySQL:
+	case types.ProductMariaDB, types.ProductMySQL:
 		// Coerce types to the what the mysql driver expects.
 		switch typeName {
 		case "binary", "blob", "longblob", "mediumblob", "tinyblob", "varbinary":

--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -258,7 +258,7 @@ func (w *watcher) getTables(ctx context.Context, tx *types.TargetPool) (*types.S
 			rows, err = tx.QueryContext(ctx,
 				fmt.Sprintf(tableTemplateCrdb, ident.New(dbNameRaw)), dbNameRaw, parts[1].Raw())
 
-		case types.ProductMySQL:
+		case types.ProductMariaDB, types.ProductMySQL:
 			rows, err = tx.QueryContext(ctx, tableTemplateMySQL, w.schema.Raw())
 		case types.ProductOracle:
 			rows, err = tx.QueryContext(ctx, tableTemplateOracle, w.schema.Raw())

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -95,7 +95,7 @@ func TestWatch(t *testing.T) {
 		case types.ProductCockroachDB, types.ProductPostgreSQL:
 			r.NoError(retry.Execute(ctx, fixture.TargetPool,
 				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v VARCHAR", tblInfo.Name())))
-		case types.ProductMySQL:
+		case types.ProductMariaDB, types.ProductMySQL:
 			r.NoError(retry.Execute(ctx, fixture.TargetPool,
 				fmt.Sprintf("ALTER TABLE %s ADD COLUMN v VARCHAR(10)", tblInfo.Name())))
 		case types.ProductOracle:

--- a/internal/types/product_string.go
+++ b/internal/types/product_string.go
@@ -10,14 +10,15 @@ func _() {
 	var x [1]struct{}
 	_ = x[ProductUnknown-0]
 	_ = x[ProductCockroachDB-1]
-	_ = x[ProductMySQL-2]
-	_ = x[ProductOracle-3]
-	_ = x[ProductPostgreSQL-4]
+	_ = x[ProductMariaDB-2]
+	_ = x[ProductMySQL-3]
+	_ = x[ProductOracle-4]
+	_ = x[ProductPostgreSQL-5]
 }
 
-const _Product_name = "UnknownCockroachDBMySQLOraclePostgreSQL"
+const _Product_name = "UnknownCockroachDBMariaDBMySQLOraclePostgreSQL"
 
-var _Product_index = [...]uint8{0, 7, 18, 23, 29, 39}
+var _Product_index = [...]uint8{0, 7, 18, 25, 30, 36, 46}
 
 func (i Product) String() string {
 	if i < 0 || i >= Product(len(_Product_index)-1) {

--- a/internal/types/product_test.go
+++ b/internal/types/product_test.go
@@ -71,6 +71,16 @@ func TestProductExpand(t *testing.T) {
 			product: ProductMySQL,
 			err:     "expecting exactly one schema part",
 		},
+		{
+			input:    ident.MustSchema(ident.New("foo")),
+			product:  ProductMariaDB,
+			expected: ident.MustSchema(ident.New("foo")),
+		},
+		{
+			input:   ident.MustSchema(ident.New("foo"), ident.New("bar")),
+			product: ProductMariaDB,
+			err:     "expecting exactly one schema part",
+		},
 	}
 
 	for idx, tc := range tcs {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -263,6 +263,7 @@ type Product int
 const (
 	ProductUnknown Product = iota
 	ProductCockroachDB
+	ProductMariaDB
 	ProductMySQL
 	ProductOracle
 	ProductPostgreSQL
@@ -292,7 +293,7 @@ func (p Product) ExpandSchema(s ident.Schema) (ident.Schema, error) {
 			return ident.Schema{}, errors.Errorf("unexpected number of schema parts: %d", numParts)
 		}
 
-	case ProductMySQL, ProductOracle:
+	case ProductMySQL, ProductMariaDB, ProductOracle:
 		if numParts != 1 {
 			return ident.Schema{}, errors.Errorf("expecting exactly one schema part, had %d", numParts)
 		}

--- a/internal/util/stdpool/my.go
+++ b/internal/util/stdpool/my.go
@@ -23,6 +23,7 @@ import (
 	sqldriver "database/sql/driver"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
@@ -88,6 +89,9 @@ func OpenMySQLAsTarget(
 
 		if err := ret.QueryRow("SELECT VERSION();").Scan(&ret.Version); err != nil {
 			return nil, errors.Wrap(err, "could not query version")
+		}
+		if strings.Contains(ret.Version, "MariaDB") {
+			ret.PoolInfo.Product = types.ProductMariaDB
 		}
 		var mode string
 		if err := ret.QueryRow("SELECT @@sql_mode").Scan(&mode); err != nil {


### PR DESCRIPTION
Adding a new product type to handle the differences between MySQL and MariaDB.
    
Summary of differences:
    
- JSON type is a synonym for longtext with check constraint. The code to get schema information is now specific to MariaDB to correctly detect JSON columns.
- Spatial information in the apply_test requires custom handling.
- Default expressions are stored in a different format than mySQL in the information schema. For instance, absence of a default expression is represented by a 'NULL' string rather that a NULL value

Fixes #552 .

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/551)
<!-- Reviewable:end -->
