### PR TITLE
pglogical: Add fix and test for UDT enum types

### DIFF
--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -154,6 +154,11 @@ func (c *conn) Process(
 		case *pglogrepl.TruncateMessage:
 			err = errors.Errorf("the TRUNCATE operation cannot be supported on table %d", msg.RelationNum)
 
+		case *pglogrepl.TypeMessage:
+			// This type is intentionally discarded. We interpret the
+			// type of the data based on the target table, not the
+			// source.
+
 		default:
 			err = errors.Errorf("unimplemented logical replication message %T", msg)
 		}


### PR DESCRIPTION
This change adds a test for an enum type in the source and target databases. When a UDT is used, a TypeMessage will be sent over the pglogical feed. We can ignore this message, since we interpret incoming data via the target typesystem.

Fixes #578

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/582)
<!-- Reviewable:end -->
