### PR TITLE
wire: Make stopper.Context globally available

### DIFF
--- a/internal/cmd/fslogical/fslogical.go
+++ b/internal/cmd/fslogical/fslogical.go
@@ -21,6 +21,7 @@ package fslogical
 import (
 	"github.com/cockroachdb/cdc-sink/internal/source/fslogical"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,8 @@ func Command() *cobra.Command {
 		Bind:  cfg.Bind,
 		Short: "start a Google Cloud Firestore logical replication feed",
 		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return fslogical.Start(cmd.Context(), cfg)
+			// main.go provides this stopper.
+			return fslogical.Start(stopper.From(cmd.Context()), cfg)
 		},
 		Use: "fslogical",
 	})

--- a/internal/cmd/mylogical/mylogical.go
+++ b/internal/cmd/mylogical/mylogical.go
@@ -21,6 +21,7 @@ package mylogical
 import (
 	"github.com/cockroachdb/cdc-sink/internal/source/mylogical"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,8 @@ func Command() *cobra.Command {
 		Bind:  cfg.Bind,
 		Short: "start a mySQL replication feed",
 		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return mylogical.Start(cmd.Context(), cfg)
+			// main.go provides a stopper.
+			return mylogical.Start(stopper.From(cmd.Context()), cfg)
 		},
 		Use: "mylogical",
 	})

--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -21,6 +21,7 @@ package pglogical
 import (
 	"github.com/cockroachdb/cdc-sink/internal/source/pglogical"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,8 @@ func Command() *cobra.Command {
 		Bind:  cfg.Bind,
 		Short: "start a pg logical replication feed",
 		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return pglogical.Start(cmd.Context(), cfg)
+			// main.go provides a stopper.
+			return pglogical.Start(stopper.From(cmd.Context()), cfg)
 		},
 		Use: "pglogical",
 	})

--- a/internal/cmd/start/start.go
+++ b/internal/cmd/start/start.go
@@ -20,6 +20,7 @@ package start
 import (
 	"github.com/cockroachdb/cdc-sink/internal/source/server"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +31,8 @@ func Command() *cobra.Command {
 		Bind:  cfg.Bind,
 		Short: "start the server",
 		Start: func(cmd *cobra.Command) (any, func(), error) {
-			return server.NewServer(cmd.Context(), &cfg)
+			// main.go gives us a stopper, just unwrap it.
+			return server.NewServer(stopper.From(cmd.Context()), &cfg)
 		},
 		Use: "start",
 	})

