### PR TITLE
stage: Track applied mutations in staging tables

### DIFF
--- a/internal/source/cdc/config.go
+++ b/internal/source/cdc/config.go
@@ -27,10 +27,12 @@ import (
 )
 
 const (
-	defaultBackupPolling   = 100 * time.Millisecond
-	defaultFlushBatchSize  = 1_000
-	defaultSelectBatchSize = 10_000
-	defaultNDJsonBuffer    = bufio.MaxScanTokenSize // 64k
+	defaultBackupPolling         = 100 * time.Millisecond
+	defaultIdealBatchSize        = 1000
+	defaultMetaTable             = "resolved_timestamps"
+	defaultLargeTransactionLimit = 0                      // Opt into reduced consistency.
+	defaultNDJsonBuffer          = bufio.MaxScanTokenSize // 64k
+	defaultTimestampWindowSize   = 1000
 )
 
 // Config adds CDC-specific configuration to the core logical loop.
@@ -43,27 +45,31 @@ type Config struct {
 	// timestamps will receive the incoming resolved-timestamp message.
 	BackupPolling time.Duration
 
-	// Don't coalesce updates from different source MVCC timestamps into
-	// a single destination transaction. Setting this will preserve the
-	// original structure of updates from the source, but may decrease
-	// overall throughput by increasing the total number of target
-	// database transactions.
+	// If true, the resolver loop will behave as though
+	// TimestampWindowSize has been set to 1.  That is, each unique
+	// timestamp within a resolved-timestamp window will be processed,
+	// instead of fast-forwarding to the latest values within a batch.
+	// This flag is relevant for use-cases that employ a merge function
+	// which must see every incremental update in order to produce a
+	// meaningful result.
 	FlushEveryTimestamp bool
 
-	// Coalesce timestamps within a resolved-timestamp window until
-	// at least this many mutations have been collected.
+	// This setting controls a soft maximum on the number of rows that
+	// will be flushed in one target transaction.
 	IdealFlushBatchSize int
+
+	// If non-zero and the number of rows in a single timestamp exceeds
+	// this value, allow that source transaction to be applied over
+	// multiple target transactions.
+	LargeTransactionLimit int
+
+	// The name of the resolved_timestamps table.
+	MetaTableName ident.Ident
 
 	// The maximum amount of data to buffer when reading a single line
 	// of ndjson input. This can be increased if the source cluster
 	// has large blob values.
 	NDJsonBuffer int
-
-	// The name of the resolved_timestamps table.
-	MetaTableName ident.Ident
-
-	// The number of rows to retrieve when loading staged data.
-	SelectBatchSize int
 
 	// Retain staged, applied data for an extra amount of time. This
 	// allows, for example, additional time to validate what was staged
@@ -71,6 +77,13 @@ type Config struct {
 	// be retired as soon as there is a resolved timestamp greater than
 	// the timestamp of the mutation.
 	RetireOffset time.Duration
+
+	// The maximum number of source transactions to unstage at once.
+	// This does not place a hard limit on the number of mutations that
+	// may be dequeued at once, but it does reduce the total number of
+	// round-trips to the staging database when the average transaction
+	// size is small.
+	TimestampWindowSize int
 }
 
 // Bind adds configuration flags to the set.
@@ -80,19 +93,27 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	f.DurationVar(&c.BackupPolling, "backupPolling", defaultBackupPolling,
 		"poll for resolved timestamps from other instances of cdc-sink")
 	f.BoolVar(&c.FlushEveryTimestamp, "flushEveryTimestamp", false,
-		"preserve intermediate updates from the source in transactional mode; "+
+		"don't fast-forward to the latest row values within a resolved timestamp; "+
 			"may negatively impact throughput")
-	f.IntVar(&c.IdealFlushBatchSize, "idealFlushBatchSize", defaultFlushBatchSize,
-		"try to apply at least this many mutations per resolved-timestamp window")
+	f.IntVar(&c.IdealFlushBatchSize, "idealFlushBatchSize", defaultIdealBatchSize,
+		"a soft limit on the number of rows to send to the target at once")
+	f.IntVar(&c.LargeTransactionLimit, "largeTransactionLimit", defaultLargeTransactionLimit,
+		"if non-zero, all source transactions with more than this "+
+			"number of rows may be applied in multiple target transactions")
 	f.IntVar(&c.NDJsonBuffer, "ndjsonBufferSize", defaultNDJsonBuffer,
 		"the maximum amount of data to buffer while reading a single line of ndjson input; "+
 			"increase when source cluster has large blob values")
-	f.Var(ident.NewValue("resolved_timestamps", &c.MetaTableName), "metaTable",
+	f.Var(ident.NewValue(defaultMetaTable, &c.MetaTableName), "metaTable",
 		"the name of the table in which to store resolved timestamps")
-	f.IntVar(&c.SelectBatchSize, "selectBatchSize", defaultSelectBatchSize,
-		"the number of rows to select at once when reading staged data")
 	f.DurationVar(&c.RetireOffset, "retireOffset", 0,
-		"retain staged, applied data for an extra duration")
+		"if non-zero, retain staged, applied data for an extra duration")
+	f.IntVar(&c.TimestampWindowSize, "timestampWindowSize", defaultTimestampWindowSize,
+		"the maximum number of source transaction timestamps to unstage at once")
+
+	var deprecated int
+	const msg = "replaced by --largeTransactionLimit and --timestampWindowSize"
+	f.IntVar(&deprecated, "selectBatchSize", 0, "")
+	_ = f.MarkDeprecated("selectBatchSize", msg)
 }
 
 // Preflight implements logical.Config.
