### PR TITLE
pglogical: skip empty transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/otiai10/copy v1.6.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
+	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,8 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,7 +96,7 @@ func TestPGLogical(t *testing.T) {
 
 func testPGLogical(t *testing.T, fc *fixtureConfig) {
 	a := assert.New(t)
-
+	r := require.New(t)
 	// Create a basic test fixture.
 	fixture, err := base.NewFixture(t)
 	if !a.NoError(err) {
@@ -106,11 +109,12 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 	crdbPool := fixture.TargetPool
 
 	pgPool, cancel, err := setupPGPool(dbName)
-	if !a.NoError(err) {
-		return
-	}
-	defer cancel()
+	r.NoError(err)
 
+	defer cancel()
+	cancel, err = setupPublication(ctx, pgPool, dbName, "ALL TABLES")
+	r.NoError(err)
+	defer cancel()
 	// Create the schema in both locations.
 	var tgts []ident.Table
 	if fc.script {
@@ -187,9 +191,7 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 			})
 		}
 	}
-	if !a.NoError(eg.Wait()) {
-		return
-	}
+	r.NoError(err)
 
 	pubNameRaw := publicationName(dbName).Raw()
 	// Start the connection, to demonstrate that we can backfill pending mutations.
@@ -222,9 +224,7 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 		}
 	}
 	repl, err := Start(ctx, cfg)
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 
 	// Wait for backfill.
 	for _, tgt := range tgts {
@@ -244,17 +244,13 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 
 	// Let's perform an update in a single transaction.
 	tx, err := pgPool.Begin(ctx)
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 	for _, tgt := range tgts {
 		if _, err := tx.Exec(ctx, fmt.Sprintf("UPDATE %s SET v = 'updated'", tgt)); !a.NoError(err) {
 			return
 		}
 	}
-	if !a.NoError(tx.Commit(ctx)) {
-		return
-	}
+	r.NoError(tx.Commit(ctx))
 
 	// Wait for the update to propagate.
 	for _, tgt := range tgts {
@@ -274,17 +270,13 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 
 	// Delete some rows.
 	tx, err = pgPool.Begin(ctx)
-	if !a.NoError(err) {
-		return
-	}
+	r.NoError(err)
 	for _, tgt := range tgts {
 		if _, err := tx.Exec(ctx, fmt.Sprintf("DELETE FROM %s WHERE pk < 50", tgt)); !a.NoError(err) {
 			return
 		}
 	}
-	if !a.NoError(tx.Commit(ctx)) {
-		return
-	}
+	r.NoError(tx.Commit(ctx))
 
 	// Wait for the deletes to propagate.
 	for _, tgt := range tgts {
@@ -378,6 +370,10 @@ func TestDataTypes(t *testing.T) {
 	r.NoError(err)
 	defer cancel()
 
+	cancel, err = setupPublication(ctx, pgPool, dbName, "ALL TABLES")
+	r.NoError(err)
+	defer cancel()
+
 	enumQ := fmt.Sprintf(`CREATE TYPE %s."Simple-Enum" AS ENUM ('foo', 'bar')`, dbSchema)
 	_, err = crdbPool.ExecContext(ctx, enumQ)
 	r.NoError(err, enumQ)
@@ -437,9 +433,7 @@ func TestDataTypes(t *testing.T) {
 		a.NoError(tx.Commit(ctx))
 	}
 	log.Info(tgts)
-
 	pubNameRaw := publicationName(dbName).Raw()
-
 	// Start the connection, to demonstrate that we can backfill pending mutations.
 	repl, err := Start(fixture.Context, &Config{
 		BaseConfig: logical.BaseConfig{
@@ -484,6 +478,143 @@ func TestDataTypes(t *testing.T) {
 	a.NoError(ctx.Wait())
 }
 
+func TestEmptyTransactions(t *testing.T) {
+	t.Run("donot-skip-empty", func(t *testing.T) {
+		testEmptyTransactions(t, false)
+	})
+	t.Run("skip-empty", func(t *testing.T) {
+		testEmptyTransactions(t, true)
+	})
+}
+
+func getCounterValue(t *testing.T, counter prometheus.Counter) int {
+	r := require.New(t)
+	var metric = &dto.Metric{}
+	err := emptyTransactionCount.Write(metric)
+	r.NoError(err)
+	return int(metric.Counter.GetValue())
+}
+
+// testEmptyTransactions must be run sequentially
+// we are tracking metrics to verify that we see,
+// and skip if required, empty transactions.
+func testEmptyTransactions(t *testing.T, skipEmpty bool) {
+
+	a := assert.New(t)
+	r := require.New(t)
+
+	emptyTxnSeenStart := getCounterValue(t, emptyTransactionCount)
+	emptyTxnSkippedStart := getCounterValue(t, skippedEmptyTransactionCount)
+
+	applicableVersions := regexp.MustCompile("PostgreSQL 1[1234]")
+	// Create a basic test fixture.
+	fixture, err := base.NewFixture(t)
+	r.NoError(err)
+
+	ctx := fixture.Context
+	dbSchema := fixture.TargetSchema.Schema()
+	dbName := dbSchema.Idents(nil)[0] // Extract first name part.
+
+	pgPool, cancel, err := setupPGPool(dbName)
+	r.NoError(err)
+	defer cancel()
+
+	rows, err := pgPool.Query(ctx, "select version()")
+	r.NoError(err)
+	defer rows.Close()
+	var pgVersion string
+	if rows.Next() {
+		rows.Scan(&pgVersion)
+	}
+	if !applicableVersions.MatchString(pgVersion) {
+		t.Skipf("not applicable for Postgres >= 15. Version: %s", fixture.SourcePool.Version)
+	}
+	rows.Close()
+
+	crdbPool := fixture.TargetPool
+	replTable := ident.NewTable(dbSchema, ident.New("replTable"))
+	localTable := ident.NewTable(dbSchema, ident.New("localTable"))
+
+	// Create replTable in both locations.
+	var schema = fmt.Sprintf("CREATE TABLE %s (k INT PRIMARY KEY, v int)", replTable)
+	_, err = crdbPool.ExecContext(ctx, schema)
+	if !a.NoErrorf(err, "CRDB %s", replTable) {
+		return
+	}
+
+	if _, err := pgPool.Exec(ctx, schema); !a.NoErrorf(err, "PG %s", schema) {
+		return
+	}
+	var localSchema = fmt.Sprintf("CREATE TABLE %s (k INT PRIMARY KEY, v int)", localTable.Table())
+	if _, err := pgPool.Exec(ctx, localSchema); !a.NoErrorf(err, "PG %s", localTable) {
+		return
+	}
+	// setup replication for only the replTable
+	cancel, err = setupPublication(ctx, pgPool, dbName, fmt.Sprintf(`TABLE %s`, replTable))
+	r.NoError(err)
+	defer cancel()
+
+	pubNameRaw := publicationName(dbName).Raw()
+
+	// Start the connection, to demonstrate that we can backfill pending mutations.
+	repl, err := Start(fixture.Context, &Config{
+		BaseConfig: logical.BaseConfig{
+			RetryDelay:    time.Millisecond,
+			StagingSchema: fixture.StagingDB.Schema(),
+			TargetConn:    crdbPool.ConnectionString,
+		},
+		LoopConfig: logical.LoopConfig{
+			LoopName:     "pglogicaltest",
+			TargetSchema: dbSchema,
+		},
+		Publication:           pubNameRaw,
+		SkipEmptyTransactions: skipEmpty,
+		Slot:                  pubNameRaw,
+		SourceConn:            *pgConnString + dbName.Raw(),
+	})
+	r.NoError(err)
+
+	// Insert a value in the replTable
+	if _, err := pgPool.Exec(ctx,
+		fmt.Sprintf(`INSERT INTO %s VALUES (1,1)`, replTable)); !a.NoErrorf(err, "%s", replTable) {
+		return
+	}
+
+	// Insert a value in the localTable
+	if _, err := pgPool.Exec(ctx,
+		fmt.Sprintf(`INSERT INTO %s VALUES (1,1)`, localTable)); !a.NoErrorf(err, "%s", replTable) {
+		return
+	}
+	// Insert a value in the replTable
+	if _, err := pgPool.Exec(ctx,
+		fmt.Sprintf(`INSERT INTO %s VALUES (2,2)`, replTable)); !a.NoErrorf(err, "%s", replTable) {
+		return
+	}
+
+	// Waiting for the values in the replTable to show up
+	var count int
+	for count < 2 {
+		count, err = base.GetRowCount(ctx, crdbPool, replTable)
+		if !a.NoError(err) {
+			return
+		}
+		if count == 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	a.Equal(2, count)
+	// Check emptyTransactionCount, we should see one empty transaction.
+	a.Equal(emptyTxnSeenStart+1, getCounterValue(t, emptyTransactionCount))
+	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
+	// If we are skipping transactions, check the skippedEmptyTransactionCount.
+	if skipEmpty {
+		a.Equal(emptyTxnSkippedStart+1, getCounterValue(t, skippedEmptyTransactionCount))
+	}
+	ctx.Stop(time.Second)
+	a.NoError(ctx.Wait())
+
+}
+
 // Allowable publication slot names are a subset of allowable
 // database names, so we need to replace the must-quote dashes in
 // the database name.
@@ -514,27 +645,41 @@ func setupPGPool(database ident.Ident) (*pgxpool.Pool, func(), error) {
 		return nil, func() {}, err
 	}
 
-	pubName := publicationName(database)
+	return retConn, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Can't drop the default database from its own connection.
+		_, err = baseConn.Exec(ctx, fmt.Sprintf("DROP DATABASE %s", database))
+		if err != nil {
+			log.WithError(err).Error("could not drop database")
+		}
+		baseConn.Close()
+		log.Trace("finished pg pool cleanup")
+	}, nil
+}
 
+func setupPublication(
+	ctx context.Context, retConn *pgxpool.Pool, database ident.Ident, scope string,
+) (func(), error) {
+	pubName := publicationName(database)
 	if _, err := retConn.Exec(ctx,
-		fmt.Sprintf("CREATE PUBLICATION %s FOR ALL TABLES", pubName),
+		fmt.Sprintf("CREATE PUBLICATION %s FOR %s", pubName, scope),
 	); err != nil {
-		return nil, func() {}, err
+		return func() {}, err
 	}
 
 	if _, err := retConn.Exec(ctx,
 		"SELECT pg_create_logical_replication_slot($1, 'pgoutput')",
 		pubName.Raw(),
 	); err != nil {
-		return nil, func() {}, err
+		return func() {}, err
 	}
-
-	return retConn, func() {
+	return func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		_, err := retConn.Exec(ctx, "SELECT pg_drop_replication_slot($1)", pubName.Raw())
 		if err != nil {
-			log.WithError(err).Error("could not drop database")
+			log.WithError(err).Error("could not drop replication slot")
 		}
 		_, err = retConn.Exec(ctx, fmt.Sprintf("DROP PUBLICATION %s", pubName))
 		if err != nil {
@@ -542,12 +687,6 @@ func setupPGPool(database ident.Ident) (*pgxpool.Pool, func(), error) {
 		}
 		retConn.Close()
 
-		// Can't drop the default database from its own connection.
-		_, err = baseConn.Exec(ctx, fmt.Sprintf("DROP DATABASE %s", database))
-		if err != nil {
-			log.WithError(err).Error("could not drop database")
-		}
-		baseConn.Close()
 		log.Trace("finished pg pool cleanup")
 	}, nil
 }

--- a/internal/source/pglogical/metrics.go
+++ b/internal/source/pglogical/metrics.go
@@ -30,4 +30,12 @@ var (
 		Name: "pglogical_dial_success_total",
 		Help: "the number of times we successfully dialed a replication connection",
 	})
+	skippedEmptyTransactionCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_skipped_empty_transactions",
+		Help: "the number of times we skipped an empty transaction",
+	})
+	emptyTransactionCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_empty_transactions",
+		Help: "the number of empty transactions we have seen",
+	})
 )

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -89,11 +89,12 @@ func ProvideDialect(
 	sourceConfig.RuntimeParams["replication"] = "database"
 
 	return &conn{
-		columns:         &ident.TableMap[[]types.ColData]{},
-		publicationName: config.Publication,
-		relations:       make(map[uint32]ident.Table),
-		slotName:        config.Slot,
-		sourceConfig:    sourceConfig,
+		columns:               &ident.TableMap[[]types.ColData]{},
+		publicationName:       config.Publication,
+		relations:             make(map[uint32]ident.Table),
+		skipEmptyTransactions: config.SkipEmptyTransactions,
+		slotName:              config.Slot,
+		sourceConfig:          sourceConfig,
 	}, nil
 }
 


### PR DESCRIPTION
In Postgres older releases (<v15) the walsender sends an empty transaction if all DMLs in the transaction are not published to publication filter.

See https://github.com/postgres/postgres/commit/d5a9d86d8f. 

This change allows cdc-sink to skip these transactions without updating the last consistent point in the memo table. The change is gated behind the --skipEmptyTransactions configuration flag.

Adding two prometheus counters to track empty transactions and skipped empty transactions.
Fixes #588

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/589)
<!-- Reviewable:end -->
