### PR TITLE
pglogical: using the parameter standbyTimeout to configure consistent point commit frequency.

### DIFF
--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -67,6 +67,8 @@ type conn struct {
 	slotName string
 	// The configuration for opening replication connections.
 	sourceConfig *pgconn.Config
+	// How ofter to commit the consistent point
+	standbyTimeout time.Duration
 	// Support for toasted columns
 	toastedColumns bool
 }
@@ -84,6 +86,7 @@ func (c *conn) Process(
 			_ = batch.OnRollback(ctx)
 		}
 	}()
+	cpDeadline := time.Now().Add(c.standbyTimeout)
 
 	// We rely on the upstream database to replay events in the case of
 	// errors, so we may receive events that we've already processed.
@@ -153,10 +156,13 @@ func (c *conn) Process(
 				log.Trace("skipping empty transaction")
 				continue
 			}
-			// The COMMIT records are written in order, so they're a
-			// better marker to record.
-			if err := events.SetConsistentPoint(ctx, &lsnStamp{msg.CommitLSN, msg.CommitTime}); err != nil {
-				return err
+			if time.Now().After(cpDeadline) {
+				cpDeadline = time.Now().Add(c.standbyTimeout)
+				// The COMMIT records are written in order, so they're a
+				// better marker to record.
+				if err := events.SetConsistentPoint(ctx, &lsnStamp{msg.CommitLSN, msg.CommitTime}); err != nil {
+					return err
+				}
 			}
 
 		case *pglogrepl.DeleteMessage:
@@ -216,8 +222,7 @@ func (c *conn) ReadInto(ctx context.Context, ch chan<- logical.Message, state lo
 	}
 	dialSuccessCount.Inc()
 
-	const standbyTimeout = time.Second * 10
-	standbyDeadline := time.Now().Add(standbyTimeout)
+	standbyDeadline := time.Now().Add(c.standbyTimeout)
 
 	for {
 		select {
@@ -226,7 +231,7 @@ func (c *conn) ReadInto(ctx context.Context, ch chan<- logical.Message, state lo
 		default:
 		}
 		if time.Now().After(standbyDeadline) {
-			standbyDeadline = time.Now().Add(standbyTimeout)
+			standbyDeadline = time.Now().Add(c.standbyTimeout)
 			cp, _ := state.GetConsistentPoint()
 			if lsn, ok := cp.(*lsnStamp); ok {
 				if err := pglogrepl.SendStandbyStatusUpdate(ctx, replConn, pglogrepl.StandbyStatusUpdate{

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -200,12 +200,13 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 	// Start the connection, to demonstrate that we can backfill pending mutations.
 	cfg := &Config{
 		BaseConfig: logical.BaseConfig{
-			ApplyTimeout:  2 * time.Minute, // Increase to make using the debugger easier.
-			ChaosProb:     fc.chaosProb,
-			Immediate:     fc.immediate,
-			RetryDelay:    time.Millisecond,
-			StagingSchema: fixture.StagingDB.Schema(),
-			TargetConn:    crdbPool.ConnectionString,
+			ApplyTimeout:   2 * time.Minute, // Increase to make using the debugger easier.
+			ChaosProb:      fc.chaosProb,
+			Immediate:      fc.immediate,
+			RetryDelay:     time.Millisecond,
+			StagingSchema:  fixture.StagingDB.Schema(),
+			TargetConn:     crdbPool.ConnectionString,
+			StandbyTimeout: 100 * time.Millisecond,
 		},
 		LoopConfig: logical.LoopConfig{
 			LoopName:     "pglogicaltest",

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -94,6 +94,7 @@ func ProvideDialect(
 		relations:       make(map[uint32]ident.Table),
 		slotName:        config.Slot,
 		sourceConfig:    sourceConfig,
+		standbyTimeout:  config.StandbyTimeout,
 		toastedColumns:  config.ToastedColumns,
 	}, nil
 }


### PR DESCRIPTION
Previously pglogical used a hardcoded value to determine how often to update the replication status back to the source.

This change allows the user to configure the frequency via the existing standbyTimeout command line parameter.
In addition the parameter determines how ofter to commit the consistent point in the memo table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/608)
<!-- Reviewable:end -->
