### PR TITLE
support for a mutation specific custom upsert template.

### DIFF
--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	Slot string
 	// Connection string for the source db.
 	SourceConn string
+	// Enable support for toasted columns
+	ToastedColumns bool
 }
 
 // Bind adds flags to the set.
@@ -55,6 +57,8 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	f.StringVar(&c.SourceConn, "sourceConn", "", "the source database's connection string")
 	f.StringVar(&c.Publication, "publicationName", "",
 		"the publication within the source database to replicate")
+	f.BoolVar(&c.ToastedColumns, "enableToastedColumns", false,
+		"Enable support for toasted columns")
 }
 
 // Preflight updates the configuration with sane defaults or returns an

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -21,8 +21,11 @@ package pglogical
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
@@ -490,7 +493,7 @@ func TestEmptyTransactions(t *testing.T) {
 func getCounterValue(t *testing.T, counter prometheus.Counter) int {
 	r := require.New(t)
 	var metric = &dto.Metric{}
-	err := emptyTransactionCount.Write(metric)
+	err := counter.Write(metric)
 	r.NoError(err)
 	return int(metric.Counter.GetValue())
 }
@@ -613,6 +616,139 @@ func testEmptyTransactions(t *testing.T, skipEmpty bool) {
 	ctx.Stop(time.Second)
 	a.NoError(ctx.Wait())
 
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func TestToast(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+	// We need a long string that is not compressible.
+	longString := randString(1 << 12)
+	longObj, err := json.Marshal(longString)
+	r.NoError(err)
+	// Create a basic test fixture.
+	fixture, err := base.NewFixture(t)
+	r.NoError(err)
+
+	ctx := fixture.Context
+	dbSchema := fixture.TargetSchema.Schema()
+	dbName := dbSchema.Idents(nil)[0] // Extract first name part.
+	crdbPool := fixture.TargetPool
+
+	pgPool, cancel, err := setupPGPool(dbName)
+	r.NoError(err)
+	defer cancel()
+
+	cancel, err = setupPublication(ctx, pgPool, dbName, "ALL TABLES")
+	r.NoError(err)
+	defer cancel()
+
+	name := ident.NewTable(dbSchema, ident.New("toast"))
+	// Create the schema in both locations.
+	schema := fmt.Sprintf(`
+	CREATE TABLE %s
+	  (k INT PRIMARY KEY,
+	   i int,
+	   j jsonb,
+	   s string,
+	   t text,
+	   deleted bool not null default false)`, name)
+	if _, err := crdbPool.ExecContext(ctx, schema); !a.NoError(err) {
+		return
+	}
+	schema = fmt.Sprintf(`
+	CREATE TABLE %s
+	  (k INT PRIMARY KEY,
+	   i int,
+	   j jsonb,
+	   s text,
+	   t text,
+	   deleted bool not null default false)`, name)
+	if _, err := pgPool.Exec(ctx, schema); !a.NoErrorf(err, "PG %s", schema) {
+		return
+	}
+	// Inserting an initial value. The t,s,j columns contains a large object that
+	// will be toast-ed in the Postgres side.
+	_, err = pgPool.Exec(ctx,
+		fmt.Sprintf(`INSERT INTO %s VALUES ($1, $2, $3, $4, $5)`, name),
+		1, 0, longObj, longString, longString)
+	r.NoError(err)
+	// We update the "i" column few times without changing the j column.
+	updates := 10
+	for i := 1; i <= updates; i++ {
+		if _, err := pgPool.Exec(ctx,
+			fmt.Sprintf(`UPDATE %s SET i = $2 WHERE k = $1`, name), 1, i,
+		); !a.NoErrorf(err, "%s", name) {
+			return
+		}
+	}
+
+	pubNameRaw := publicationName(dbName).Raw()
+
+	cfg := &Config{
+		BaseConfig: logical.BaseConfig{
+			RetryDelay:    time.Millisecond,
+			StagingSchema: fixture.StagingDB.Schema(),
+			TargetConn:    crdbPool.ConnectionString,
+			Immediate:     true,
+		},
+		LoopConfig: logical.LoopConfig{
+			LoopName:     "pglogicaltest",
+			TargetSchema: dbSchema,
+		},
+		Publication:    pubNameRaw,
+		Slot:           pubNameRaw,
+		SourceConn:     *pgConnString + dbName.Raw(),
+		ToastedColumns: true,
+	}
+	repl, err := Start(fixture.Context, cfg)
+
+	if !a.NoError(err) {
+		return
+	}
+
+	t.Run("toast", func(t *testing.T) {
+		a := assert.New(t)
+		count := 1
+		for count < updates {
+			row := crdbPool.QueryRowContext(ctx, fmt.Sprintf("SELECT i from %s limit 1", name))
+			err = row.Scan(&count)
+			if err == sql.ErrNoRows {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			r.NoError(err)
+			if count < updates {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+		a.Equalf(updates, count, "mismatch in %s", name)
+		var text sql.NullString
+		var st sql.NullString
+		var json []byte
+		row := crdbPool.QueryRowContext(ctx, fmt.Sprintf("SELECT j,s,t from %s where k=1", name))
+		err = row.Scan(&json, &st, &text)
+		// Verify that the toasted column has the initial value
+		a.Equal(longObj, json)
+		a.Equal(longString, st.String)
+		a.Equal(longString, text.String)
+		// Verify that we actually seen empty toasted column markers
+		a.Equal(updates*3, getCounterValue(t, unchangedToastedColumns))
+
+	})
+
+	sinktest.CheckDiagnostics(ctx, t, repl.Diagnostics)
+	ctx.Stop(time.Second)
+	a.NoError(ctx.Wait())
 }
 
 // Allowable publication slot names are a subset of allowable

--- a/internal/source/pglogical/metrics.go
+++ b/internal/source/pglogical/metrics.go
@@ -38,4 +38,8 @@ var (
 		Name: "pglogical_empty_transactions",
 		Help: "the number of empty transactions we have seen",
 	})
+	unchangedToastedColumns = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_unchanged_toasted_columns",
+		Help: "the number of times we see unchanged toasted columns",
+	})
 )

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -95,6 +95,7 @@ func ProvideDialect(
 		skipEmptyTransactions: config.SkipEmptyTransactions,
 		slotName:              config.Slot,
 		sourceConfig:          sourceConfig,
+		toastedColumns:        config.ToastedColumns,
 	}, nil
 }
 

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -200,10 +200,24 @@ func (a *apply) Apply(ctx context.Context, tx types.TargetQuerier, muts []types.
 				}
 				deletes = deletes[:0]
 			}
