### PR TITLE
workflows: Use larger machine shape for test suite

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -72,7 +72,8 @@ jobs:
   # Integration matrix tests for all supported CRDB and source DBs.
   tests:
     name: Integration Tests
-    runs-on: ${{ matrix.runs-on || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runs-on || 'ubuntu-latest-8-core' }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       # Refer to the CRDB support policy when determining how many
@@ -118,8 +119,6 @@ jobs:
 #            target: oracle-v18.4
 #            targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
           - cockroachdb: v23.1
-            # Managed by dev-inf team.
-            runs-on: ubuntu-latest-8-core
             target: oracle-v21.3
             targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
 

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -109,6 +109,7 @@ func createFixture(
 }
 
 func testQueryHandler(t *testing.T, htc *fixtureConfig) {
+	t.Parallel()
 	t.Helper()
 	fixture, tableInfo := createFixture(t, htc)
 	ctx := fixture.Context
@@ -299,6 +300,7 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 }
 
 func testHandler(t *testing.T, cfg *fixtureConfig) {
+	t.Parallel()
 	t.Helper()
 	fixture, tableInfo := createFixture(t, cfg)
 	ctx := fixture.Context

--- a/internal/source/server/integration_test.go
+++ b/internal/source/server/integration_test.go
@@ -116,6 +116,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func testIntegration(t *testing.T, cfg testConfig) {
+	t.Parallel()
 	a := assert.New(t)
 	r := require.New(t)
 

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -987,7 +987,9 @@ func TestAllDataTypes(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc // Capture for t.Parallel().
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			r := require.New(t)
 
 			// Creating a new database for each loop is, as of v22.2 and

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -420,6 +420,11 @@ func TestGetColumns(t *testing.T) {
 
 	for i, test := range testcases {
 		t.Run(fmt.Sprintf("%d:%s", i, test.tableSchema), func(t *testing.T) {
+			// This test can't be marked as parallel until the test
+			// cases above are able to take a *Fixture as input.
+			// Otherwise, concurrent tests would clash on tables defined
+			// in the same schema, leading to a race condition.
+
 			if test.skip {
 				t.Skip("not applicable")
 			}


### PR DESCRIPTION
This change uses an 8-core machine with more memory for running the unit tests. Several tests which were not marked as `t.Parallel()` due to resource constraints are allowed to run in parallel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/580)
<!-- Reviewable:end -->
