### PR TITLE
script: Fix race condition and missing Before in UserScript

### DIFF
--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/dop251/goja"
 	esbuild "github.com/evanw/esbuild/pkg/api"
@@ -114,6 +115,7 @@ type Loader struct {
 	requireStack []*url.URL            // Allows relative import paths.
 	requireCache map[string]goja.Value // Keys are URLs.
 	rt           *goja.Runtime         // JS Runtime.
+	rtMu         *sync.Mutex           // Serialize access to the VM.
 	sources      map[string]*sourceJS  // User configuration.
 	targets      map[string]*targetJS  // User configuration.
 }

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -19,6 +19,7 @@ package script
 import (
 	"context"
 	"net/url"
+	"sync"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
@@ -65,6 +66,7 @@ func ProvideLoader(cfg *Config) (*Loader, error) {
 		options:      options,
 		requireCache: make(map[string]goja.Value),
 		rt:           goja.New(),
+		rtMu:         &sync.Mutex{},
 		sources:      make(map[string]*sourceJS),
 		targets:      make(map[string]*targetJS),
 	}
@@ -140,6 +142,7 @@ func ProvideUserScript(
 		Sources: &ident.Map[*Source]{},
 		Targets: &ident.TableMap[*Target]{},
 		rt:      boot.rt,
+		rtMu:    boot.rtMu,
 		target:  target.AsSchema(),
 		watcher: watcher,
 	}

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -97,18 +97,21 @@ func TestScript(t *testing.T) {
 
 	if cfg := s.Sources.GetZero(ident.New("expander")); a.NotNil(cfg) {
 		a.Equal(tbl1, cfg.DeletesTo)
-		mut := types.Mutation{Data: []byte(`{"msg":true}`)}
+		mut := types.Mutation{Before: []byte(`{"before":true}`), Data: []byte(`{"msg":true}`)}
 		mapped, err := cfg.Dispatch(context.Background(), mut)
 		if a.NoError(err) && a.NotNil(mapped) {
 			if docs := mapped.GetZero(tbl1); a.Len(docs, 1) {
+				a.Equal(`{"before":true}`, string(docs[0].Before))
 				a.Equal(`{"dest":"table1","msg":true}`, string(docs[0].Data))
 				a.Equal(`[true]`, string(docs[0].Key))
 			}
 
 			if docs := mapped.GetZero(tbl2); a.Len(docs, 2) {
+				a.Equal(`{"before":true}`, string(docs[0].Before))
 				a.Equal(`{"dest":"table2","idx":0,"msg":true}`, string(docs[0].Data))
 				a.Equal(`[0]`, string(docs[0].Key))
 
+				a.Equal(`{"before":true}`, string(docs[1].Before))
 				a.Equal(`{"dest":"table2","idx":1,"msg":true}`, string(docs[1].Data))
 				a.Equal(`[1]`, string(docs[1].Key))
 			}


### PR DESCRIPTION
This change fixes two bugs in the script package. Firstly, if the `script.Evaluate()` function is called more than once (as it is when multiple logical loops are started), the UserScript instances that are created share a common goja.Runtime object, but have separate mutexes to guard access to the runtime. This changes the script loader (which constructs the Runtime) to also allocate a shared mutex which is passed to the derived UserScript instance(s).

There is also a small fix to `bindMap()` where a mutation's Before field was not being propagated. A test is added to verify the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/566)
<!-- Reviewable:end -->