@@ -105,19 +126,25 @@ func (c *Config) Preflight() error {
 		c.BackupPolling = defaultBackupPolling
 	}
 	if c.IdealFlushBatchSize == 0 {
-		c.IdealFlushBatchSize = defaultFlushBatchSize
+		c.IdealFlushBatchSize = defaultIdealBatchSize
+	}
+	// Zero is legal; implies no limit.
+	if c.LargeTransactionLimit < 0 {
+		return errors.New("largeTransactionLimit must be >= 0")
 	}
 	if c.NDJsonBuffer == 0 {
 		c.NDJsonBuffer = defaultNDJsonBuffer
 	}
 	if c.MetaTableName.Empty() {
-		return errors.New("no metadata table specified")
-	}
-	if c.SelectBatchSize == 0 {
-		c.SelectBatchSize = defaultSelectBatchSize
+		c.MetaTableName = ident.New(defaultMetaTable)
 	}
 	if c.RetireOffset < 0 {
 		return errors.New("retireOffset must be >= 0")
+	}
+	if c.TimestampWindowSize < 0 {
+		return errors.New("timestampWindowSize must be >= 0")
+	} else if c.TimestampWindowSize == 0 {
+		c.TimestampWindowSize = defaultTimestampWindowSize
 	}
 
 	return nil

--- a/internal/source/cdc/resolver.go
+++ b/internal/source/cdc/resolver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
 	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/jackc/pgx/v5"