--- a/internal/script/injector.go
+++ b/internal/script/injector.go
@@ -27,24 +27,29 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
 // Evaluate the loaded script.
 func Evaluate(
-	ctx context.Context,
+	ctx *stopper.Context,
 	loader *Loader,
 	configs *applycfg.Configs,
 	diags *diag.Diagnostics,
 	targetSchema TargetSchema,
 	watchers types.Watchers,
 ) (*UserScript, error) {
-	panic(wire.Build(ProvideUserScript))
+	panic(wire.Build(
+		ProvideUserScript,
+		wire.Bind(new(context.Context), new(*stopper.Context)),
+	))
 }
 
 func newScriptFromFixture(*all.Fixture, *Config, TargetSchema) (*UserScript, error) {
 	panic(wire.Build(
 		Set,
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.FieldsOf(new(*all.Fixture), "Diagnostics", "Fixture", "Configs", "Watchers"),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 	))

--- a/internal/script/wire_gen.go
+++ b/internal/script/wire_gen.go
@@ -7,11 +7,11 @@
 package script
 
 import (
-	"context"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 )
 
 import (
@@ -21,7 +21,7 @@ import (
 // Injectors from injector.go:
 
 // Evaluate the loaded script.
-func Evaluate(ctx context.Context, loader *Loader, configs *applycfg.Configs, diags *diag.Diagnostics, targetSchema TargetSchema, watchers types.Watchers) (*UserScript, error) {
+func Evaluate(ctx *stopper.Context, loader *Loader, configs *applycfg.Configs, diags *diag.Diagnostics, targetSchema TargetSchema, watchers types.Watchers) (*UserScript, error) {
 	userScript, err := ProvideUserScript(ctx, configs, loader, diags, targetSchema, watchers)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func Evaluate(ctx context.Context, loader *Loader, configs *applycfg.Configs, di
 
 func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema TargetSchema) (*UserScript, error) {
 	baseFixture := fixture.Fixture
-	contextContext := baseFixture.Context
+	context := baseFixture.Context
 	configs := fixture.Configs
 	loader, err := ProvideLoader(config)
 	if err != nil {
@@ -39,7 +39,7 @@ func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema Tar
 	}
 	diagnostics := fixture.Diagnostics
 	watchers := fixture.Watchers
-	userScript, err := ProvideUserScript(contextContext, configs, loader, diagnostics, targetSchema, watchers)
+	userScript, err := ProvideUserScript(context, configs, loader, diagnostics, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -23,10 +23,7 @@ import (
 // NewFixture constructs a self-contained test fixture for all services
 // in the target sub-packages.
 func NewFixture() (*Fixture, func(), error) {
-	context, cleanup, err := base.ProvideContext()
-	if err != nil {
-		return nil, nil, err
-	}
+	context, cleanup := base.ProvideContext()
 	diagnostics, cleanup2 := diag.New(context)
 	sourcePool, cleanup3, err := base.ProvideSourcePool(context, diagnostics)
 	if err != nil {
@@ -160,7 +157,7 @@ func NewFixture() (*Fixture, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	stagers := stage.ProvideFactory(stagingPool, stagingSchema)
+	stagers := stage.ProvideFactory(stagingPool, stagingSchema, context)
 	checker := version.ProvideChecker(stagingPool, memoMemo)
 	watcher, err := ProvideWatcher(context, targetSchema, watchers)
 	if err != nil {

--- a/internal/sinktest/base/wire_gen.go
+++ b/internal/sinktest/base/wire_gen.go
@@ -14,10 +14,7 @@ import (
 
 // NewFixture constructs a self-contained test fixture.
 func NewFixture() (*Fixture, func(), error) {
-	context, cleanup, err := ProvideContext()
-	if err != nil {
-		return nil, nil, err
-	}
+	context, cleanup := ProvideContext()
 	diagnostics, cleanup2 := diag.New(context)
 	sourcePool, cleanup3, err := ProvideSourcePool(context, diagnostics)
 	if err != nil {

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -20,6 +20,8 @@
 package cdc
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/leases"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
@@ -50,6 +53,7 @@ func newTestFixture(*all.Fixture, *Config) (*testFixture, func(), error) {
 		target.Set,
 		trust.New, // Is valid to use as a provider.
 		wire.Struct(new(testFixture), "*"),
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 	))
 }

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -121,7 +121,7 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(),
 	}
 	metaTable := ProvideMetaTable(config)
 	stagers := fixture.Stagers
-	resolvers, cleanup8, err := ProvideResolvers(context, config, typesLeases, factory, metaTable, stagingPool, stagers, watchers)
+	resolvers, err := ProvideResolvers(context, config, typesLeases, factory, metaTable, stagingPool, stagers, watchers)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -147,7 +147,6 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(),
 		Resolvers: resolvers,
 	}
 	return cdcTestFixture, func() {
-		cleanup8()
 		cleanup7()
 		cleanup6()
 		cleanup5()

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -29,13 +29,15 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(context.Context, *Config) (*FSLogical, func(), error) {
+func Start(*stopper.Context, *Config) (*FSLogical, func(), error) {
 	panic(wire.Build(
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.Struct(new(FSLogical), "*"),
 		ProvideFirestoreClient,
@@ -53,6 +55,7 @@ func Start(context.Context, *Config) (*FSLogical, func(), error) {
 // Build remaining testable components from a common fixture.
 func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, func(), error) {
 	panic(wire.Build(
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),

--- a/internal/source/mylogical/injector.go
+++ b/internal/source/mylogical/injector.go
@@ -27,13 +27,15 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
 // Start creates a MySQL/MariaDB logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
+func Start(ctx *stopper.Context, config *Config) (*MYLogical, func(), error) {
 	panic(wire.Build(
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.Struct(new(MYLogical), "*"),
 		Set,

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -276,13 +276,8 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 
 	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
 
-	cancelLoop()
-	select {
-	case <-ctx.Done():
-		a.Fail("cancelConn timed out")
-	case <-repl.Loop.Stopped():
-		// OK
-	}
+	ctx.Stop(time.Second)
+	a.NoError(ctx.Wait())
 }
 
 func TestDataTypes(t *testing.T) {
@@ -502,11 +497,8 @@ func TestDataTypes(t *testing.T) {
 
 	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
 
-	cancelLoop()
-	select {
-	case <-repl.Loop.Stopped():
-	case <-ctx.Done():
-	}
+	ctx.Stop(time.Second)
+	a.NoError(ctx.Wait())
 }
 
 func myDo(

--- a/internal/source/mylogical/provider.go
+++ b/internal/source/mylogical/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/google/wire"
 )
@@ -64,8 +65,8 @@ func ProvideDialect(config *Config, _ *script.Loader) (logical.Dialect, error) {
 // ProvideLoop is called by Wire to construct the sole logical loop used
 // in the mylogical mode.
 func ProvideLoop(
-	cfg *Config, dialect logical.Dialect, loops *logical.Factory,
-) (*logical.Loop, func(), error) {
+	ctx *stopper.Context, cfg *Config, dialect logical.Dialect, loops *logical.Factory,
+) (*logical.Loop, error) {
 	cfg.Dialect = dialect
-	return loops.Start(&cfg.LoopConfig)
+	return loops.Start(ctx, &cfg.LoopConfig)
 }

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -7,7 +7,6 @@
 package mylogical
 
 import (
-	"context"
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
@@ -17,13 +16,14 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 )
 
 // Injectors from injector.go:
 
 // Start creates a MySQL/MariaDB logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
+func Start(ctx *stopper.Context, config *Config) (*MYLogical, func(), error) {
 	diagnostics, cleanup := diag.New(ctx)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
@@ -120,7 +120,7 @@ func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	loop, cleanup7, err := ProvideLoop(config, dialect, factory)
+	loop, err := ProvideLoop(ctx, config, dialect, factory)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -135,7 +135,6 @@ func Start(ctx context.Context, config *Config) (*MYLogical, func(), error) {
 		Loop:        loop,
 	}
 	return myLogical, func() {
-		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()

--- a/internal/source/pglogical/injector.go
+++ b/internal/source/pglogical/injector.go
@@ -27,13 +27,15 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
+func Start(ctx *stopper.Context, config *Config) (*PGLogical, func(), error) {
 	panic(wire.Build(
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.Struct(new(PGLogical), "*"),
 		Set,

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdpool"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -103,8 +104,8 @@ func ProvideDialect(
 // ProvideLoop is called by Wire to construct the sole logical loop used
 // in the pglogical mode.
 func ProvideLoop(
-	cfg *Config, dialect logical.Dialect, loops *logical.Factory,
-) (*logical.Loop, func(), error) {
+	ctx *stopper.Context, cfg *Config, dialect logical.Dialect, loops *logical.Factory,
+) (*logical.Loop, error) {
 	cfg.Dialect = dialect
-	return loops.Start(&cfg.LoopConfig)
+	return loops.Start(ctx, &cfg.LoopConfig)
 }

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -7,7 +7,6 @@
 package pglogical
 
 import (
-	"context"
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
@@ -17,13 +16,14 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/target/schemawatch"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 )
 
 // Injectors from injector.go:
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
+func Start(ctx *stopper.Context, config *Config) (*PGLogical, func(), error) {
 	diagnostics, cleanup := diag.New(ctx)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
@@ -120,7 +120,7 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		cleanup()
 		return nil, nil, err
 	}
-	loop, cleanup7, err := ProvideLoop(config, dialect, factory)
+	loop, err := ProvideLoop(ctx, config, dialect, factory)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -135,7 +135,6 @@ func Start(ctx context.Context, config *Config) (*PGLogical, func(), error) {
 		Loop:        loop,
 	}
 	return pgLogical, func() {
-		cleanup7()
 		cleanup6()
 		cleanup5()
 		cleanup4()

--- a/internal/source/server/injector.go
+++ b/internal/source/server/injector.go
@@ -28,10 +28,11 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
-func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
+func NewServer(ctx *stopper.Context, config *Config) (*Server, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
@@ -40,6 +41,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, func(), error) {
 		script.Set,
 		staging.Set,
 		target.Set,
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*Config), "CDC"),
 	))

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	joonix "github.com/joonix/log"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -153,7 +154,7 @@ func testIntegration(t *testing.T, cfg testConfig) {
 	targetPool := destFixture.TargetPool
 
 	// The target fixture contains the cdc-sink server.
-	targetFixture, cancel, err := newTestFixture(ctx, &Config{
+	targetFixture, cancel, err := newTestFixture(stopper.WithContext(ctx), &Config{
 		CDC: cdc.Config{
 			BaseConfig: logical.BaseConfig{
 				Immediate:     cfg.immediate,

--- a/internal/source/server/test_fixture.go
+++ b/internal/source/server/test_fixture.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
@@ -48,7 +49,7 @@ type testFixture struct {
 
 // We want this to be as close as possible to Start, it just exposes
 // additional plumbing details via the returned testFixture pointer.
-func newTestFixture(context.Context, *Config) (*testFixture, func(), error) {
+func newTestFixture(*stopper.Context, *Config) (*testFixture, func(), error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,
@@ -57,6 +58,7 @@ func newTestFixture(context.Context, *Config) (*testFixture, func(), error) {
 		script.Set,
 		staging.Set,
 		target.Set,
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*Config), "CDC"),
 		wire.Struct(new(testFixture), "*"),

--- a/internal/staging/stage/provider.go
+++ b/internal/staging/stage/provider.go
@@ -19,6 +19,7 @@ package stage
 import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
@@ -28,10 +29,13 @@ var Set = wire.NewSet(
 )
 
 // ProvideFactory is called by Wire to construct the Stagers factory.
-func ProvideFactory(db *types.StagingPool, stagingDB ident.StagingSchema) types.Stagers {
+func ProvideFactory(
+	db *types.StagingPool, stagingDB ident.StagingSchema, stop *stopper.Context,
+) types.Stagers {
 	f := &factory{
 		db:        db,
 		stagingDB: stagingDB.Schema(),
+		stop:      stop,
 	}
 	f.mu.instances = &ident.TableMap[*stage]{}
 	return f

--- a/internal/staging/stage/stage.go
+++ b/internal/staging/stage/stage.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/metrics"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pkg/errors"
@@ -79,7 +80,7 @@ var _ types.Stager = (*stage)(nil)
 // newStore constructs a new mutation stage that will track pending
 // mutations to be applied to the given target table.
 func newStore(
-	ctx context.Context, db *types.StagingPool, stagingDB ident.Schema, target ident.Table,
+	ctx *stopper.Context, db *types.StagingPool, stagingDB ident.Schema, target ident.Table,
 ) (*stage, error) {
 	table := stagingTable(stagingDB, target)
 


### PR DESCRIPTION
Review note: Start with the top-level `main.go` to see how we can now explicitly control graceful shutdown independently of tearing down the entire stack.  Several types like `cdc.Resolvers` no longer need to manage the lifecyle of things that they create, since it can be delegated to the stack-global stopper.

This change cleans up some longstanding lifecycle issues around graceful draining. In the past, we relied on the ability to return a cancel function to Wire to shut down background goroutines that might be started by some service or another. This works, but it would be nice to standardize on the stopper.Context utility type for running goroutines that can benefit from a soft-exit condition.

The crux of this change is to make `*stopper.Context` available from all injectors. The `context.Context` type remains injectable, but it becomes an alias for the `*stopper.Context`. The top-level injectors now require a `*stopper.Context`, which gives the callers the ability to trigger a soft shutdown of background processes before tearing down the entire stack. This should reduce the amount of log-spam during shutdown.

This change will also make it far more straightforward to implement metrics that tick (e.g. #560) since a service or object that needs to produce a ticking metric has the option to use the stack-global `*stopper.Context.Go()`. Increase use of our `Go()` method also provides a future opportunity to improve observabiity around background processes within a cdc-sink binary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/575)
<!-- Reviewable:end -->