+		} else if custom, ok := muts[i].Meta[types.CustomUpsert]; ok {
+			// Flush
+			if err := a.upsertLocked(ctx, tx, upserts, ""); err != nil {
+				return countError(err)
+			}
+			upserts = upserts[:0]
+			template, ok := custom.(string)
+			if !ok {
+				return errors.Errorf("invalid value for Meta[%s]", types.CustomUpsert)
+			}
+			// Apply custom template on its own.
+			if err := a.upsertLocked(ctx, tx, []types.Mutation{muts[i]}, template); err != nil {
+				return countError(err)
+			}
 		} else {
 			upserts = append(upserts, muts[i])
 			if len(upserts) == cap(upserts) {
-				if err := a.upsertLocked(ctx, tx, upserts); err != nil {
+				if err := a.upsertLocked(ctx, tx, upserts, ""); err != nil {
 					return countError(err)
 				}
 				upserts = upserts[:0]
@@ -215,7 +229,7 @@ func (a *apply) Apply(ctx context.Context, tx types.TargetQuerier, muts []types.
 	if err := a.deleteLocked(ctx, tx, deletes); err != nil {
 		return countError(err)
 	}
-	if err := a.upsertLocked(ctx, tx, upserts); err != nil {
+	if err := a.upsertLocked(ctx, tx, upserts, ""); err != nil {
 		return countError(err)
 	}
 	a.durations.Observe(time.Since(start).Seconds())
@@ -296,7 +310,7 @@ func (a *apply) deleteLocked(
 // upsertLocked decodes the mutations into property bags and calls
 // upsertBagsLocked.
 func (a *apply) upsertLocked(
-	ctx context.Context, db types.TargetQuerier, muts []types.Mutation,
+	ctx context.Context, db types.TargetQuerier, muts []types.Mutation, template string,
 ) error {
 	// Decode the mutations into schema-aware property bags. These will
 	// group property values into those known in the schema, versus
@@ -310,8 +324,7 @@ func (a *apply) upsertLocked(
 	); err != nil {
 		return err
 	}
-
-	return a.upsertBagsLocked(ctx, db, applyConditional, muts, allPayloadData)
+	return a.upsertBagsLocked(ctx, db, applyConditional, muts, allPayloadData, template)
 }
 
 // upsertArgsLocked shuffles the contents of the property bags into the
@@ -438,6 +451,7 @@ func (a *apply) upsertBagsLocked(
 	mode applyMode,
 	muts []types.Mutation,
 	bags []*merge.Bag,
+	template string,
 ) error {
 	// Don't test len(muts), we discard them when applying merged data.
 	if len(bags) == 0 {
@@ -455,8 +469,13 @@ func (a *apply) upsertBagsLocked(
 	// transaction.
 	stmt, err := a.cache.Prepare(ctx,
 		db,
-		fmt.Sprintf("upsert-%s-%d-%d-%v", a.target, a.mu.gen, len(bags), mode),
+		fmt.Sprintf("upsert-%s-%d-%d-%v-%s", a.target, a.mu.gen, len(bags), mode, template),
 		func() (string, error) {
+			if template != "" {
+				// We only support applyUnconditional with custom templates.
+				mode = applyUnconditional
+				return a.mu.templates.customExpr(len(bags), template, mode)
+			}
 			return a.mu.templates.upsertExpr(len(bags), mode)
 		})
 	if err != nil {
@@ -465,6 +484,9 @@ func (a *apply) upsertBagsLocked(
 
 	merger := a.mu.templates.Merger
 
+	if template != "" && merger != nil {
+		return errors.New("merge not supported with custom templates")
+	}
 	// If no merge function is defined or if we're forcing upserts,
 	// we'll just execute the statement and return.
 	if mode == applyUnconditional || merger == nil {
@@ -605,7 +627,7 @@ func (a *apply) upsertBagsLocked(
 	log.WithField("resolves", len(fixups)).Trace("resolved merge conflicts")
 
 	// We'll recurse into this function, but apply unconditionally.
-	return a.upsertBagsLocked(ctx, db, applyUnconditional, nil, fixups)
+	return a.upsertBagsLocked(ctx, db, applyUnconditional, nil, fixups, template)
 }
 
 // newBagLocked constructs a new property bag using cached metadata.

--- a/internal/target/apply/queries/crdb/common.tmpl
+++ b/internal/target/apply/queries/crdb/common.tmpl
@@ -48,6 +48,33 @@ The validity check allows us to distinguish null vs. unset in the payload.
     {{- end -}}
 {{- end -}}
 
+{{- define "toasted" -}}
+    {{- range $idx, $col := .Columns -}}
+        {{- if $idx -}},{{- end -}}
+        {{nl}}{{sp}}
+        {{- if $col.Primary -}}
+            data.{{$col.Name}}
+        {{-  else if eq $col.Type "JSONB"  -}}
+ CASE WHEN data.{{$col.Name}}='{{toasted}}'::JSONB
+      THEN current.{{$col.Name}}
+      ELSE data.{{$col.Name}}
+      END
+        {{- else if eq $col.Type "TEXT"  -}}
+ CASE WHEN data.{{$col.Name}}='{{toasted}}'::TEXT
+      THEN current.{{$col.Name}}
+      ELSE data.{{$col.Name}}
+      END
+        {{- else if eq $col.Type "STRING"  -}}
+ CASE WHEN data.{{$col.Name}}='{{toasted}}'::STRING
+      THEN current.{{$col.Name}}
+      ELSE data.{{$col.Name}}
+      END
+        {{- else -}}
+            data.{{$col.Name}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
 {{- /* join creates a comma-separated list of its input: a, b, c, ... */ -}}
 {{- define "join" -}}
     {{- range $idx, $val := . }}

--- a/internal/target/apply/queries/crdb/toasted.tmpl
+++ b/internal/target/apply/queries/crdb/toasted.tmpl
@@ -1,0 +1,17 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+
+WITH data ({{- template "names" .Columns -}} ) AS (
+VALUES{{- nl -}}
+{{- template "exprs" . -}}
+),
+{{- nl -}}
+action AS (
+SELECT {{ template "toasted"  . }}
+FROM data
+LEFT JOIN  {{ .TableName }} as current
+USING ({{ template "names" .PK }}))
+
+UPSERT INTO {{ .TableName }} (
+{{ template "names" .Columns }}
+)
+SELECT {{ template "names" .Columns }}  FROM action

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -487,7 +487,18 @@ func checkTemplate(t *testing.T, global *templateGlobal, tc *templateTestCase) {
 			fmt.Sprintf("testdata/%s/%s.upsert.sql", global.dir, tc.name),
 			s)
 	})
+	t.Run("toasted", func(t *testing.T) {
+		r := require.New(t)
 
+		if tc.name != "base" || global.product != types.ProductCockroachDB {
+			t.Skip("toasted only for crdb target, base upsert")
+		}
+		s, err := tmpls.customExpr(2, "toasted", applyUnconditional)
+		r.NoError(err)
+		checkFile(t,
+			fmt.Sprintf("testdata/%s/%s.toasted.sql", global.dir, tc.name),
+			s)
+	})
 	t.Run("delete", func(t *testing.T) {
 		r := require.New(t)
 		s, err := tmpls.deleteExpr(2)

--- a/internal/target/apply/testdata/crdb/base.toasted.sql
+++ b/internal/target/apply/testdata/crdb/base.toasted.sql
@@ -1,0 +1,28 @@
+WITH data ("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
+VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
+action AS (
+SELECT 
+ data."pk0",
+ data."pk1",
+ CASE WHEN data."val0"='"__cdc__sink__toasted__"'::STRING
+      THEN current."val0"
+      ELSE data."val0"
+      END,
+ CASE WHEN data."val1"='"__cdc__sink__toasted__"'::STRING
+      THEN current."val1"
+      ELSE data."val1"
+      END,
+ data."geom",
+ data."geog",
+ data."enum",
+ data."has_default"
+FROM data
+LEFT JOIN  "database"."schema"."table" as current
+USING ("pk0","pk1"))
+
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog","enum","has_default"
+)
+SELECT "pk0","pk1","val0","val1","geom","geog","enum","has_default"  FROM action

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -126,6 +126,13 @@ type Memo interface {
 	Put(ctx context.Context, tx StagingQuerier, key string, value []byte) error
 }
 
+// CustomUpsert defines a custom upsert template that will
+// be used for the mutation.
+// A mutation may specify a custom upsert by adding
+// an entry in the Meta map below
+// Meta[CustomUpsert] = "custom.template.name"
+const CustomUpsert = "upsert.custom"
+
 // A Mutation describes a row to upsert into the target database.  That
 // is, it is a collection of column values to apply to a row in some
 // table.
@@ -219,6 +226,11 @@ type Stagers interface {
 	// the timestamp values.
 	Unstage(ctx context.Context, tx StagingQuerier, q *UnstageCursor, fn UnstageCallback) (*UnstageCursor, bool, error)
 }
+
+// ToastedColumnPlaceholder is a placeholder to identify a unchanged
+// Postgres toasted column. Must be quoted, so it can be used
+// in JSON columns.
+const ToastedColumnPlaceholder = `"__cdc__sink__toasted__"`
 
 // ColData hold SQL column metadata.
 type ColData struct {


### PR DESCRIPTION
This change allows source dialect to request custom upsert templates for specific mutations. The logical apply loop will use the custom template if available.

For instance, this is used to handle Postgres unchanged toasted columns. If a custom colum is detected, then a custom upsert template is used to query the current value of the toasted column in target database before inserting the mutation.

This change also adds a new configuration flag '--enableToastedColumns' which allows cdc-sink to support toasted columns when using Postres as a source.

Support is limited for logical replication with basic upserts into CRDB targets via a custom template (no user scripts or merge functionality).

When the experimental support for toasted columns is enabled, and cdc-sink receives a TupleDataTypeToast, it marks the column with a placeholder.

The placeholder is recognized by the logical apply loop which uses the custom upsert template for any mutations with toasted columns. The templates retrieves the current value for the toasted column in the target database before applying the mutation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/600)
<!-- Reviewable:end -->
