### PR TITLE
wire: Remove all cleanup functions

### DIFF
--- a/internal/cmd/fslogical/fslogical.go
+++ b/internal/cmd/fslogical/fslogical.go
@@ -31,9 +31,9 @@ func Command() *cobra.Command {
 	return stdlogical.New(&stdlogical.Template{
 		Bind:  cfg.Bind,
 		Short: "start a Google Cloud Firestore logical replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
+		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
 			// main.go provides this stopper.
-			return fslogical.Start(stopper.From(cmd.Context()), cfg)
+			return fslogical.Start(ctx, cfg)
 		},
 		Use: "fslogical",
 	})

--- a/internal/cmd/mylogical/mylogical.go
+++ b/internal/cmd/mylogical/mylogical.go
@@ -31,9 +31,8 @@ func Command() *cobra.Command {
 	return stdlogical.New(&stdlogical.Template{
 		Bind:  cfg.Bind,
 		Short: "start a mySQL replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			// main.go provides a stopper.
-			return mylogical.Start(stopper.From(cmd.Context()), cfg)
+		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
+			return mylogical.Start(ctx, cfg)
 		},
 		Use: "mylogical",
 	})

--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -31,9 +31,8 @@ func Command() *cobra.Command {
 	return stdlogical.New(&stdlogical.Template{
 		Bind:  cfg.Bind,
 		Short: "start a pg logical replication feed",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			// main.go provides a stopper.
-			return pglogical.Start(stopper.From(cmd.Context()), cfg)
+		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
+			return pglogical.Start(ctx, cfg)
 		},
 		Use: "pglogical",
 	})