@@ -163,18 +164,18 @@ func (r *resolver) Mark(ctx context.Context, ts hlc.Time) error {
 func (r *resolver) BackfillInto(
 	ctx context.Context, ch chan<- logical.Message, state logical.State,
 ) error {
-	return r.readInto(ctx, ch, state, true)
+	return r.readInto(ctx, ch, state)
 }
 
 // ReadInto implements logical.Dialect.
 func (r *resolver) ReadInto(
 	ctx context.Context, ch chan<- logical.Message, state logical.State,
 ) error {
-	return r.readInto(ctx, ch, state, false)
+	return r.readInto(ctx, ch, state)
 }
 
 func (r *resolver) readInto(
-	ctx context.Context, ch chan<- logical.Message, state logical.State, backfill bool,
+	ctx context.Context, ch chan<- logical.Message, state logical.State,
 ) error {
 	// This will either be from a previous iteration or ZeroStamp.
 	cp, cpUpdated := state.GetConsistentPoint()
@@ -210,7 +211,7 @@ func (r *resolver) readInto(
 			} else {
 				// We're looping around with a committed timestamp, so
 				// look for work to do and send it.
-				proposed, err := r.nextProposedStamp(ctx, resumeFrom, backfill)
+				proposed, err := r.nextProposedStamp(ctx, resumeFrom)
 				switch {
 				case err == nil:
 					log.WithFields(log.Fields{
@@ -285,7 +286,7 @@ func (r *resolver) readInto(
 // may be one of the sentinel values errNoWork or errBlocked that are
 // returned by selectTimestamp.
 func (r *resolver) nextProposedStamp(
-	ctx context.Context, prev *resolvedStamp, backfill bool,
+	ctx context.Context, prev *resolvedStamp,
 ) (*resolvedStamp, error) {
 	// Find the next resolved timestamp to apply, starting from
 	// a timestamp known to be committed.
@@ -298,11 +299,6 @@ func (r *resolver) nextProposedStamp(
 	ret, err := prev.NewProposed(nextResolved)
 	if err != nil {
 		return nil, err
-	}
-
-	// Propagate the backfilling flag.
-	if backfill {
-		ret.Backfill = true
 	}
 
 	return ret, nil
@@ -352,8 +348,7 @@ func (r *resolver) ZeroStamp() stamp.Stamp {
 }
 
 // process makes incremental progress in fulfilling the given
-// resolvedStamp. It returns the state to which the resolved timestamp
-// has been advanced.
+// resolvedStamp.
 func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logical.Events) error {
 	start := time.Now()
 	targets := r.watcher.Get().Order
@@ -362,69 +357,60 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 		return errors.Errorf("no tables known in schema %s; have they been created?", r.target)
 	}
 
-	cursor := &types.SelectManyCursor{
-		Backfill:    rs.Backfill,
-		End:         rs.ProposedTime,
-		Limit:       r.cfg.SelectBatchSize,
-		OffsetKey:   rs.OffsetKey,
-		OffsetTable: rs.OffsetTable,
-		OffsetTime:  rs.OffsetTime,
-		Start:       rs.CommittedTime,
-		Targets:     targets,
+	flattened := make([]ident.Table, 0, len(targets))
+	for _, tgts := range targets {
+		flattened = append(flattened, tgts...)
 	}
 
-	source := script.SourceName(r.target)
-	flush := func(toApply *ident.TableMap[[]types.Mutation], final bool) error {
+	cursor := &types.UnstageCursor{
+		StartAt:        rs.CommittedTime,
+		EndBefore:      rs.ProposedTime,
+		Targets:        flattened,
+		TimestampLimit: r.cfg.TimestampWindowSize,
+		UpdateLimit:    r.cfg.LargeTransactionLimit,
+	}
+	if rs.LargeBatchOffset != nil && rs.LargeBatchOffset.Len() > 0 {
+		rs.LargeBatchOffset.CopyInto(&cursor.StartAfterKey)
+	}
+
+	flush := func(toApply *ident.TableMap[[]types.Mutation]) error {
 		flushStart := time.Now()
 
 		ctx, cancel := context.WithTimeout(ctx, r.cfg.ApplyTimeout)
 		defer cancel()
 
-		// Apply the retrieved data.
-		batch, err := events.OnBegin(ctx)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = batch.OnRollback(ctx) }()
-
-		for _, tables := range targets {
-			for _, table := range tables {
-				muts := toApply.GetZero(table)
-				if len(muts) == 0 {
-					continue
-				}
-				if err := batch.OnData(ctx, source, table, muts); err != nil {
-					return err
-				}
-			}
-		}
-
-		// OnCommit is asynchronous to support (a future)
-		// unified-immediate mode. We'll wait for the data to be
-		// committed.
-		select {
-		case err := <-batch.OnCommit(ctx):
+		if err := retry.Retry(ctx, func(ctx context.Context) error {
+			// Apply the retrieved data.
+			batch, err := events.OnBegin(ctx)
 			if err != nil {
 				return err
 			}
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+			defer func() { _ = batch.OnRollback(ctx) }()
 
-		// Advance and save the stamp once the flush has completed.
-		if final {
-			rs, err = rs.NewCommitted()
-			if err != nil {
-				return err
+			for _, tables := range targets {
+				for _, table := range tables {
+					muts := toApply.GetZero(table)
+					if len(muts) == 0 {
+						continue
+					}
+					source := script.SourceName(r.target)
+					muts = append([]types.Mutation(nil), muts...)
+					if err := batch.OnData(ctx, source, table, muts); err != nil {
+						return err
+					}
+				}
 			}
-			// Mark the timestamp has being processed.
-			if err := r.Record(ctx, rs.CommittedTime); err != nil {
+
+			// OnCommit is asynchronous to support (a future)
+			// unified-immediate mode. We'll wait for the data to be
+			// committed.
+			select {
+			case err := <-batch.OnCommit(ctx):
 				return err
+			case <-ctx.Done():
+				return ctx.Err()
 			}
-		} else {
-			rs = rs.NewProgress(cursor)
-		}
-		if err := events.SetConsistentPoint(ctx, rs); err != nil {
+		}); err != nil {
 			return err
 		}
 
@@ -436,61 +422,124 @@ func (r *resolver) process(ctx context.Context, rs *resolvedStamp, events logica
 		return nil
 	}
 
-	var epoch hlc.Time
-	flushCounter := 0
-	toApply := &ident.TableMap[[]types.Mutation]{}
-	total := 0
-	if err := r.stagers.SelectMany(ctx, r.pool, cursor,
-		func(ctx context.Context, tbl ident.Table, mut types.Mutation) error {
-			// Check for flush before accumulating.
-			var needsFlush bool
-			if rs.Backfill {
-				// We're receiving data in table-order. Just read data
-				// and flush it once we hit our soft limit, since we
-				// can resume at any point.
-				needsFlush = flushCounter >= r.cfg.IdealFlushBatchSize
-			} else if r.cfg.FlushEveryTimestamp {
-				// The user wants to preserve all intermediate updates
-				// to a row, rather than fast-forwarding the values of a
-				// row to the latest transactionally-consistent state.
-				// We'll flush on every MVCC boundary change.
-				needsFlush = epoch != hlc.Zero() && hlc.Compare(mut.Time, epoch) > 0
-			} else {
-				// We're receiving data ordered by MVCC timestamp. Flush
-				// data when we see a new epoch after accumulating a
-				// minimum number of mutations. This increases
-				// throughput when there are many single-row
-				// transactions in the source database.
-				needsFlush = flushCounter >= r.cfg.IdealFlushBatchSize &&
-					hlc.Compare(mut.Time, epoch) > 0
+	total := 0 // Reported in logging at the bottom of this method.
+
+	// We run in a loop until the attempt to unstage returns no more
+	// data (i.e. we've consumed all mutations within the resolving
+	// window). If a LargeBatchLimit is configured, we may wind up
+	// calling flush() several times within a particularly large MVCC
+	// timestamp.
+	for hadData := true; hadData; {
+		if err := retry.Retry(ctx, func(ctx context.Context) error {
+			unstageTX, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+			if err != nil {
+				return errors.Wrap(err, "could not open staging transaction")
 			}
-			if needsFlush {
-				if err := flush(toApply, false /* interim */); err != nil {
-					return err
-				}
-				total += flushCounter
-				flushCounter = 0
-				// Reset the slices in toApply; flush() ignores zero-length entries.
-				_ = toApply.Range(func(tbl ident.Table, muts []types.Mutation) error {
-					toApply.Put(tbl, muts[:0])
+			defer func() { _ = unstageTX.Rollback(ctx) }()
+
+			var epoch hlc.Time
+			var nextCursor *types.UnstageCursor
+			pendingMutations := 0
+			toApply := &ident.TableMap[[]types.Mutation]{}
+
+			nextCursor, hadData, err = r.stagers.Unstage(ctx, unstageTX, cursor,
+				func(ctx context.Context, tbl ident.Table, mut types.Mutation) error {
+					total++
+
+					// Decorate the mutation.
+					script.AddMeta("cdc", tbl, &mut)
+
+					if epoch == hlc.Zero() {
+						epoch = mut.Time
+					} else if r.cfg.FlushEveryTimestamp ||
+						pendingMutations >= r.cfg.IdealFlushBatchSize {
+						// If the user wants to see all intermediate
+						// values for a row, we'll flush whenever
+						// there's a change in the timestamp value. We
+						// may also preemptively flush to prevent
+						// unbounded memory use.
+						if hlc.Compare(mut.Time, epoch) > 0 {
+							if err := flush(toApply); err != nil {
+								return err
+							}
+							epoch = mut.Time
+							pendingMutations = 0
+							toApply = &ident.TableMap[[]types.Mutation]{}
+						}
+					} else if hlc.Compare(mut.Time, epoch) < 0 {
+						// This would imply a coding error in Unstage.
+						return errors.New("epoch going backwards")
+					}
+
+					// Accumulate the mutation.
+					toApply.Put(tbl, append(toApply.GetZero(tbl), mut))
+					pendingMutations++
 					return nil
 				})
+			if err != nil {
+				return errors.Wrap(err, "could not unstage mutations")
 			}
 
-			flushCounter++
-			script.AddMeta("cdc", tbl, &mut)
-			toApply.Put(tbl, append(toApply.GetZero(tbl), mut))
-			epoch = mut.Time
+			if hadData {
+				// Final flush of the data that was unstaged. It's
+				// possible, although unlikely, that the final callback
+				// from Unstage performed a flush. If this were to
+				// happen, we don't want to perform a no-work flush.
+				if pendingMutations > 0 {
+					if err := flush(toApply); err != nil {
+						return err
+					}
+				}
+
+				// Commit the transaction that unstaged the data. Note that
+				// without an X/A transaction model, there's always a
+				// possibility where we've committed the target transaction
+				// and then the unstaging transaction fails to commit. In
+				// general, we expect that re-applying a mutation within a
+				// short timeframe should be idempotent, although this might
+				// not necessarily be the case for data-aware merge
+				// functions in the absence of conflict-free datatypes. We
+				// could choose to keep a manifest of (table, key,
+				// timestamp) entries in the target database to filter
+				// repeated updates.
+				// https://github.com/cockroachdb/cdc-sink/issues/565
+				if err := unstageTX.Commit(ctx); err != nil {
+					return errors.Wrap(err, "could not commit unstaging transaction; "+
+						"mutations may be reapplied")
+				}
+
+				// If we're going to continue around, update the
+				// consistent point with partial progress. This ensures
+				// that cdc-sink can make progress on large batches,
+				// even if it's restarted.
+				cursor = nextCursor
+				rs = rs.NewProgress(cursor)
+			} else {
+				// We read no data, which means that we're done. We'll
+				// let the unstaging transaction be rolled back by the
+				// defer above since it performed no actual work in the
+				// database.
+				rs, err = rs.NewCommitted()
+				if err != nil {
+					return err
+				}
+				// Mark the timestamp has being processed.
+				if err := r.Record(ctx, rs.CommittedTime); err != nil {
+					return err
+				}
+			}
+
+			// Save the consistent point to be able to resume if the
+			// cdc-sink process is stopped.
+			if err := events.SetConsistentPoint(ctx, rs); err != nil {
+				return err
+			}
 			return nil
 		}); err != nil {
-		return err
+			return err
+		}
 	}
 
-	// Final flush cycle to commit the final stamp.
-	if err := flush(toApply, true /* final */); err != nil {
-		return err
-	}
-	total += flushCounter
 	log.WithFields(log.Fields{
 		"committed": rs.CommittedTime,
 		"count":     total,

--- a/internal/staging/stage/metrics.go
+++ b/internal/staging/stage/metrics.go
@@ -32,7 +32,6 @@ var (
 		Name: "stage_retire_errors_total",
 		Help: "the number of times an error was encountered while retiring mutations",
 	}, metrics.TableLabels)
-
 	stageSelectCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "stage_select_mutations_total",
 		Help: "the number of mutations read for this table",
@@ -46,7 +45,10 @@ var (
 		Name: "stage_select_errors_total",
 		Help: "the number of times an error was encountered while selecting mutations",
 	}, metrics.TableLabels)
-
+	stageStaleMutations = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stage_stale_mutations_count",
+		Help: "the number of un-applied staged mutations left after retiring applied mutations",
+	}, metrics.TableLabels)
 	stageStoreCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "stage_store_mutations_total",
 		Help: "the number of mutations stored for this table",

--- a/internal/staging/stage/queries/unstage.tmpl
+++ b/internal/staging/stage/queries/unstage.tmpl
@@ -1,0 +1,107 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/staging/stage.templateData*/ -}}
+{{- $top := . -}}
+WITH {{- sp -}}
+
+{{- /*
+Select the minimum unapplied timestamp(s) from the source table.
+
+We start scanning at some timestamp, but after a starting key, which
+could be a zero-length string.
+
+hlc_0 AS (
+  SELECT nanos, logical FROM staging_table
+  WHERE (nanos, logical, key) > (start_at_nanos, start_at_logical, start_after_key)
+  AND (nanos, locical) < (end_before_nanos, end_before_logical)
+  AND NOT APPLIED
+  GROUP BY nanos, logical -- We want multi-column distinct behavior
+  ORDER BY nanos, logical
+  LIMIT N
+)
+
+*/ -}}
+{{- range  $idx, $tgt := .Cursor.Targets -}}
+{{- if $idx -}}, {{- nl -}}{{- end -}}
+hlc_{{ $idx }} (n, l) AS (
+SELECT nanos, logical
+FROM {{ $top.StagingTable $tgt }}
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[ {{- add $idx 1 -}} ])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT {{ or $top.Cursor.TimestampLimit 1 }}
+)
+{{- end -}}
+
+{{- /*
+Select the minimum timestamp(s) across all source tables.
+
+hlc_all AS (
+  SELECT n, l FROM hlc_0 UNION ALL
+  SELECT n, l FROM hlc_1 UNION ALL ...
+  SELECT n, l FROM hlc_N
+),
+hlc_min AS (SELECT n, l FROM hlc_all GROUY BY n, l ORDER BY n, l LIMIT N)
+
+*/ -}}
+, {{- nl -}}
+hlc_all AS (
+{{- range $idx, $tgt := .Cursor.Targets -}}
+{{- if $idx }} UNION ALL {{- nl -}}{{- end -}}
+SELECT n, l FROM hlc_{{ $idx }}
+{{- end -}}
+),
+hlc_min AS (SELECT n, l FROM hlc_all GROUP BY n, l ORDER BY n, l LIMIT {{ or .Cursor.TimestampLimit 1 }})
+
+{{- /*
+Set the applied column and return the data.
+
+We want to update any non-applied mutations after the starting key
+and within the HLC timestamp that we're operating on.
+
+data_0 AS (
+  UPDATE staging_table SET applied=true
+  FROM hlc_min
+  WHERE (nanos, logical) IN (hlc_min)
+    AND (nanos, logical, key) > (start_at_nanos, start_at_logical, start_after_key)
+    AND NOT APPLIED
+  [ ORDER BY nanos, logical, key
+    LIMIT n ]
+  RETURNING nanos, logical, key, mut, before
+)
+*/ -}}
+{{- range $idx, $tgt := .Cursor.Targets -}}
+, {{- nl -}}
+data_{{ $idx }} AS (
+UPDATE {{ $top.StagingTable $tgt }}
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[ {{- add $idx 1 -}} ])
+AND NOT applied
+{{- if $top.Cursor.UpdateLimit -}} {{- nl -}}
+ORDER BY nanos, logical, key
+LIMIT {{ $top.Cursor.UpdateLimit }}
+{{- end -}}
+{{- nl -}} RETURNING nanos, logical, key, mut, before)
+{{- end -}}
+{{- nl -}}
+
+{{- /*
+Top-level query aggregates the updates in table order.
+
+SELECT 0 idx, * FROM data_0 UNION ALL
+SELECT 1 idx, * FROM data_1 UNION ALL ...
+SELECT N idx, * FROM data_N
+ORDER BY nanos, logical, idx, key
+
+*/ -}}
+SELECT * FROM ( {{- nl -}}
+{{- range $idx, $tgt := .Cursor.Targets -}}
+{{- if $idx }} UNION ALL {{- nl -}}{{- end -}}
+SELECT {{ $idx }} idx, nanos, logical, key, mut, before FROM data_{{ $idx }}
+{{- end -}}
+) {{- nl -}}
+ORDER BY nanos, logical, idx, key
+
+{{- /* Consume whitespace */ -}}

--- a/internal/staging/stage/templates.go
+++ b/internal/staging/stage/templates.go
@@ -1,0 +1,59 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stage
+
+import (
+	"embed"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+//go:embed queries/*.tmpl
+var templateFS embed.FS
+
+var (
+	tmplFuncs = template.FuncMap{
+		"add": func(a, b int) int { return a + b },
+		"nl":  func() string { return "\n" },
+		"sp":  func() string { return " " },
+	}
+	templates = template.Must(
+		template.New("").Funcs(tmplFuncs).ParseFS(templateFS, "queries/*.tmpl"))
+	unstage = templates.Lookup("unstage.tmpl")
+)
+
+type templateData struct {
+	Cursor        *types.UnstageCursor // Required input.
+	StagingSchema ident.Schema         // Required input.
+}
+
+func (d *templateData) Eval() (string, error) {
+	var sb strings.Builder
+	err := unstage.Execute(&sb, d)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return sb.String(), nil
+}
+
+func (d *templateData) StagingTable(tbl ident.Table) ident.Table {
+	return stagingTable(d.StagingSchema, tbl)
+}

--- a/internal/staging/stage/templates_test.go
+++ b/internal/staging/stage/templates_test.go
@@ -1,0 +1,94 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+const rewriteExpcted = false
+
+func TestRewriteIsFalse(t *testing.T) {
+	require.False(t, rewriteExpcted)
+}
+
+func TestTimeOrderTemplate(t *testing.T) {
+	r := require.New(t)
+
+	r.NotNil(unstage)
+
+	sch := ident.MustSchema(ident.New("my_db"), ident.Public)
+	tbl0 := ident.NewTable(sch, ident.New("tbl0"))
+	tbl1 := ident.NewTable(sch, ident.New("tbl1"))
+	tbl2 := ident.NewTable(sch, ident.New("tbl2"))
+	tbl3 := ident.NewTable(sch, ident.New("tbl3"))
+
+	staging := ident.MustSchema(ident.New("_cdc_sink"), ident.Public)
+
+	tcs := []struct {
+		name   string
+		cursor *types.UnstageCursor
+	}{
+		{
+			name: "unstage",
+			cursor: &types.UnstageCursor{
+				StartAt:   hlc.New(1, 2),
+				EndBefore: hlc.New(3, 4),
+				Targets:   []ident.Table{tbl0, tbl1, tbl2, tbl3},
+			},
+		},
+		{
+			name: "unstage_limit",
+			cursor: &types.UnstageCursor{
+				StartAt:        hlc.New(1, 2),
+				EndBefore:      hlc.New(3, 4),
+				TimestampLimit: 22,
+				Targets:        []ident.Table{tbl0, tbl1, tbl2, tbl3},
+				UpdateLimit:    10000,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			data := &templateData{
+				Cursor:        tc.cursor,
+				StagingSchema: staging,
+			}
+
+			out, err := data.Eval()
+			r.NoError(err)
+
+			filename := fmt.Sprintf("./testdata/%s.sql", tc.name)
+			if rewriteExpcted {
+				r.NoError(os.WriteFile(filename, []byte(out), 0644))
+			} else {
+				data, err := os.ReadFile(filename)
+				r.NoError(err)
+				r.Equal(string(data), out)
+			}
+		})
+	}
+}

--- a/internal/staging/stage/testdata/unstage.sql
+++ b/internal/staging/stage/testdata/unstage.sql
@@ -1,0 +1,83 @@
+WITH hlc_0 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl0"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[1])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 1
+),
+hlc_1 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl1"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[2])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 1
+),
+hlc_2 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl2"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[3])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 1
+),
+hlc_3 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl3"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[4])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 1
+),
+hlc_all AS (SELECT n, l FROM hlc_0 UNION ALL
+SELECT n, l FROM hlc_1 UNION ALL
+SELECT n, l FROM hlc_2 UNION ALL
+SELECT n, l FROM hlc_3),
+hlc_min AS (SELECT n, l FROM hlc_all GROUP BY n, l ORDER BY n, l LIMIT 1),
+data_0 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[1])
+AND NOT applied
+RETURNING nanos, logical, key, mut, before),
+data_1 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[2])
+AND NOT applied
+RETURNING nanos, logical, key, mut, before),
+data_2 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[3])
+AND NOT applied
+RETURNING nanos, logical, key, mut, before),
+data_3 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[4])
+AND NOT applied
+RETURNING nanos, logical, key, mut, before)
+SELECT * FROM (
+SELECT 0 idx, nanos, logical, key, mut, before FROM data_0 UNION ALL
+SELECT 1 idx, nanos, logical, key, mut, before FROM data_1 UNION ALL
+SELECT 2 idx, nanos, logical, key, mut, before FROM data_2 UNION ALL
+SELECT 3 idx, nanos, logical, key, mut, before FROM data_3)
+ORDER BY nanos, logical, idx, key

--- a/internal/staging/stage/testdata/unstage_limit.sql
+++ b/internal/staging/stage/testdata/unstage_limit.sql
@@ -1,0 +1,91 @@
+WITH hlc_0 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl0"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[1])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 22
+),
+hlc_1 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl1"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[2])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 22
+),
+hlc_2 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl2"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[3])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 22
+),
+hlc_3 (n, l) AS (
+SELECT nanos, logical
+FROM "_cdc_sink"."public"."my_db_public_tbl3"
+WHERE (nanos, logical, key) > ($1, $2, ($5::STRING[])[4])
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+GROUP BY nanos, logical
+ORDER BY nanos, logical
+LIMIT 22
+),
+hlc_all AS (SELECT n, l FROM hlc_0 UNION ALL
+SELECT n, l FROM hlc_1 UNION ALL
+SELECT n, l FROM hlc_2 UNION ALL
+SELECT n, l FROM hlc_3),
+hlc_min AS (SELECT n, l FROM hlc_all GROUP BY n, l ORDER BY n, l LIMIT 22),
+data_0 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[1])
+AND NOT applied
+ORDER BY nanos, logical, key
+LIMIT 10000
+RETURNING nanos, logical, key, mut, before),
+data_1 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[2])
+AND NOT applied
+ORDER BY nanos, logical, key
+LIMIT 10000
+RETURNING nanos, logical, key, mut, before),
+data_2 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[3])
+AND NOT applied
+ORDER BY nanos, logical, key
+LIMIT 10000
+RETURNING nanos, logical, key, mut, before),
+data_3 AS (
+UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
+SET applied=true
+FROM hlc_min
+WHERE (nanos,logical) = (n, l)
+AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[4])
+AND NOT applied
+ORDER BY nanos, logical, key
+LIMIT 10000
+RETURNING nanos, logical, key, mut, before)
+SELECT * FROM (
+SELECT 0 idx, nanos, logical, key, mut, before FROM data_0 UNION ALL
+SELECT 1 idx, nanos, logical, key, mut, before FROM data_1 UNION ALL
+SELECT 2 idx, nanos, logical, key, mut, before FROM data_2 UNION ALL
+SELECT 3 idx, nanos, logical, key, mut, before FROM data_3)
+ORDER BY nanos, logical, idx, key

