### PR TITLE
pglogical: using the parameter standbyTimeout to configure consistent point commit frequency.

### DIFF
--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -69,6 +69,8 @@ type conn struct {
 	slotName string
 	// The configuration for opening replication connections.
 	sourceConfig *pgconn.Config
+	// How ofter to commit the consistent point
+	standbyTimeout time.Duration
 	// Support for toasted columns
 	toastedColumns bool
 }
@@ -86,6 +88,7 @@ func (c *conn) Process(
 			_ = batch.OnRollback(ctx)
 		}
 	}()
+	cpDeadline := time.Now().Add(c.standbyTimeout)
 
 	// We rely on the upstream database to replay events in the case of
 	// errors, so we may receive events that we've already processed.
@@ -155,10 +158,13 @@ func (c *conn) Process(
 					continue
 				}
 			}
-			// The COMMIT records are written in order, so they're a
-			// better marker to record.
-			if err := events.SetConsistentPoint(ctx, &lsnStamp{msg.CommitLSN, msg.CommitTime}); err != nil {
-				return err
+			if time.Now().After(cpDeadline) {
+				cpDeadline = time.Now().Add(c.standbyTimeout)
+				// The COMMIT records are written in order, so they're a
+				// better marker to record.
+				if err := events.SetConsistentPoint(ctx, &lsnStamp{msg.CommitLSN, msg.CommitTime}); err != nil {
+					return err
+				}
 			}
 
 		case *pglogrepl.DeleteMessage:
@@ -218,8 +224,7 @@ func (c *conn) ReadInto(ctx context.Context, ch chan<- logical.Message, state lo
 	}
 	dialSuccessCount.Inc()
 
-	const standbyTimeout = time.Second * 10
-	standbyDeadline := time.Now().Add(standbyTimeout)
+	standbyDeadline := time.Now().Add(c.standbyTimeout)
 
 	for {
 		select {
@@ -228,7 +233,7 @@ func (c *conn) ReadInto(ctx context.Context, ch chan<- logical.Message, state lo
 		default:
 		}
 		if time.Now().After(standbyDeadline) {
-			standbyDeadline = time.Now().Add(standbyTimeout)
+			standbyDeadline = time.Now().Add(c.standbyTimeout)
 			cp, _ := state.GetConsistentPoint()
 			if lsn, ok := cp.(*lsnStamp); ok {
 				if err := pglogrepl.SendStandbyStatusUpdate(ctx, replConn, pglogrepl.StandbyStatusUpdate{

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -95,6 +95,7 @@ func ProvideDialect(
 		skipEmptyTransactions: config.SkipEmptyTransactions,
 		slotName:              config.Slot,
 		sourceConfig:          sourceConfig,
+		standbyTimeout:        config.StandbyTimeout,
 		toastedColumns:        config.ToastedColumns,
 	}, nil
 }


### PR DESCRIPTION
Previously pglogical used a hardcoded value to determine how often to update the replication status back to the source.

This change allows the user to configure the frequency via the existing standbyTimeout command line parameter.
In addition the parameter determines how ofter to commit the consistent point in the memo table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/605)
<!-- Reviewable:end -->