--- a/internal/cmd/start/start.go
+++ b/internal/cmd/start/start.go
@@ -30,9 +30,8 @@ func Command() *cobra.Command {
 	return stdlogical.New(&stdlogical.Template{
 		Bind:  cfg.Bind,
 		Short: "start the server",
-		Start: func(cmd *cobra.Command) (any, func(), error) {
-			// main.go gives us a stopper, just unwrap it.
-			return server.NewServer(stopper.From(cmd.Context()), &cfg)
+		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
+			return server.NewServer(ctx, &cfg)
 		},
 		Use: "start",
 	})

--- a/internal/script/injector.go
+++ b/internal/script/injector.go
@@ -20,10 +20,7 @@
 package script
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
-	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -42,15 +39,12 @@ func Evaluate(
 ) (*UserScript, error) {
 	panic(wire.Build(
 		ProvideUserScript,
-		wire.Bind(new(context.Context), new(*stopper.Context)),
 	))
 }
 
 func newScriptFromFixture(*all.Fixture, *Config, TargetSchema) (*UserScript, error) {
 	panic(wire.Build(
 		Set,
-		wire.Bind(new(context.Context), new(*stopper.Context)),
-		wire.FieldsOf(new(*all.Fixture), "Diagnostics", "Fixture", "Configs", "Watchers"),
-		wire.FieldsOf(new(*base.Fixture), "Context"),
+		wire.FieldsOf(new(*all.Fixture), "Diagnostics", "Configs", "Watchers"),
 	))
 }

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -17,7 +17,6 @@
 package script
 
 import (
-	"context"
 	"net/url"
 	"sync"
 
@@ -118,7 +117,6 @@ func ProvideLoader(cfg *Config) (*Loader, error) {
 // ProvideUserScript is called by wire to bind the UserScript to the
 // target database.
 func ProvideUserScript(
-	ctx context.Context,
 	applyConfigs *applycfg.Configs,
 	boot *Loader,
 	diags *diag.Diagnostics,
@@ -133,7 +131,7 @@ func ProvideUserScript(
 		}, nil
 	}
 
-	watcher, err := watchers.Get(ctx, target.AsSchema())
+	watcher, err := watchers.Get(target.AsSchema())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -52,9 +52,8 @@ func TestScript(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	schema := fixture.TargetSchema.Schema()

--- a/internal/script/wire_gen.go
+++ b/internal/script/wire_gen.go
@@ -22,7 +22,7 @@ import (
 
 // Evaluate the loaded script.
 func Evaluate(ctx *stopper.Context, loader *Loader, configs *applycfg.Configs, diags *diag.Diagnostics, targetSchema TargetSchema, watchers types.Watchers) (*UserScript, error) {
-	userScript, err := ProvideUserScript(ctx, configs, loader, diags, targetSchema, watchers)
+	userScript, err := ProvideUserScript(configs, loader, diags, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +30,6 @@ func Evaluate(ctx *stopper.Context, loader *Loader, configs *applycfg.Configs, d
 }
 
 func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema TargetSchema) (*UserScript, error) {
-	baseFixture := fixture.Fixture
-	context := baseFixture.Context
 	configs := fixture.Configs
 	loader, err := ProvideLoader(config)
 	if err != nil {
@@ -39,7 +37,7 @@ func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema Tar
 	}
 	diagnostics := fixture.Diagnostics
 	watchers := fixture.Watchers
-	userScript, err := ProvideUserScript(context, configs, loader, diagnostics, targetSchema, watchers)
+	userScript, err := ProvideUserScript(configs, loader, diagnostics, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sinktest/all/all_test.go
+++ b/internal/sinktest/all/all_test.go
@@ -25,9 +25,8 @@ import (
 func TestAllSmoke(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cleanup, err := NewFixture()
+	fixture, err := NewFixture(t)
 	r.NoError(err)
-	defer cleanup()
 
 	r.NotEmpty(fixture.StagingPool.Version)
 	r.NotEmpty(fixture.TargetPool.Version)

--- a/internal/sinktest/all/injector.go
+++ b/internal/sinktest/all/injector.go
@@ -19,10 +19,14 @@
 
 package all
 
-import "github.com/google/wire"
+import (
+	"testing"
+
+	"github.com/google/wire"
+)
 
 // NewFixture constructs a self-contained test fixture for all services
 // in the target sub-packages.
-func NewFixture() (*Fixture, func(), error) {
+func NewFixture(t testing.TB) (*Fixture, error) {
 	panic(wire.Build(TestSet))
 }

--- a/internal/sinktest/all/provider.go
+++ b/internal/sinktest/all/provider.go
@@ -18,8 +18,6 @@
 package all
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
@@ -49,8 +47,6 @@ func ProvideDLQConfig() (*dlq.Config, error) {
 
 // ProvideWatcher is called by Wire to construct a Watcher
 // bound to the testing database.
-func ProvideWatcher(
-	ctx context.Context, target sinktest.TargetSchema, watchers types.Watchers,
-) (types.Watcher, error) {
-	return watchers.Get(ctx, target.Schema())
+func ProvideWatcher(target sinktest.TargetSchema, watchers types.Watchers) (types.Watcher, error) {
+	return watchers.Get(target.Schema())
 }

--- a/internal/sinktest/base/base_test.go
+++ b/internal/sinktest/base/base_test.go
@@ -25,9 +25,8 @@ import (
 func TestBaseSmoke(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cleanup, err := NewFixture()
+	fixture, err := NewFixture(t)
 	r.NoError(err)
-	defer cleanup()
 
 	r.NotNil(fixture.SourcePool.DB)
 	r.NotEmpty(fixture.SourcePool.ConnectionString)

--- a/internal/sinktest/base/injector.go
+++ b/internal/sinktest/base/injector.go
@@ -19,9 +19,13 @@
 
 package base
 
-import "github.com/google/wire"
+import (
+	"testing"
+
+	"github.com/google/wire"
+)
 
 // NewFixture constructs a self-contained test fixture.
-func NewFixture() (*Fixture, func(), error) {
+func NewFixture(t testing.TB) (*Fixture, error) {
 	panic(wire.Build(TestSet))
 }

--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/sinktest"
@@ -140,8 +141,9 @@ var caseTimout = flag.Duration(
 
 // ProvideContext returns an execution context that is associated with a
 // singleton connection to a CockroachDB cluster.
-func ProvideContext() (*stopper.Context, func()) {
+func ProvideContext(t testing.TB) *stopper.Context {
 	ctx := stopper.WithContext(context.Background())
+	t.Cleanup(func() { ctx.Stop(10 * time.Millisecond) })
 	ctx.Go(func() error {
 		select {
 		case <-ctx.Stopping():
@@ -152,45 +154,36 @@ func ProvideContext() (*stopper.Context, func()) {
 		}
 		return nil
 	})
-	return ctx, func() { ctx.Stop(100 * time.Millisecond) }
+	return ctx
 }
 
 // ProvideSourcePool connects to the source database. If the source is a
 // CockroachDB cluster, this function will also configure the rangefeed
 // and license cluster settings if they have not been previously
 // configured.
-func ProvideSourcePool(
-	ctx context.Context, diags *diag.Diagnostics,
-) (*types.SourcePool, func(), error) {
+func ProvideSourcePool(ctx *stopper.Context, diags *diag.Diagnostics) (*types.SourcePool, error) {
 	tgt := *sourceConn
 	log.Infof("source connect string: %s", tgt)
-	ret, cancel, err := stdpool.OpenTarget(ctx, tgt,
+	ret, err := stdpool.OpenTarget(ctx, tgt,
 		stdpool.WithDiagnostics(diags, "source"),
 		stdpool.WithTestControls(stdpool.TestControls{
 			WaitForStartup: true,
 		}),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if ret.Product != types.ProductCockroachDB {
-		return (*types.SourcePool)(ret), cancel, err
+		return (*types.SourcePool)(ret), err
 	}
-
-	success := false
-	defer func() {
-		if !success {
-			cancel()
-		}
-	}()
 
 	// Set the cluster settings once, if we need to.
 	var enabled bool
 	if err := retry.Retry(ctx, func(ctx context.Context) error {
 		return ret.QueryRowContext(ctx, "SHOW CLUSTER SETTING kv.rangefeed.enabled").Scan(&enabled)
 	}); err != nil {
-		return nil, nil, errors.Wrap(err, "could not check cluster setting")
+		return nil, errors.Wrap(err, "could not check cluster setting")
 	}
 	if !enabled {
 		if lic, ok := os.LookupEnv("COCKROACH_DEV_LICENSE"); ok {
@@ -198,90 +191,96 @@ func ProvideSourcePool(
 				"SET CLUSTER SETTING cluster.organization = $1",
 				"Cockroach Labs - Production Testing",
 			); err != nil {
-				return nil, nil, errors.Wrap(err, "could not set cluster.organization")
+				return nil, errors.Wrap(err, "could not set cluster.organization")
 			}
 			if err := retry.Execute(ctx, ret,
 				"SET CLUSTER SETTING enterprise.license = $1", lic,
 			); err != nil {
-				return nil, nil, errors.Wrap(err, "could not set enterprise.license")
+				return nil, errors.Wrap(err, "could not set enterprise.license")
 			}
 		}
 
 		if err := retry.Execute(ctx, ret,
 			"SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
-			return nil, nil, errors.Wrap(err, "could not enable rangefeeds")
+			return nil, errors.Wrap(err, "could not enable rangefeeds")
 		}
 	}
 
-	success = true
-	return (*types.SourcePool)(ret), cancel, nil
+	return (*types.SourcePool)(ret), nil
 }
 
 // ProvideStagingSchema create a globally-unique container for tables in the
 // staging database.
 func ProvideStagingSchema(
-	ctx context.Context, pool *types.StagingPool,
-) (ident.StagingSchema, func(), error) {
-	ret, cancel, err := provideSchema(ctx, pool, "cdc")
-	return ident.StagingSchema(ret), cancel, err
+	ctx *stopper.Context, pool *types.StagingPool,
+) (ident.StagingSchema, error) {
+	ret, err := provideSchema(ctx, pool, "cdc")
+	return ident.StagingSchema(ret), err
 }
 
 // ProvideStagingPool opens a connection to the CockroachDB staging
 // cluster under test.
-func ProvideStagingPool(ctx context.Context) (*types.StagingPool, func(), error) {
+func ProvideStagingPool(ctx *stopper.Context) (*types.StagingPool, error) {
 	tgt := *stagingConn
 	log.Infof("staging connect string: %s", tgt)
-	return stdpool.OpenPgxAsStaging(ctx, tgt,
+	pool, err := stdpool.OpenPgxAsStaging(ctx, tgt,
 		stdpool.WithTestControls(stdpool.TestControls{
 			WaitForStartup: true,
 		}),
 	)
+	if err != nil {
+		return nil, err
+	}
+	return pool, nil
 }
 
 // ProvideTargetPool connects to the target database (which is most
 // often the same as the source database).
 func ProvideTargetPool(
-	ctx context.Context, source *types.SourcePool, diags *diag.Diagnostics,
-) (*types.TargetPool, func(), error) {
+	ctx *stopper.Context, source *types.SourcePool, diags *diag.Diagnostics,
+) (*types.TargetPool, error) {
 	tgt := *targetString
 	if tgt == source.ConnectionString {
 		log.Info("reusing SourcePool as TargetPool")
-		return (*types.TargetPool)(source), func() {}, nil
+		return (*types.TargetPool)(source), nil
 	}
 	log.Infof("target connect string: %s", tgt)
-	return stdpool.OpenTarget(ctx, *targetString,
+	pool, err := stdpool.OpenTarget(ctx, *targetString,
 		stdpool.WithDiagnostics(diags, "target"),
 		stdpool.WithTestControls(stdpool.TestControls{
 			WaitForStartup: true,
 		}),
 	)
+	if err != nil {
+		return nil, err
+	}
+	return pool, nil
 }
 
 // ProvideSourceSchema create a globally-unique container for tables in
 // the source database.
 func ProvideSourceSchema(
-	ctx context.Context, pool *types.SourcePool,
-) (sinktest.SourceSchema, func(), error) {
-	sch, cancel, err := provideSchema(ctx, pool, "src")
+	ctx *stopper.Context, pool *types.SourcePool,
+) (sinktest.SourceSchema, error) {
+	sch, err := provideSchema(ctx, pool, "src")
 	log.Infof("source schema: %s", sch)
-	return sinktest.SourceSchema(sch), cancel, err
+	return sinktest.SourceSchema(sch), err
 }
 
 // ProvideTargetSchema create a globally-unique container for tables in
 // the target database.
 func ProvideTargetSchema(
-	ctx context.Context,
+	ctx *stopper.Context,
 	diags *diag.Diagnostics,
 	pool *types.TargetPool,
 	stmts *types.TargetStatements,
-) (sinktest.TargetSchema, func(), error) {
-	sch, dropSchema, err := provideSchema(ctx, pool, "tgt")
+) (sinktest.TargetSchema, error) {
+	sch, err := provideSchema(ctx, pool, "tgt")
 	ret := sinktest.TargetSchema(sch)
 	if err != nil {
-		return ret, nil, err
+		return ret, err
 	}
 	log.Infof("target schema: %s", sch)
-	cancel := dropSchema
 
 	// In PostgresSQL, connections are tightly coupled to the target
 	// database.  Cross-database queries are generally unsupported, as
@@ -296,35 +295,31 @@ func ProvideTargetSchema(
 	if pool.Info().Product == types.ProductPostgreSQL {
 		db, _ := sch.Split()
 		conn := fmt.Sprintf("%s/%s", pool.ConnectionString, db.Raw())
-		next, cancelNext, err := stdpool.OpenPgxAsTarget(ctx, conn, stdpool.WithDiagnostics(diags, "target_reopened"))
+		next, err := stdpool.OpenPgxAsTarget(ctx, conn, stdpool.WithDiagnostics(diags, "target_reopened"))
 		if err != nil {
-			cancel()
-			return sinktest.TargetSchema{}, nil, err
+			return sinktest.TargetSchema{}, err
 		}
-		nextCache, clearCache := ProvideTargetStatements(next)
+
+		nextCache := ProvideTargetStatements(ctx, next)
 		pool.ConnectionString = conn
 		pool.DB = next.DB
 		stmts.Cache = nextCache.Cache
-		cancel = func() {
-			dropSchema()
-			clearCache()
-			cancelNext()
-		}
 	}
-	return ret, cancel, nil
+	return ret, nil
 }
 
 // ProvideTargetStatements is called by Wire to construct a
 // prepared-statement cache. Anywhere the associated TargetPool is
 // reused should also reuse the cache.
-func ProvideTargetStatements(pool *types.TargetPool) (*types.TargetStatements, func()) {
+func ProvideTargetStatements(ctx *stopper.Context, pool *types.TargetPool) *types.TargetStatements {
 	ret := stmtcache.New[string](pool.DB, statementCacheSize)
-	return &types.TargetStatements{Cache: ret}, ret.Close
+	ctx.Defer(ret.Close)
+	return &types.TargetStatements{Cache: ret}
 }
 
 func provideSchema[P types.AnyPool](
-	ctx context.Context, pool P, prefix string,
-) (ident.Schema, func(), error) {
+	ctx *stopper.Context, pool P, prefix string,
+) (ident.Schema, error) {
 	switch pool.Info().Product {
 	case types.ProductCockroachDB, types.ProductMariaDB, types.ProductMySQL, types.ProductPostgreSQL:
 		return CreateSchema(ctx, pool, prefix)
@@ -338,25 +333,25 @@ func provideSchema[P types.AnyPool](
 
 		err := retry.Execute(ctx, pool, fmt.Sprintf("CREATE USER %s", name))
 		if err != nil {
-			return ident.Schema{}, nil, errors.Wrapf(err, "could not create user %s", name)
+			return ident.Schema{}, errors.Wrapf(err, "could not create user %s", name)
 		}
 
 		err = retry.Execute(ctx, pool, fmt.Sprintf("ALTER USER %s QUOTA UNLIMITED ON USERS", name))
 		if err != nil {
-			return ident.Schema{}, nil, errors.Wrapf(err, "could not grant quota to %s", name)
+			return ident.Schema{}, errors.Wrapf(err, "could not grant quota to %s", name)
 		}
 
-		cancel := func() {
+		ctx.Defer(func() {
 			err := retry.Execute(ctx, pool, fmt.Sprintf("DROP USER %s CASCADE", name))
 			if err != nil {
 				log.WithError(err).Warnf("could not clean up schema %s", name)
 			}
-		}
+		})
 
-		return ident.MustSchema(name), cancel, nil
+		return ident.MustSchema(name), nil
 
 	default:
-		return ident.Schema{}, nil,
+		return ident.Schema{},
 			errors.Errorf("cannot create test db for %s", pool.Info().Product)
 	}
 }
@@ -365,10 +360,10 @@ func provideSchema[P types.AnyPool](
 var dbIdentCounter atomic.Int32
 
 // CreateSchema creates a schema with a unique name that will be
-// dropped when the cancel function is called.
+// dropped when the stopper has stopped.
 func CreateSchema[P types.AnyPool](
-	ctx context.Context, pool P, prefix string,
-) (ident.Schema, func(), error) {
+	ctx *stopper.Context, pool P, prefix string,
+) (ident.Schema, error) {
 	dbNum := dbIdentCounter.Add(1)
 
 	// Each package tests run in a separate binary, so we need a
@@ -389,24 +384,17 @@ func CreateSchema[P types.AnyPool](
 		err := retry.Execute(ctx, pool, fmt.Sprintf("DROP DATABASE IF EXISTS %s %s", name, option))
 		log.WithError(err).WithField("target", name).Debug("dropped database")
 	}
-
-	// Clean up if anything below fails.
-	success := false
-	defer func() {
-		if !success {
-			cancel()
-		}
-	}()
+	ctx.Defer(cancel)
 
 	if err := retry.Execute(ctx, pool, fmt.Sprintf(
 		"CREATE DATABASE %s", name)); err != nil {
-		return ident.Schema{}, cancel, errors.WithStack(err)
+		return ident.Schema{}, errors.WithStack(err)
 	}
 
 	if pool.Info().Product == types.ProductCockroachDB {
 		if err := retry.Execute(ctx, pool, fmt.Sprintf(
 			`ALTER DATABASE %s CONFIGURE ZONE USING gc.ttlseconds = 600`, name)); err != nil {
-			return ident.Schema{}, cancel, errors.WithStack(err)
+			return ident.Schema{}, errors.WithStack(err)
 		}
 	}
 	var sch ident.Schema
@@ -418,11 +406,10 @@ func CreateSchema[P types.AnyPool](
 		sch, err = ident.NewSchema(name, ident.Public)
 	}
 	if err != nil {
-		return ident.Schema{}, cancel, err
+		return ident.Schema{}, err
 	}
 
-	success = true
-	return sch, cancel, nil
+	return sch, nil
 }
 
 // A global counter for allocating all temp tables in a test run. We

--- a/internal/sinktest/base/wire_gen.go
+++ b/internal/sinktest/base/wire_gen.go
@@ -8,66 +8,39 @@ package base
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"testing"
 )
 
 // Injectors from injector.go:
 
 // NewFixture constructs a self-contained test fixture.
-func NewFixture() (*Fixture, func(), error) {
-	context, cleanup := ProvideContext()
-	diagnostics, cleanup2 := diag.New(context)
-	sourcePool, cleanup3, err := ProvideSourcePool(context, diagnostics)
+func NewFixture(t testing.TB) (*Fixture, error) {
+	context := ProvideContext(t)
+	diagnostics := diag.New(context)
+	sourcePool, err := ProvideSourcePool(context, diagnostics)
 	if err != nil {
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	sourceSchema, cleanup4, err := ProvideSourceSchema(context, sourcePool)
+	sourceSchema, err := ProvideSourceSchema(context, sourcePool)
 	if err != nil {
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	stagingPool, cleanup5, err := ProvideStagingPool(context)
+	stagingPool, err := ProvideStagingPool(context)
 	if err != nil {
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	stagingSchema, cleanup6, err := ProvideStagingSchema(context, stagingPool)
+	stagingSchema, err := ProvideStagingSchema(context, stagingPool)
 	if err != nil {
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	targetPool, cleanup7, err := ProvideTargetPool(context, sourcePool, diagnostics)
+	targetPool, err := ProvideTargetPool(context, sourcePool, diagnostics)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	targetStatements, cleanup8 := ProvideTargetStatements(targetPool)
-	targetSchema, cleanup9, err := ProvideTargetSchema(context, diagnostics, targetPool, targetStatements)
+	targetStatements := ProvideTargetStatements(context, targetPool)
+	targetSchema, err := ProvideTargetSchema(context, diagnostics, targetPool, targetStatements)
 	if err != nil {
-		cleanup8()
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	fixture := &Fixture{
 		Context:      context,
@@ -79,15 +52,5 @@ func NewFixture() (*Fixture, func(), error) {
 		TargetPool:   targetPool,
 		TargetSchema: targetSchema,
 	}
-	return fixture, func() {
-		cleanup9()
-		cleanup8()
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-	}, nil
+	return fixture, nil
 }

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -17,7 +17,6 @@
 package cdc
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -69,9 +68,8 @@ func createFixture(
 ) (*testFixture, base.TableInfo[*types.TargetPool]) {
 	t.Helper()
 	r := require.New(t)
-	baseFixture, cancel, err := all.NewFixture()
+	baseFixture, err := all.NewFixture(t)
 	r.NoError(err)
-	t.Cleanup(cancel)
 
 	// Ensure that the dispatch and mapper functions must have been
 	// called by using a column name that's only known to the mapper
@@ -104,9 +102,8 @@ func createFixture(
 			MainPath: "/testdata/logical_test.ts",
 		}
 	}
-	fixture, cancel, err := newTestFixture(baseFixture, cfg)
+	fixture, err := newTestFixture(baseFixture, cfg)
 	r.NoError(err)
-	t.Cleanup(cancel)
 
 	return fixture, tableInfo
 }
@@ -122,7 +119,7 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 		if htc.immediate {
 			return nil
 		}
-		loop, resolver, err := h.Resolvers.get(ctx, target.Schema())
+		loop, resolver, err := h.Resolvers.get(target.Schema())
 		if err != nil {
 			return err
 		}
@@ -347,7 +344,7 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 		if cfg.immediate {
 			return nil
 		}
-		loop, resolver, err := h.Resolvers.get(ctx, target.Schema())
+		loop, resolver, err := h.Resolvers.get(target.Schema())
 		if err != nil {
 			return err
 		}
@@ -657,21 +654,11 @@ func testMassBackfillWithForeignKeys(
 ) {
 	r := require.New(t)
 
-	baseFixture, cancel, err := all.NewFixture()
-	ctx := baseFixture.Context
+	baseFixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
+	ctx := baseFixture.Context
 
 	fixtures := make([]*testFixture, fixtureCount)
-
-	cancels := make([]context.CancelFunc, fixtureCount)
-	defer func() {
-		for _, fn := range cancels {
-			if fn != nil {
-				fn()
-			}
-		}
-	}()
 
 	for idx := range fixtures {
 		cfg := &Config{
@@ -691,7 +678,7 @@ func testMassBackfillWithForeignKeys(
 		for _, fn := range fns {
 			fn(cfg)
 		}
-		fixtures[idx], cancels[idx], err = newTestFixture(baseFixture, cfg)
+		fixtures[idx], err = newTestFixture(baseFixture, cfg)
 		r.NoError(err)
 	}
 

--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -35,10 +35,10 @@ import (
 
 // parseMutation takes a single line from an ndjson and extracts enough
 // information to be able to persist it to the staging table.
-type parseMutation func(context.Context, *request, []byte) (types.Mutation, error)
+type parseMutation func(*request, []byte) (types.Mutation, error)
 
 // parseNdjsonMutation is a parseMutation function
-func parseNdjsonMutation(_ context.Context, _ *request, rawBytes []byte) (types.Mutation, error) {
+func parseNdjsonMutation(_ *request, rawBytes []byte) (types.Mutation, error) {
 	var payload struct {
 		After   json.RawMessage `json:"after"`
 		Before  json.RawMessage `json:"before"`
@@ -81,7 +81,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request, parser parseMutation
 	var flush func(muts []types.Mutation) error
 
 	if h.Config.Immediate {
-		batcher, err := h.Immediate.Get(ctx, target.Schema())
+		batcher, err := h.Immediate.Get(target.Schema())
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request, parser parseMutation
 		if len(buf) == 0 {
 			continue
 		}
-		mut, err := parser(ctx, req, buf)
+		mut, err := parser(req, buf)
 		if err != nil {
 			return err
 		}

--- a/internal/source/cdc/ndjson_query.go
+++ b/internal/source/cdc/ndjson_query.go
@@ -19,7 +19,6 @@ package cdc
 // This file contains code repackaged from url.go.
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
@@ -32,10 +31,8 @@ import (
 // returned by the event_op() function.
 // SELECT *, event_op() as operation
 // See (https://www.cockroachlabs.com/docs/stable/cdc-queries.html#cdc-query-function-support)
-func (h *Handler) parseNdjsonQueryMutation(
-	ctx context.Context, req *request, rawBytes []byte,
-) (types.Mutation, error) {
-	keys, err := h.getPrimaryKey(ctx, req)
+func (h *Handler) parseNdjsonQueryMutation(req *request, rawBytes []byte) (types.Mutation, error) {
+	keys, err := h.getPrimaryKey(req)
 	if err != nil {
 		return types.Mutation{}, err
 	}
@@ -50,7 +47,7 @@ func (h *Handler) parseNdjsonQueryMutation(
 
 // getPrimaryKey returns a map that contains all the columns that make up the primary key
 // for the target table and their ordinal position within the key.
-func (h *Handler) getPrimaryKey(ctx context.Context, req *request) (*ident.Map[int], error) {
+func (h *Handler) getPrimaryKey(req *request) (*ident.Map[int], error) {
 	if req.keys != nil {
 		return req.keys, nil
 	}
@@ -58,7 +55,7 @@ func (h *Handler) getPrimaryKey(ctx context.Context, req *request) (*ident.Map[i
 	if !ok {
 		return nil, errors.Errorf("expecting ident.Table, got %T", req.target)
 	}
-	watcher, err := h.Resolvers.watchers.Get(ctx, table.Schema())
+	watcher, err := h.Resolvers.watchers.Get(table.Schema())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -42,9 +42,9 @@ type MetaTable ident.Table
 func (t MetaTable) Table() ident.Table { return ident.Table(t) }
 
 // ProvideImmediate is called by wire.
-func ProvideImmediate(loops *logical.Factory) (*Immediate, func(), error) {
-	imm := &Immediate{loops: loops}
-	return imm, imm.cleanup, nil
+func ProvideImmediate(ctx *stopper.Context, loops *logical.Factory) (*Immediate, error) {
+	imm := &Immediate{loops: loops, stop: ctx}
+	return imm, nil
 }
 
 // ProvideMetaTable is called by wire. It returns the
@@ -86,7 +86,7 @@ func ProvideResolvers(
 		return nil, err
 	}
 	for _, schema := range schemas {
-		if _, _, err := ret.get(ctx, schema); err != nil {
+		if _, _, err := ret.get(schema); err != nil {
 			return nil, errors.Wrapf(err, "could not bootstrap resolver for schema %s", schema)
 		}
 	}

--- a/internal/source/cdc/resolved.go
+++ b/internal/source/cdc/resolved.go
@@ -63,7 +63,7 @@ func parseResolvedTimestamp(timestamp string, logical string) (hlc.Time, error) 
 
 // resolved acts upon a resolved timestamp message.
 func (h *Handler) resolved(ctx context.Context, req *request) error {
-	_, resolver, err := h.Resolvers.get(ctx, req.target.Schema())
+	_, resolver, err := h.Resolvers.get(req.target.Schema())
 	if err != nil {
 		return err
 	}

--- a/internal/source/cdc/resolver_test.go
+++ b/internal/source/cdc/resolver_test.go
@@ -33,11 +33,10 @@ func TestResolverDeQueue(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	baseFixture, cancel, err := all.NewFixture()
+	baseFixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
-	fixture, cancel, err := newTestFixture(baseFixture, &Config{
+	fixture, err := newTestFixture(baseFixture, &Config{
 		MetaTableName: ident.New("resolved_timestamps"),
 		BaseConfig: logical.BaseConfig{
 			StagingSchema: baseFixture.StagingDB.Schema(),
@@ -46,7 +45,6 @@ func TestResolverDeQueue(t *testing.T) {
 		},
 	})
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	tbl, err := fixture.CreateTargetTable(ctx,
@@ -55,7 +53,7 @@ func TestResolverDeQueue(t *testing.T) {
 
 	// Disable call to loop.Start().
 	fixture.Resolvers.noStart = true
-	_, resolver, err := fixture.Resolvers.get(ctx, tbl.Name().Schema())
+	_, resolver, err := fixture.Resolvers.get(tbl.Name().Schema())
 	r.NoError(err)
 
 	for i := int64(0); i < rowCount; i++ {

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -40,7 +40,7 @@ type testFixture struct {
 	Resolvers *Resolvers
 }
 
-func newTestFixture(*all.Fixture, *Config) (*testFixture, func(), error) {
+func newTestFixture(*all.Fixture, *Config) (*testFixture, error) {
 	panic(wire.Build(
 		Set,
 		wire.FieldsOf(new(*base.Fixture), "Context"),

--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -136,7 +136,7 @@ func (h *Handler) processMutationsDeferred(
 func (h *Handler) processMutationsImmediate(
 	ctx context.Context, target ident.Schema, toProcess *ident.TableMap[[]types.Mutation],
 ) error {
-	batcher, err := h.Immediate.Get(ctx, target)
+	batcher, err := h.Immediate.Get(target)
 	if err != nil {
 		return err
 	}

--- a/internal/source/cdc/webhook_query.go
+++ b/internal/source/cdc/webhook_query.go
@@ -33,7 +33,7 @@ import (
 // SELECT *, event_op() as __event_op__
 func (h *Handler) webhookForQuery(ctx context.Context, req *request) error {
 	table := req.target.(ident.Table)
-	keys, err := h.getPrimaryKey(ctx, req)
+	keys, err := h.getPrimaryKey(req)
 	if err != nil {
 		return err
 	}

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -20,117 +20,69 @@ import (
 
 // Injectors from test_fixture.go:
 
-func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(), error) {
+func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) {
 	authenticator := trust.New()
 	baseFixture := fixture.Fixture
 	context := baseFixture.Context
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	loader, err := script.ProvideLoader(scriptConfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	baseConfig, err := logical.ProvideBaseConfig(config, loader)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	diagnostics, cleanup := diag.New(context)
-	targetPool, cleanup2, err := logical.ProvideTargetPool(context, baseConfig, diagnostics)
+	diagnostics := diag.New(context)
+	targetPool, err := logical.ProvideTargetPool(context, baseConfig, diagnostics)
 	if err != nil {
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	targetStatements, cleanup3, err := logical.ProvideTargetStatements(baseConfig, targetPool, diagnostics)
+	targetStatements, err := logical.ProvideTargetStatements(context, baseConfig, targetPool, diagnostics)
 	if err != nil {
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	configs := fixture.Configs
 	dlqConfig := logical.ProvideDLQConfig(baseConfig)
-	watchers, cleanup4, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics)
 	if err != nil {
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	dlQs := dlq.ProvideDLQs(dlqConfig, targetPool, watchers)
-	appliers, cleanup5, err := apply.ProvideFactory(targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
+	appliers, err := apply.ProvideFactory(context, targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
 	if err != nil {
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	memo := fixture.Memo
-	stagingPool, cleanup6, err := logical.ProvideStagingPool(context, baseConfig, diagnostics)
+	stagingPool, err := logical.ProvideStagingPool(context, baseConfig, diagnostics)
 	if err != nil {
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	checker := fixture.VersionChecker
 	factory, err := logical.ProvideFactory(context, appliers, configs, baseConfig, diagnostics, memo, loader, stagingPool, targetPool, watchers, checker)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	immediate, cleanup7, err := ProvideImmediate(factory)
+	immediate, err := ProvideImmediate(context, factory)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	typesLeases, err := leases.ProvideLeases(context, stagingPool, stagingSchema)
 	if err != nil {
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	metaTable := ProvideMetaTable(config)
 	stagers := fixture.Stagers
 	resolvers, err := ProvideResolvers(context, config, typesLeases, factory, metaTable, stagingPool, stagers, watchers)
 	if err != nil {
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	handler := &Handler{
 		Authenticator: authenticator,
@@ -146,15 +98,7 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, func(),
 		Handler:   handler,
 		Resolvers: resolvers,
 	}
-	return cdcTestFixture, func() {
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-	}, nil
+	return cdcTestFixture, nil
 }
 
 // test_fixture.go:

--- a/internal/source/fslogical/fslogical.go
+++ b/internal/source/fslogical/fslogical.go
@@ -646,19 +646,9 @@ type FSLogical struct {
 
 var (
 	_ stdlogical.HasDiagnostics = (*FSLogical)(nil)
-	_ stdlogical.HasStoppable   = (*FSLogical)(nil)
 )
 
 // GetDiagnostics implements stdlogical.HasDiagnostics.
 func (l *FSLogical) GetDiagnostics() *diag.Diagnostics {
 	return l.Diagnostics
-}
-
-// GetStoppable implements stdlogical.HasStoppable.
-func (l *FSLogical) GetStoppable() types.Stoppable {
-	ret := make(types.Stoppables, len(l.Loops))
-	for idx, loop := range l.Loops {
-		ret[idx] = loop
-	}
-	return ret
 }

--- a/internal/source/fslogical/injector.go
+++ b/internal/source/fslogical/injector.go
@@ -35,7 +35,7 @@ import (
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(*stopper.Context, *Config) (*FSLogical, func(), error) {
+func Start(*stopper.Context, *Config) (*FSLogical, error) {
 	panic(wire.Build(
 		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
@@ -53,9 +53,8 @@ func Start(*stopper.Context, *Config) (*FSLogical, func(), error) {
 }
 
 // Build remaining testable components from a common fixture.
-func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, func(), error) {
+func startLoopsFromFixture(*all.Fixture, *Config) ([]*logical.Loop, error) {
 	panic(wire.Build(
-		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),
 		wire.FieldsOf(new(*base.Fixture), "Context"),
 		wire.FieldsOf(new(*all.Fixture),

--- a/internal/source/fslogical/integration_test.go
+++ b/internal/source/fslogical/integration_test.go
@@ -56,9 +56,8 @@ func testSmoke(t *testing.T, chaosProb float32) {
 	const docCount = 200
 
 	// Create a target database.
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	// Mangle our DB ident into something the emulator will accept.
@@ -179,9 +178,8 @@ api.configureSource("group:subcollection", { recurse:true, target: %[2]s } );
 		UpdatedAtProperty:           ident.New("updated_at"),
 	}
 
-	loops, cancel, err := startLoopsFromFixture(fixture, cfg)
+	loops, err := startLoopsFromFixture(fixture, cfg)
 	r.NoError(err)
-	defer cancel()
 	a.Len(loops, 2)
 
 	log.Info("waiting for top-level backfill")

--- a/internal/source/logical/factory.go
+++ b/internal/source/logical/factory.go
@@ -17,7 +17,6 @@
 package logical
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cdc-sink/internal/script"
@@ -39,13 +38,14 @@ type Factory struct {
 	memo         types.Memo
 	scriptLoader *script.Loader
 	stagingPool  *types.StagingPool
+	stop         *stopper.Context
 	targetPool   *types.TargetPool
 	watchers     types.Watchers
 }
 
 // Immediate supports use cases where it is desirable to write directly
 // into the target schema.
-func (f *Factory) Immediate(ctx context.Context, target ident.Schema) (Batcher, func(), error) {
+func (f *Factory) Immediate(target ident.Schema) (Batcher, error) {
 	// Construct a fake loop and then steal the parts of the
 	// implementation that are useful. We want to build the Batcher that
 	// is returned by this method using the same code-path that we would
@@ -60,28 +60,23 @@ func (f *Factory) Immediate(ctx context.Context, target ident.Schema) (Batcher, 
 	// no-ops and wait to exit. The implementation of Process would make
 	// the Events / Batcher available externally. This has the downside
 	// of actually needing to start the loop goroutines.
-	stop := stopper.WithContext(ctx)
-	fake, err := f.newLoop(stop, &LoopConfig{
+	fake, err := f.newLoop(f.stop, &LoopConfig{
 		Dialect:      &fakeDialect{},
 		LoopName:     fmt.Sprintf("immediate-%s", target.Raw()),
 		TargetSchema: target,
 	})
 	if err != nil {
-		return nil, nil, err
-	}
-	cancel := func() {
-		stop.Stop(f.baseConfig.ApplyTimeout)
-		<-stop.Done()
+		return nil, err
 	}
 
 	if f.baseConfig.Immediate {
-		return fake.loop.events.fan, cancel, nil
+		return fake.loop.events.fan, nil
 	}
-	return fake.loop.events.serial, cancel, nil
+	return fake.loop.events.serial, nil
 }
 
 // Start constructs a new replication Loop.
-func (f *Factory) Start(ctx *stopper.Context, config *LoopConfig) (*Loop, error) {
+func (f *Factory) Start(config *LoopConfig) (*Loop, error) {
 	var err error
 
 	// Ensure the configuration is set up and validated.
@@ -91,12 +86,11 @@ func (f *Factory) Start(ctx *stopper.Context, config *LoopConfig) (*Loop, error)
 	}
 
 	// Construct the new loop and start it.
-	ctx = stopper.WithContext(ctx)
-	loop, err := f.newLoop(ctx, config)
+	loop, err := f.newLoop(f.stop, config)
 	if err != nil {
 		return nil, err
 	}
-	ctx.Go(func() error {
+	f.stop.Go(func() error {
 		loop.loop.run()
 		return nil
 	})
@@ -120,9 +114,11 @@ func (f *Factory) expandConfig(config *LoopConfig) (*LoopConfig, error) {
 	return config, config.Preflight()
 }
 
-// newLoop constructs a loop, but does not start it.
+// newLoop constructs a loop, but does not start it. It accepts a
+// stopper since we use this method for creating temporory backfill
+// loops.
 func (f *Factory) newLoop(ctx *stopper.Context, config *LoopConfig) (*Loop, error) {
-	watcher, err := f.watchers.Get(ctx, config.TargetSchema)
+	watcher, err := f.watchers.Get(config.TargetSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -172,10 +168,8 @@ func (f *Factory) newLoop(ctx *stopper.Context, config *LoopConfig) (*Loop, erro
 		return nil, err
 	}
 	// Unregister the loop on shutdown.
-	ctx.Go(func() error {
-		<-ctx.Stopping()
+	ctx.Defer(func() {
 		f.diags.Unregister(config.LoopName)
-		return nil
 	})
 
 	userscript, err := script.Evaluate(

--- a/internal/source/logical/fan_events.go
+++ b/internal/source/logical/fan_events.go
@@ -32,8 +32,8 @@ type fanEvents struct {
 var _ Events = (*fanEvents)(nil)
 
 // Backfill implements Events. It delegates to the enclosing loop.
-func (f *fanEvents) Backfill(ctx context.Context, source string, backfiller Backfiller) error {
-	return f.loop.doBackfill(ctx, source, backfiller)
+func (f *fanEvents) Backfill(_ context.Context, source string, backfiller Backfiller) error {
+	return f.loop.doBackfill(source, backfiller)
 }
 
 // GetConsistentPoint implements State. It delegates to the loop.

--- a/internal/source/logical/injector.go
+++ b/internal/source/logical/injector.go
@@ -26,15 +26,17 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging"
 	"github.com/cockroachdb/cdc-sink/internal/target"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/google/wire"
 )
 
-func NewFactoryForTests(ctx context.Context, config Config) (*Factory, func(), error) {
+func NewFactoryForTests(ctx *stopper.Context, config Config) (*Factory, error) {
 	panic(wire.Build(
 		Set,
 		diag.New,
 		script.Set,
 		staging.Set,
 		target.Set,
+		wire.Bind(new(context.Context), new(*stopper.Context)),
 	))
 }

--- a/internal/source/logical/serial_events.go
+++ b/internal/source/logical/serial_events.go
@@ -35,8 +35,8 @@ type serialEvents struct {
 var _ Events = (*serialEvents)(nil)
 
 // Backfill implements Events. It delegates to the enclosing loop.
-func (e *serialEvents) Backfill(ctx context.Context, source string, backfiller Backfiller) error {
-	return e.loop.doBackfill(ctx, source, backfiller)
+func (e *serialEvents) Backfill(_ context.Context, source string, backfiller Backfiller) error {
+	return e.loop.doBackfill(source, backfiller)
 }
 
 // GetConsistentPoint implements State. It delegates to the loop.

--- a/internal/source/mylogical/injector.go
+++ b/internal/source/mylogical/injector.go
@@ -33,7 +33,7 @@ import (
 
 // Start creates a MySQL/MariaDB logical replication loop using the
 // provided configuration.
-func Start(ctx *stopper.Context, config *Config) (*MYLogical, func(), error) {
+func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 	panic(wire.Build(
 		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -91,11 +91,10 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 	a := assert.New(t)
 
 	// Create a basic test fixture.
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	dbName := fixture.TargetSchema.Schema()
@@ -133,8 +132,6 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 	if !a.NoError(err) {
 		return
 	}
-
-	defer cancel()
 
 	myPool, cancel, err := setupMYPool(config)
 	if !a.NoError(err) {
@@ -198,11 +195,10 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 	}
 
 	// Start the connection, to demonstrate that we can backfill pending mutations.
-	repl, cancelLoop, err := Start(ctx, config)
+	repl, err := Start(ctx, config)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancelLoop()
 
 	for {
 		var count int
@@ -371,11 +367,10 @@ func TestDataTypes(t *testing.T) {
 	}
 
 	// Create a basic test fixture.
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	dbName := fixture.TargetSchema.Schema()
@@ -470,11 +465,10 @@ func TestDataTypes(t *testing.T) {
 	}
 
 	// Start the connection, to demonstrate that we can backfill pending mutations.
-	repl, cancelLoop, err := Start(ctx, config)
+	repl, err := Start(ctx, config)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancelLoop()
 
 	// Wait for rows to show up.
 	for idx, tc := range tcs {

--- a/internal/source/mylogical/mylogical.go
+++ b/internal/source/mylogical/mylogical.go
@@ -18,7 +18,6 @@ package mylogical
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
-	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
 )
@@ -31,15 +30,9 @@ type MYLogical struct {
 
 var (
 	_ stdlogical.HasDiagnostics = (*MYLogical)(nil)
-	_ stdlogical.HasStoppable   = (*MYLogical)(nil)
 )
 
 // GetDiagnostics implements [stdlogical.HasDiagnostics].
 func (l *MYLogical) GetDiagnostics() *diag.Diagnostics {
 	return l.Diagnostics
-}
-
-// GetStoppable implements [stdlogical.HasStoppable].
-func (l *MYLogical) GetStoppable() types.Stoppable {
-	return l.Loop
 }

--- a/internal/source/mylogical/provider.go
+++ b/internal/source/mylogical/provider.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/google/wire"
 )
@@ -65,8 +64,8 @@ func ProvideDialect(config *Config, _ *script.Loader) (logical.Dialect, error) {
 // ProvideLoop is called by Wire to construct the sole logical loop used
 // in the mylogical mode.
 func ProvideLoop(
-	ctx *stopper.Context, cfg *Config, dialect logical.Dialect, loops *logical.Factory,
+	cfg *Config, dialect logical.Dialect, loops *logical.Factory,
 ) (*logical.Loop, error) {
 	cfg.Dialect = dialect
-	return loops.Start(ctx, &cfg.LoopConfig)
+	return loops.Start(&cfg.LoopConfig)
 }

--- a/internal/source/pglogical/injector.go
+++ b/internal/source/pglogical/injector.go
@@ -33,7 +33,7 @@ import (
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx *stopper.Context, config *Config) (*PGLogical, func(), error) {
+func Start(ctx *stopper.Context, config *Config) (*PGLogical, error) {
 	panic(wire.Build(
 		wire.Bind(new(context.Context), new(*stopper.Context)),
 		wire.Bind(new(logical.Config), new(*Config)),

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -94,11 +94,10 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 	a := assert.New(t)
 
 	// Create a basic test fixture.
-	fixture, cancel, err := base.NewFixture()
+	fixture, err := base.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	dbSchema := fixture.TargetSchema.Schema()
@@ -221,11 +220,10 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 			MainPath: "/testdata/logical_test.ts",
 		}
 	}
-	repl, cancelLoop, err := Start(ctx, cfg)
+	repl, err := Start(ctx, cfg)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancelLoop()
 
 	// Wait for backfill.
 	for _, tgt := range tgts {
@@ -365,11 +363,10 @@ func TestDataTypes(t *testing.T) {
 	}
 
 	// Create a basic test fixture.
-	fixture, cancel, err := base.NewFixture()
+	fixture, err := base.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	dbSchema := fixture.TargetSchema.Schema()
@@ -429,7 +426,7 @@ func TestDataTypes(t *testing.T) {
 	pubNameRaw := publicationName(dbName).Raw()
 
 	// Start the connection, to demonstrate that we can backfill pending mutations.
-	repl, cancelLoop, err := Start(ctx, &Config{
+	repl, err := Start(fixture.Context, &Config{
 		BaseConfig: logical.BaseConfig{
 			RetryDelay:    time.Millisecond,
 			StagingSchema: fixture.StagingDB.Schema(),
@@ -446,7 +443,6 @@ func TestDataTypes(t *testing.T) {
 	if !a.NoError(err) {
 		return
 	}
-	defer cancelLoop()
 
 	// Wait for rows to show up.
 	for idx, tc := range tcs {

--- a/internal/source/pglogical/pglogical.go
+++ b/internal/source/pglogical/pglogical.go
@@ -18,7 +18,6 @@ package pglogical
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/source/logical"
-	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/stdlogical"
 )
@@ -31,15 +30,9 @@ type PGLogical struct {
 
 var (
 	_ stdlogical.HasDiagnostics = (*PGLogical)(nil)
-	_ stdlogical.HasStoppable   = (*PGLogical)(nil)
 )
 
 // GetDiagnostics implements [stdlogical.HasDiagnostics].
 func (l *PGLogical) GetDiagnostics() *diag.Diagnostics {
 	return l.Diagnostics
-}
-
-// GetStoppable implements [stdlogical.HasStoppable].
-func (l *PGLogical) GetStoppable() types.Stoppable {
-	return l.Loop
 }

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -23,123 +23,70 @@ import (
 
 // Start creates a PostgreSQL logical replication loop using the
 // provided configuration.
-func Start(ctx *stopper.Context, config *Config) (*PGLogical, func(), error) {
-	diagnostics, cleanup := diag.New(ctx)
+func Start(ctx *stopper.Context, config *Config) (*PGLogical, error) {
+	diagnostics := diag.New(ctx)
 	scriptConfig, err := logical.ProvideUserScriptConfig(config)
 	if err != nil {
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	loader, err := script.ProvideLoader(scriptConfig)
 	if err != nil {
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	dialect, err := ProvideDialect(ctx, config, loader)
 	if err != nil {
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	baseConfig, err := logical.ProvideBaseConfig(config, loader)
 	if err != nil {
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	targetPool, cleanup2, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
+	targetPool, err := logical.ProvideTargetPool(ctx, baseConfig, diagnostics)
 	if err != nil {
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	targetStatements, cleanup3, err := logical.ProvideTargetStatements(baseConfig, targetPool, diagnostics)
+	targetStatements, err := logical.ProvideTargetStatements(ctx, baseConfig, targetPool, diagnostics)
 	if err != nil {
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	configs, err := applycfg.ProvideConfigs(diagnostics)
 	if err != nil {
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	dlqConfig := logical.ProvideDLQConfig(baseConfig)
-	watchers, cleanup4, err := schemawatch.ProvideFactory(targetPool, diagnostics)
+	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics)
 	if err != nil {
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	dlQs := dlq.ProvideDLQs(dlqConfig, targetPool, watchers)
-	appliers, cleanup5, err := apply.ProvideFactory(targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
+	appliers, err := apply.ProvideFactory(ctx, targetStatements, configs, diagnostics, dlQs, targetPool, watchers)
 	if err != nil {
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	stagingPool, cleanup6, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
+	stagingPool, err := logical.ProvideStagingPool(ctx, baseConfig, diagnostics)
 	if err != nil {
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	stagingSchema, err := logical.ProvideStagingDB(baseConfig)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	memoMemo, err := memo.ProvideMemo(ctx, stagingPool, stagingSchema)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	checker := version.ProvideChecker(stagingPool, memoMemo)
 	factory, err := logical.ProvideFactory(ctx, appliers, configs, baseConfig, diagnostics, memoMemo, loader, stagingPool, targetPool, watchers, checker)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
-	loop, err := ProvideLoop(ctx, config, dialect, factory)
+	loop, err := ProvideLoop(config, dialect, factory)
 	if err != nil {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return nil, nil, err
+		return nil, err
 	}
 	pgLogical := &PGLogical{
 		Diagnostics: diagnostics,
 		Loop:        loop,
 	}
-	return pgLogical, func() {
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-	}, nil
+	return pgLogical, nil
 }

--- a/internal/source/server/injector.go
+++ b/internal/source/server/injector.go
@@ -32,7 +32,7 @@ import (
 	"github.com/google/wire"
 )
 
-func NewServer(ctx *stopper.Context, config *Config) (*Server, func(), error) {
+func NewServer(ctx *stopper.Context, config *Config) (*Server, error) {
 	panic(wire.Build(
 		Set,
 		cdc.Set,

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -110,9 +110,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc // Capture for t.Parallel()
 		t.Run(tc.String(), func(t *testing.T) {
-			t.Parallel()
 			testIntegration(t, tc)
 		})
 	}
@@ -130,9 +128,8 @@ func testIntegration(t *testing.T, cfg testConfig) {
 	}()
 
 	// Create a basic fixture to represent a source database.
-	sourceFixture, cancel, err := base.NewFixture()
+	sourceFixture, err := base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	version := sourceFixture.SourcePool.Version
 	supportsWebhook := supportsWebhook(version)
@@ -146,9 +143,8 @@ func testIntegration(t *testing.T, cfg testConfig) {
 	ctx := sourceFixture.Context
 
 	// Create a basic destination database connection.
-	destFixture, cancel, err := base.NewFixture()
+	destFixture, err := base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	targetDB := destFixture.TargetSchema.Schema()
 	targetPool := destFixture.TargetPool
@@ -182,7 +178,7 @@ func testIntegration(t *testing.T, cfg testConfig) {
 	target := ident.NewTable(targetDB, source.Name().Table())
 	_, err = targetPool.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (pk INT PRIMARY KEY, val VARCHAR(2048))", target))
 	r.NoError(err)
-	watcher, err := targetFixture.Watcher.Get(ctx, targetDB)
+	watcher, err := targetFixture.Watcher.Get(targetDB)
 	r.NoError(err)
 	r.NoError(watcher.Refresh(ctx, targetPool))
 

--- a/internal/source/server/server.go
+++ b/internal/source/server/server.go
@@ -31,17 +31,15 @@ import (
 // A Server receives incoming CockroachDB changefeed messages and
 // applies them to a target cluster.
 type Server struct {
-	auth    types.Authenticator
-	diags   *diag.Diagnostics
-	mux     *http.ServeMux
-	stopped chan struct{}
+	auth  types.Authenticator
+	diags *diag.Diagnostics
+	mux   *http.ServeMux
 }
 
 var (
 	_ stdlogical.HasAuthenticator = (*Server)(nil)
 	_ stdlogical.HasDiagnostics   = (*Server)(nil)
 	_ stdlogical.HasServeMux      = (*Server)(nil)
-	_ stdlogical.HasStoppable     = (*Server)(nil)
 )
 
 // GetAuthenticator implements [stdlogical.HasAuthenticator].
@@ -57,15 +55,4 @@ func (s *Server) GetDiagnostics() *diag.Diagnostics {
 // GetServeMux implements [stdlogical.HasServeMux].
 func (s *Server) GetServeMux() *http.ServeMux {
 	return s.mux
-}
-
-// GetStoppable implements [stdlogical.HasStoppable].
-func (s *Server) GetStoppable() types.Stoppable {
-	return s
-}
-
-// Stopped returns a channel that will be closed when the server has
-// been shut down.
-func (s *Server) Stopped() <-chan struct{} {
-	return s.stopped
 }

--- a/internal/staging/auth/jwt/jwt_test.go
+++ b/internal/staging/auth/jwt/jwt_test.go
@@ -29,18 +29,16 @@ import (
 func TestJWT(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	pool := fixture.StagingPool
 	stagingDB := fixture.StagingDB
 
-	auth, cancel, err := ProvideAuth(ctx, pool, stagingDB)
-	defer cancel()
+	auth, err := ProvideAuth(ctx, pool, stagingDB)
 	if !a.NoError(err) {
 		return
 	}
@@ -53,7 +51,6 @@ func TestJWT(t *testing.T) {
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	a.Len(impl.mu.publicKeys, 1)
 

--- a/internal/staging/leases/leases_test.go
+++ b/internal/staging/leases/leases_test.go
@@ -35,15 +35,13 @@ import (
 func TestLeases(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := base.NewFixture()
+	fixture, err := base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 
-	enclosing, cancel, err := base.CreateSchema(ctx, fixture.StagingPool, "leases_")
+	enclosing, err := base.CreateSchema(ctx, fixture.StagingPool, "leases_")
 	r.NoError(err)
-	defer cancel()
 
 	tbl, err := base.CreateTable(ctx, fixture.StagingPool, enclosing, schema)
 	r.NoError(err)

--- a/internal/staging/memo/memo_test.go
+++ b/internal/staging/memo/memo_test.go
@@ -24,11 +24,10 @@ import (
 )
 
 func TestRoundtrip(t *testing.T) {
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !assert.NoError(t, err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	memo := fixture.Memo

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -40,11 +40,10 @@ import (
 func TestPutAndDrain(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	a.NotEmpty(fixture.StagingPool.Version)
@@ -213,11 +212,10 @@ func TestSelectMany(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	a.NotEmpty(fixture.StagingPool.Version)
@@ -461,11 +459,10 @@ func BenchmarkStage(b *testing.B) {
 }
 
 func benchmarkStage(b *testing.B, batchSize int) {
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(b)
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	targetDB := fixture.TargetSchema.Schema()

--- a/internal/staging/version/version_test.go
+++ b/internal/staging/version/version_test.go
@@ -27,9 +27,8 @@ import (
 func TestChecker(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	checker := fixture.VersionChecker
 	ctx := fixture.Context

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -34,7 +34,9 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/merge"
 	"github.com/cockroachdb/cdc-sink/internal/util/metrics"
 	"github.com/cockroachdb/cdc-sink/internal/util/msort"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
 	"github.com/cockroachdb/cdc-sink/internal/util/pjson"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -73,23 +75,18 @@ const (
 
 // newApply constructs an apply by inspecting the target table.
 func (f *factory) newApply(
-	product types.Product, inTarget ident.Table,
-) (_ *apply, cancel func(), _ error) {
-	// Start a background goroutine to refresh the templates.
-	ctx, cancel := context.WithCancel(context.Background())
-
-	w, err := f.watchers.Get(ctx, inTarget.Schema())
+	ctx *stopper.Context, product types.Product, inTarget ident.Table,
+) (*apply, error) {
+	w, err := f.watchers.Get(inTarget.Schema())
 	if err != nil {
-		cancel()
-		return nil, nil, err
+		return nil, err
 	}
 	// Use the target database's name for the table. We perform a lookup
 	// against the column data map to retrieve the original table name
 	// key under which the data was inserted.
 	target, ok := w.Get().OriginalName(inTarget)
 	if !ok {
-		cancel()
-		return nil, nil, errors.Errorf("unknown table %s", inTarget)
+		return nil, errors.Errorf("unknown table %s", inTarget)
 	}
 
 	labelValues := metrics.TableValues(target)
@@ -107,65 +104,60 @@ func (f *factory) newApply(
 		upserts:   applyUpserts.WithLabelValues(labelValues...),
 	}
 
-	errs := make(chan error, 1)
-	go func(ctx context.Context, errs chan<- error) {
-		defer cancel()
+	configHandle := f.configs.Get(target)
+	configData, configChanged := configHandle.Get()
 
+	if configData.Merger != nil {
+		switch a.product {
+		case types.ProductCockroachDB:
+		case types.ProductPostgreSQL:
+		default:
+			// Work items in https://github.com/cockroachdb/cdc-sink/issues/487
+			return nil, errors.Errorf("merge operation not implemented for %s", a.product)
+		}
+	}
+
+	var initialErr notify.Var[error]
+	_, ready := initialErr.Get()
+	ctx.Go(func() error {
 		schemaCh, cancelSchema, err := w.Watch(target)
 		if err != nil {
-			errs <- err
-			return
+			return err
 		}
 		defer cancelSchema()
-
-		configHandle := f.configs.Get(target)
-		configData, configChanged := configHandle.Get()
-
-		if configData.Merger != nil {
-			switch a.product {
-			case types.ProductCockroachDB:
-			case types.ProductPostgreSQL:
-			default:
-				// Work items in https://github.com/cockroachdb/cdc-sink/issues/487
-				errs <- errors.Errorf("merge operation not implemented for %s", a.product)
-				return
-			}
-		}
-
+		initial := true
 		var schemaData []types.ColData
 		for {
 			select {
-			case <-ctx.Done():
-				return
+			case <-ctx.Stopping():
+				return nil
 			case <-configChanged:
 				configData, configChanged = configHandle.Get()
 			case schemaData = <-schemaCh:
 			}
+
 			if len(schemaData) > 0 {
 				err := a.refreshUnlocked(configData, schemaData)
-				if err != nil {
+				if initial {
+					// If we're just starting up, return errors.
+					initialErr.Set(errors.Wrap(err, "could not read table metadata"))
+					initial = false
+				} else if err != nil {
+					// In the steady state, just log refresh errors.
 					log.WithError(err).WithField("table", target).Warn("could not refresh table metadata")
-				}
-				// Send the first error (or nil) to the channel, then
-				// close it. Shut down if we get an error at the outset.
-				if errs != nil {
-					errs <- err
-					close(errs)
-					errs = nil
-					if err != nil {
-						return
-					}
 				}
 			}
 		}
-	}(ctx, errs)
+	})
 
-	// Wait for the first loop of the refresh goroutine above.
-	if err := <-errs; err != nil {
-		return nil, nil, err
+	select {
+	case <-ready:
+		// Wait for the first loop of the refresh goroutine above.
+		err, _ = initialErr.Get()
+	case <-ctx.Stopping():
+		err = errors.New("stopping before initial schema read")
 	}
-
-	return a, cancel, nil
+	return a, err
 }
 
 // Apply applies the mutations to the target table.

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -48,11 +48,10 @@ import (
 func TestApply(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -947,7 +946,7 @@ func TestAllDataTypes(t *testing.T) {
 	var readBackQ string
 	var testcases []dataTypeTestCase
 	{
-		fixture, cancel, err := all.NewFixture()
+		fixture, err := all.NewFixture(t)
 		require.NoError(t, err)
 
 		switch fixture.TargetPool.Product {
@@ -985,7 +984,6 @@ func TestAllDataTypes(t *testing.T) {
 		default:
 			t.Fatal("unimplemented product")
 		}
-		cancel()
 	}
 
 	for _, tc := range testcases {
@@ -999,9 +997,8 @@ func TestAllDataTypes(t *testing.T) {
 			// changes in v23.1.
 			//
 			// https://github.com/cockroachdb/cockroach/issues/102259
-			fixture, cancel, err := all.NewFixture()
+			fixture, err := all.NewFixture(t)
 			require.NoError(t, err)
-			defer cancel()
 
 			ctx := fixture.Context
 
@@ -1108,11 +1105,10 @@ func TestConditionals(t *testing.T) {
 func testConditions(t *testing.T, cas, deadline bool) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -1286,11 +1282,10 @@ func testConditions(t *testing.T, cas, deadline bool) {
 func TestExpressionColumns(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -1357,9 +1352,8 @@ func TestExpressionColumns(t *testing.T) {
 func TestMergeWiring(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -1579,11 +1573,10 @@ func TestMergeWiring(t *testing.T) {
 func TestIgnoredColumns(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -1634,11 +1627,10 @@ func TestIgnoredColumns(t *testing.T) {
 func TestRenamedColumns(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -1687,11 +1679,10 @@ func TestRenamedColumns(t *testing.T) {
 func TestRepeatedKeysWithIgnoredColumns(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	if strings.Contains(fixture.TargetPool.Version, "PostgreSQL 11") {
 		t.Skip("PostgreSQL v11 doesn't support generated columns")
@@ -1786,9 +1777,8 @@ func TestRepeatedKeysWithIgnoredColumns(t *testing.T) {
 // Verify that user-defined enums with mixed-case identifiers work.
 func TestUDTEnum(t *testing.T) {
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	require.NoError(t, err)
-	defer cancel()
 
 	if fixture.TargetPool.Product != types.ProductCockroachDB {
 		t.Skip("test not relevant to product")
@@ -1855,11 +1845,10 @@ func TestUDTEnum(t *testing.T) {
 func TestVirtualColumns(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	switch fixture.TargetPool.Product {
 	case types.ProductMariaDB, types.ProductMySQL:
@@ -2057,11 +2046,10 @@ func BenchmarkApply(b *testing.B) {
 func benchConditions(b *testing.B, cfg benchConfig) {
 	a := assert.New(b)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(b)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 

--- a/internal/target/dlq/dlq.go
+++ b/internal/target/dlq/dlq.go
@@ -97,7 +97,7 @@ func (d *dlqs) Get(ctx context.Context, target ident.Schema, name string) (types
 		return found, nil
 	}
 
-	watcher, err := d.watchers.Get(ctx, target)
+	watcher, err := d.watchers.Get(target)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/target/dlq/dlq_test.go
+++ b/internal/target/dlq/dlq_test.go
@@ -32,9 +32,8 @@ import (
 func TestDLQ(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -74,9 +73,8 @@ func TestDLQ(t *testing.T) {
 func TestMissingColumns(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -99,9 +97,8 @@ func TestMissingColumns(t *testing.T) {
 func TestMissingTable(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	_, err = fixture.DLQs.Get(ctx, fixture.TargetSchema.Schema(), "foo")

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -32,11 +32,10 @@ import (
 func TestGetColumns(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 
@@ -472,7 +471,7 @@ func TestGetColumns(t *testing.T) {
 					name = "ignored_" + name
 				}
 				if colData[i].Primary {
-					a.Empty(dataCols, "should see PKs before data colums")
+					a.Empty(dataCols, "should see PKs before data columns")
 					primaryKeys = append(primaryKeys, name)
 				} else {
 					dataCols = append(dataCols, name)
@@ -498,11 +497,10 @@ func TestGetColumns(t *testing.T) {
 func TestColDataIgnoresViews(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 

--- a/internal/target/schemawatch/dependencies_test.go
+++ b/internal/target/schemawatch/dependencies_test.go
@@ -34,9 +34,8 @@ func TestGetDependencyOrder(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	tcs := []struct {
 		name   string
@@ -201,9 +200,8 @@ func TestNoDeferrableConstraints(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, cancel, err := base.NewFixture()
+	fixture, err := base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	if fixture.TargetPool.Product != types.ProductCockroachDB {
 		t.Skip("only for CRDB")
@@ -223,9 +221,8 @@ func TestCrossSchemaTableReferencesPG(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	pool := fixture.TargetPool

--- a/internal/target/schemawatch/watcher_test.go
+++ b/internal/target/schemawatch/watcher_test.go
@@ -38,15 +38,14 @@ func TestWatch(t *testing.T) {
 	*schemawatch.RefreshDelay = delay
 	defer func() { *schemawatch.RefreshDelay = time.Minute }()
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	dbName := fixture.TargetSchema.Schema()
 	w := fixture.Watcher
 
-	w2, err := fixture.Watchers.Get(ctx, sinktest.JumbleSchema(fixture.TargetSchema.Schema()))
+	w2, err := fixture.Watchers.Get(sinktest.JumbleSchema(fixture.TargetSchema.Schema()))
 	r.NoError(err)
 	r.Same(w, w2)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -346,31 +346,6 @@ type StagingPool struct {
 	_ noCopy
 }
 
-// A Stoppable object can indicate when it has reached a terminal state.
-type Stoppable interface {
-	Stopped() <-chan struct{}
-}
-
-// Stoppables aggregates multiple Stoppable instances.
-type Stoppables []Stoppable
-
-// Stopped implements Stoppable to return a channel that is closed
-// when all enclosed elements have been stopped.
-func (s Stoppables) Stopped() <-chan struct{} {
-	chans := make([]<-chan struct{}, len(s))
-	for idx, stoppable := range s {
-		chans[idx] = stoppable.Stopped()
-	}
-	ch := make(chan struct{})
-	go func() {
-		defer close(ch)
-		for _, sub := range chans {
-			<-sub
-		}
-	}()
-	return ch
-}
-
 // SourcePool is an injection point for a connection to a source
 // database.
 type SourcePool struct {
@@ -434,7 +409,7 @@ type Watcher interface {
 
 // Watchers is a factory for Watcher instances.
 type Watchers interface {
-	Get(ctx context.Context, db ident.Schema) (Watcher, error)
+	Get(db ident.Schema) (Watcher, error)
 }
 
 type noCopy struct{}

--- a/internal/util/applycfg/configs_test.go
+++ b/internal/util/applycfg/configs_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,8 +32,7 @@ func TestConfigs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	diags, cancel := diag.New(ctx)
-	defer cancel()
+	diags := diag.New(stopper.WithContext(ctx))
 
 	cfgs, err := ProvideConfigs(diags)
 	r.NoError(err)

--- a/internal/util/diag/diag.go
+++ b/internal/util/diag/diag.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/httpauth"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -64,7 +65,7 @@ type Diagnostics struct {
 
 // New constructs a Diagnostics. The instance will write itself to the
 // log stream if the process receives a SIGUSR1.
-func New(ctx context.Context) (*Diagnostics, func()) {
+func New(ctx *stopper.Context) *Diagnostics {
 	ret := &Diagnostics{}
 	ret.mu.impls = map[string]Diagnostic{
 		"build": DiagnosticFn(func(context.Context) any {
@@ -83,10 +84,9 @@ func New(ctx context.Context) (*Diagnostics, func()) {
 		}),
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
 	logOnSignal(ctx, ret)
 
-	return ret, cancel
+	return ret
 }
 
 // Handler returns an [http.Handler] to provide a summary report.

--- a/internal/util/diag/diag_test.go
+++ b/internal/util/diag/diag_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/reject"
 	"github.com/cockroachdb/cdc-sink/internal/staging/auth/trust"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,8 +38,7 @@ func TestAuth(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d, cancel := New(ctx)
-	defer cancel()
+	d := New(stopper.WithContext(ctx))
 
 	tcs := []struct {
 		auth   types.Authenticator
@@ -77,8 +77,7 @@ func TestDiagnostics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d, cancel := New(ctx)
-	defer cancel()
+	d := New(stopper.WithContext(ctx))
 
 	var didCall atomic.Bool
 	r.NoError(d.Register("foo", DiagnosticFn(func(context.Context) any {

--- a/internal/util/serial/serial_test.go
+++ b/internal/util/serial/serial_test.go
@@ -71,11 +71,10 @@ func (u *fakeUnlockable) Unlocked() bool { return bool(*u) }
 func TestPool(t *testing.T) {
 	a := assert.New(t)
 
-	fixture, cancel, err := all.NewFixture()
+	fixture, err := all.NewFixture(t)
 	if !a.NoError(err) {
 		return
 	}
-	defer cancel()
 
 	ctx := fixture.Context
 	p := &Pool{Pool: fixture.StagingPool.Pool}

--- a/internal/util/stdlogical/stdlogical_test.go
+++ b/internal/util/stdlogical/stdlogical_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -39,8 +40,8 @@ func TestSmoke(t *testing.T) {
 	cmd := New(&Template{
 		Bind:    nil, // No extra CLI flags
 		Metrics: "127.0.0.1:13013",
-		Start: func(cmd *cobra.Command) (started any, cancel func(), err error) {
-			return nil, nil, nil
+		Start: func(ctx *stopper.Context, cmd *cobra.Command) (started any, err error) {
+			return nil, nil
 		},
 		Use: "test",
 		testCallback: func() {

--- a/internal/util/stdpool/metrics_test.go
+++ b/internal/util/stdpool/metrics_test.go
@@ -28,11 +28,9 @@ import (
 func TestConcurrentRegistration(t *testing.T) {
 	r := require.New(t)
 
-	_, cancel, err := base.NewFixture()
+	_, err := base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
-	_, cancel, err = base.NewFixture()
+	_, err = base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 }

--- a/internal/util/stdpool/target.go
+++ b/internal/util/stdpool/target.go
@@ -17,22 +17,22 @@
 package stdpool
 
 import (
-	"context"
 	"net/url"
 	"strings"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/pkg/errors"
 )
 
 // OpenTarget selects from target connector implementations based on the
 // URL scheme contained in the connection string.
 func OpenTarget(
-	ctx context.Context, connectString string, options ...Option,
-) (*types.TargetPool, func(), error) {
+	ctx *stopper.Context, connectString string, options ...Option,
+) (*types.TargetPool, error) {
 	u, err := url.Parse(connectString)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not parse connection string")
+		return nil, errors.Wrap(err, "could not parse connection string")
 	}
 
 	switch strings.ToLower(u.Scheme) {
@@ -43,6 +43,6 @@ func OpenTarget(
 	case "ora", "oracle":
 		return OpenOracleAsTarget(ctx, connectString, options...)
 	default:
-		return nil, nil, errors.Errorf("unknown URL scheme: %s", u.Scheme)
+		return nil, errors.Errorf("unknown URL scheme: %s", u.Scheme)
 	}
 }

--- a/internal/util/txguard/guard_test.go
+++ b/internal/util/txguard/guard_test.go
@@ -31,9 +31,8 @@ import (
 func TestGuard(t *testing.T) {
 	r := require.New(t)
 
-	fixture, cancel, err := base.NewFixture()
+	fixture, err := base.NewFixture(t)
 	r.NoError(err)
-	defer cancel()
 
 	ctx := fixture.Context
 	db := fixture.StagingPool


### PR DESCRIPTION
The cleanup function in Wire is quite useful, but it's not the right pattern when we have background processes in cdc-sink. It's often the case that, in tests, we tear down the database pool before some goroutine has had a chance to stop. This creates log-spam in the tests, which is also sometimes seen when shutting down a real cdc-sink process.

The existing `stopper.Context` gains a new `Defer()` method. Like its golang namesake, `Defer()` accepts a function to be called in LIFO order after the stopper has stopped. This means that cleanup of, say, a database pool can be deferred until after any goroutines that use it have exited or been cancelled.

The remainder of the changes are essentially mechanical:
* Every top-level Wire injector function that used to return a cancel function now only return the constructed object and an error.
* The Wire code-generator complains about any provider method that returns a cancel function, since there would be no way to call it.
* Provider functions that previously had a cancel behavior are changed to accept a `*stopper.Context` and to use the new `Defer()` method.
* All cases where a long-lived, background goroutine is started must now use `stopper.Context.Go()`, which coordinates the lifecycle of the goroutine versus the services that it uses in the injector graph.
* Factory types that accumulated cleanup functions for long-lived service objects delegate cleanup to the top-level stopper. This naturally falls out of the previous point.
* The test fixture injector methods `all.NewFixture()` and `base.NewFixture()` require the associated `*testing.T` and register the top-level stopper with the `TB.Cleanup()` method.

The net result is that, for any given injector graph, a consistent way to tear down long-lived objects and services in a wholly coordinated fashion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/577)
<!-- Reviewable:end -->