--- a/internal/staging/version/versions.go
+++ b/internal/staging/version/versions.go
@@ -41,6 +41,7 @@ import (
 var Versions = []Version{
 	{"Add versions table", 400},
 	{"Support single-level schema namespaces", 389},
+	{"Track applied in staging table", 572},
 }
 
 // A Version describes a breaking change in the cdc-sink metadata

--- a/migrations/pr_572.md
+++ b/migrations/pr_572.md
@@ -1,0 +1,40 @@
+# PR 572 Track Applied Mutations
+
+[PR 572](https://github.com/cockroachdb/cdc-sink/pull/572)
+
+Breaking schema change:
+
+Each staging table gains a new `applied` column which cdc-sink will use
+to suppress duplicate updates during process restarts. The resolver loop
+continues to save resolved-timestamp checkpoints, but partial progress
+within a resolved-timestamp window is handled through the `applied`
+column.
+
+Migration:
+* Run the following `ALTER TABLE` command on each staging table before
+  upgrading cdc-sink:
+
+```sql
+ALTER TABLE _cdc_sink.my_db_public_my_table
+ADD COLUMN applied BOOL NOT NULL DEFAULT false
+  CREATE FAMILY hot,
+ADD COLUMN source_time TIMESTAMPTZ
+  AS (to_timestamp(nanos::float/1e9)) VIRTUAL; 
+```
+* Mark the migration as complete:
+```sql
+UPSERT INTO _cdc_sink.memo (key, value) VALUES ('version-572','{"state":"applied"}');
+```
+* Stop all instances of cdc-sink, upgrade, and restart.
+* cdc-sink will no longer delete un-applied mutations that may be before
+  the resolved-timestamp frontier. The mutations that were present
+  before the upgrade can either be manually deleted or marked as applied:
+
+```sql
+UPDATE _cdc_sink.my_db_public_my_table
+  SET applied = true
+WHERE nanos < (
+  SELECT max(source_nanos)
+  FROM _cdc_sink.resolved_timestamps
+  WHERE target_applied_at IS NOT NULL)
+```


### PR DESCRIPTION
This change moves tracking of partially-applied resolved timestamp windows into
the staging tables by adding a new `applied` column. The goal of this change is
to move some state-tracking out of the cdc resolver loop into the stage
package. Tracking apply status on a per-mutation basis improves idempotency of
cdc-sink when the userscript has non-idempotent behaviors (e.g.: three-way
merge). It also allows us to export monitoring data around mutations which may
have slipped through the cracks or to detect when a migration process has
completely drained. Fine-grained tracking will also be useful for unifying the
non-transactional modes into a single behavior.

Many unused methods in the stage API have been deleted. The "unstaging" SQL
query is now generated with a golang template and is tested similarly to the
apply package.

The cdc package performs less work to track partial application of large
individual changes. It just persists the contents of the UnstageCursor as a
performance enhancement. Exactly-once behavior is provided by the applied
column.

The change to `server/integration_test.go` is due to the unstage processing
being a one-shot. The test being performed duplicates an existing test in
`cdc/handler_test.go`.

Breaking change: The `--selectBatchSize` flag is deprecated in favor of two
different flags `--largeTransactionLimit` and `--timestampWindowSize` which,
respectively, enable partial processing of a single, over-sized transaction and
a general limit on the total amount of data to be unstaged.

Breaking change: A staging schema migraion is required, this is documented in
the migrations directory.

X-Ref: #487
X-Ref: #504
X-Ref: #565

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/572)
<!-- Reviewable:end -->
