### PR TITLE
pglogical: reworking toasted columns support.

### DIFF
--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	Slot string
 	// Connection string for the source db.
 	SourceConn string
+	// Enable experimental support for toasted columns
+	ExperimentalToastedColumns bool
 }
 
 // Bind adds flags to the set.
@@ -55,6 +57,8 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	f.StringVar(&c.SourceConn, "sourceConn", "", "the source database's connection string")
 	f.StringVar(&c.Publication, "publicationName", "",
 		"the publication within the source database to replicate")
+	f.BoolVar(&c.ExperimentalToastedColumns, "enableToastedColumns", false,
+		"Enable experimental support for toasted columns")
 }
 
 // Preflight updates the configuration with sane defaults or returns an

--- a/internal/source/pglogical/metrics.go
+++ b/internal/source/pglogical/metrics.go
@@ -38,4 +38,8 @@ var (
 		Name: "pglogical_empty_transactions",
 		Help: "the number of empty transactions we have seen",
 	})
+	unchangedToastedColumns = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pglogical_unchanged_toasted_columns",
+		Help: "the number of times we see unchanged toasted columns",
+	})
 )

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -89,12 +89,13 @@ func ProvideDialect(
 	sourceConfig.RuntimeParams["replication"] = "database"
 
 	return &conn{
-		columns:               &ident.TableMap[[]types.ColData]{},
-		publicationName:       config.Publication,
-		relations:             make(map[uint32]ident.Table),
-		skipEmptyTransactions: config.SkipEmptyTransactions,
-		slotName:              config.Slot,
-		sourceConfig:          sourceConfig,
+		columns:                    &ident.TableMap[[]types.ColData]{},
+		publicationName:            config.Publication,
+		relations:                  make(map[uint32]ident.Table),
+		skipEmptyTransactions:      config.SkipEmptyTransactions,
+		slotName:                   config.Slot,
+		sourceConfig:               sourceConfig,
+		experimentalToastedColumns: config.ExperimentalToastedColumns,
 	}, nil
 }
 

--- a/internal/target/apply/queries/crdb/common.tmpl
+++ b/internal/target/apply/queries/crdb/common.tmpl
@@ -48,6 +48,33 @@ The validity check allows us to distinguish null vs. unset in the payload.
     {{- end -}}
 {{- end -}}
 
+{{- define "toasted" -}}
+    {{- range $idx, $col := .Columns -}}
+        {{- if $idx -}},{{- end -}}
+        {{nl}}{{sp}}
+        {{- if $col.Primary -}}
+            data.{{$col.Name}}
+        {{-  else if eq $col.Type "JSONB"  -}}
+ CASE WHEN data.{{$col.Name}}='{{toasted}}'::JSONB
+      THEN current.{{$col.Name}}
+      ELSE data.{{$col.Name}}
+      END
+        {{- else if eq $col.Type "TEXT"  -}}
+ CASE WHEN data.{{$col.Name}}='{{toasted}}'::TEXT
+      THEN current.{{$col.Name}}
+      ELSE data.{{$col.Name}}
+      END
+        {{- else if eq $col.Type "STRING"  -}}
+ CASE WHEN data.{{$col.Name}}='{{toasted}}'::STRING
+      THEN current.{{$col.Name}}
+      ELSE data.{{$col.Name}}
+      END
+        {{- else -}}
+            data.{{$col.Name}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
 {{- /* join creates a comma-separated list of its input: a, b, c, ... */ -}}
 {{- define "join" -}}
     {{- range $idx, $val := . }}

--- a/internal/target/apply/queries/crdb/toasted.tmpl
+++ b/internal/target/apply/queries/crdb/toasted.tmpl
@@ -1,0 +1,17 @@
+{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+
+WITH data ({{- template "names" .Columns -}} ) AS (
+VALUES{{- nl -}}
+{{- template "exprs" . -}}
+),
+{{- nl -}}
+action AS (
+SELECT {{ template "toasted"  . }}
+FROM data
+LEFT JOIN  {{ .TableName }} as current
+USING ({{ template "names" .PK }}))
+
+UPSERT INTO {{ .TableName }} (
+{{ template "names" .Columns }}
+)
+SELECT {{ template "names" .Columns }}  FROM action

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -487,7 +487,17 @@ func checkTemplate(t *testing.T, global *templateGlobal, tc *templateTestCase) {
 			fmt.Sprintf("testdata/%s/%s.upsert.sql", global.dir, tc.name),
 			s)
 	})
-
+	t.Run("toasted", func(t *testing.T) {
+		r := require.New(t)
+		if tmpls.toasted == nil || tc.name != "base" {
+			t.Skip("toasted only for crdb target, base upsert")
+		}
+		s, err := tmpls.toastedExpr(2, applyUnconditional)
+		r.NoError(err)
+		checkFile(t,
+			fmt.Sprintf("testdata/%s/%s.toasted.sql", global.dir, tc.name),
+			s)
+	})
 	t.Run("delete", func(t *testing.T) {
 		r := require.New(t)
 		s, err := tmpls.deleteExpr(2)

--- a/internal/target/apply/testdata/crdb/base.toasted.sql
+++ b/internal/target/apply/testdata/crdb/base.toasted.sql
@@ -1,0 +1,28 @@
+WITH data ("pk0","pk1","val0","val1","geom","geog","enum","has_default") AS (
+VALUES
+($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),
+($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
+action AS (
+SELECT 
+ data."pk0",
+ data."pk1",
+ CASE WHEN data."val0"='"__cdc__sink__toasted__"'::STRING
+      THEN current."val0"
+      ELSE data."val0"
+      END,
+ CASE WHEN data."val1"='"__cdc__sink__toasted__"'::STRING
+      THEN current."val1"
+      ELSE data."val1"
+      END,
+ data."geom",
+ data."geog",
+ data."enum",
+ data."has_default"
+FROM data
+LEFT JOIN  "database"."schema"."table" as current
+USING ("pk0","pk1"))
+
+UPSERT INTO "database"."schema"."table" (
+"pk0","pk1","val0","val1","geom","geog","enum","has_default"
+)
+SELECT "pk0","pk1","val0","val1","geom","geog","enum","has_default"  FROM action

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -220,6 +220,11 @@ type Stagers interface {
 	Unstage(ctx context.Context, tx StagingQuerier, q *UnstageCursor, fn UnstageCallback) (*UnstageCursor, bool, error)
 }
 
+// ToastedColumnPlaceholder is a placeholder to identify a unchanged
+// Postgres toasted column. Must be quoted, so it can be used
+// in JSON columns.
+const ToastedColumnPlaceholder = `"__cdc__sink__toasted__"`
+
 // ColData hold SQL column metadata.
 type ColData struct {
 	// A SQL expression to use with sparse payloads.


### PR DESCRIPTION
This change adds a new configuration flag '--enableToastedColumns' which allows cdc-sink to support toasted columns when using Postres as a source.

Support is limited for logical replication with basic upserts into CRDB targets (no user scripts or merge functionality).

When the experimental support for toasted columns is enabled, and cdc-sink receives a TupleDataTypeToast, it marks the column with a placeholder.

The placeholder is recognized by the logical apply loop which uses a special upsert template for any mutations with toasted columns. The templates retrieves the current value for the toasted column in the target database before applying the mutation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/601)
<!-- Reviewable:end -->
