### PR TITLE
logical: Reduce test output spam

### DIFF
--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -684,7 +684,7 @@ func testMassBackfillWithForeignKeys(
 				ForeignKeysEnabled: true,
 				StagingConn:        baseFixture.StagingPool.ConnectionString,
 				StagingSchema:      baseFixture.StagingDB.Schema(),
-				RetryDelay:         time.Nanosecond,
+				RetryDelay:         time.Millisecond,
 				TargetConn:         baseFixture.TargetPool.ConnectionString,
 			},
 		}

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -139,7 +139,7 @@ func testSmoke(t *testing.T, chaosProb float32) {
 			BackfillWindow:     time.Minute,
 			ChaosProb:          chaosProb,
 			ForeignKeysEnabled: true,
-			RetryDelay:         time.Nanosecond,
+			RetryDelay:         time.Millisecond,
 			StandbyTimeout:     10 * time.Millisecond,
 			StagingConn:        fixture.StagingPool.ConnectionString,
 			StagingSchema:      fixture.StagingDB.Schema(),

--- a/internal/source/logical/config.go
+++ b/internal/source/logical/config.go
@@ -180,6 +180,9 @@ func (c *BaseConfig) Preflight() error {
 	}
 	if c.RetryDelay == 0 {
 		c.RetryDelay = defaultRetryDelay
+	} else if c.RetryDelay < time.Millisecond {
+		// Set a sane lower bound to avoid spammy loops.
+		c.RetryDelay = time.Millisecond
 	}
 	if c.StagingSchema.Empty() {
 		return errors.New("no staging database specified")

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -178,7 +178,7 @@ func testLogicalSmoke(t *testing.T, mode *logicalTestMode) {
 		ChaosProb:          chaosProb,
 		ForeignKeysEnabled: mode.fk,
 		Immediate:          mode.immediate,
-		RetryDelay:         time.Nanosecond,
+		RetryDelay:         time.Millisecond,
 		StagingConn:        fixture.StagingPool.ConnectionString,
 		StagingSchema:      fixture.StagingDB.Schema(),
 		StandbyTimeout:     5 * time.Millisecond,

--- a/internal/source/logical/loop.go
+++ b/internal/source/logical/loop.go
@@ -286,17 +286,26 @@ func (l *loop) runOnceUsing(
 			case <-ctx.Stopping():
 				return nil
 			case ch <- msgRollback:
-				// We'll recover by injecting a new rollback message and
-				// then restarting the message stream from the previous
-				// consistent point.
+				// We'll recover by injecting a new rollback message,
+				// waiting for a bit, and then restarting the message
+				// stream from the previous consistent point.
 				log.WithError(err).Errorf(
 					"error from replication source %s; continuing",
 					l.loopConfig.LoopName)
-				continue
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
 				return errors.New("stopping loop due to consumer backpressure during rollback")
+			}
+
+			// Interruptable sleep since RetryDelay is likely several
+			// seconds in a reasonable configuration.
+			select {
+			case <-time.After(l.factory.baseConfig.RetryDelay):
+			case <-ctx.Stopping():
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 	})

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -109,7 +109,7 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 			ApplyTimeout:  2 * time.Minute, // Increase to make using the debugger easier.
 			ChaosProb:     fc.chaosProb,
 			Immediate:     fc.immediate,
-			RetryDelay:    time.Nanosecond,
+			RetryDelay:    time.Millisecond,
 			StagingSchema: fixture.StagingDB.Schema(),
 			TargetConn:    crdbPool.ConnectionString,
 		},

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -197,7 +197,7 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 			ApplyTimeout:  2 * time.Minute, // Increase to make using the debugger easier.
 			ChaosProb:     fc.chaosProb,
 			Immediate:     fc.immediate,
-			RetryDelay:    time.Nanosecond,
+			RetryDelay:    time.Millisecond,
 			StagingSchema: fixture.StagingDB.Schema(),
 			TargetConn:    crdbPool.ConnectionString,
 		},
@@ -434,7 +434,7 @@ func TestDataTypes(t *testing.T) {
 	// Start the connection, to demonstrate that we can backfill pending mutations.
 	repl, cancelLoop, err := Start(ctx, &Config{
 		BaseConfig: logical.BaseConfig{
-			RetryDelay:    time.Nanosecond,
+			RetryDelay:    time.Millisecond,
 			StagingSchema: fixture.StagingDB.Schema(),
 			TargetConn:    crdbPool.ConnectionString,
 		},


### PR DESCRIPTION
The `logical.loop.runOnce()` method can enter a tight loop when it encounters an error condition, leading to logging spam. It uses a `timer.After` channel, which may already have fired by the time the `select` statement is executed when test code has set the RetryDelay value to a very small value.  (Also, golang says that the selection is arbitrary when multiple conditions are satisfied.)

This change enforces a minimum RetryDelay of 1 millisecond and adds an additional RetryDelay to `loop.runOnceUsing()`, again to prevent a tight delay from causing log spam in tests.

Existing uses of the 1 nanosecond value have been updated to show what their effective value will actually be.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/576)
<!-- Reviewable:end -->
