### PR TITLE
pglogical: enabling skipping empty transactions by default.

### DIFF
--- a/internal/source/pglogical/config.go
+++ b/internal/source/pglogical/config.go
@@ -31,11 +31,6 @@ type Config struct {
 
 	// The name of the publication to attach to.
 	Publication string
-	// Skip empty transactions. False by default.
-	// In Postgres version < v15, the stream might contain empty transactions.
-	// See https://github.com/postgres/postgres/commit/d5a9d86d8f
-	// Setting this to true will allow cdc-sink to ignore them.
-	SkipEmptyTransactions bool
 	// The replication slot to attach to.
 	Slot string
 	// Connection string for the source db.
@@ -50,9 +45,6 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 
 	c.LoopConfig.LoopName = "pglogical"
 	c.LoopConfig.Bind(f)
-
-	f.BoolVar(&c.SkipEmptyTransactions, "skipEmptyTransactions", false,
-		"skip writing to the memo table when a transaction has no content")
 	f.StringVar(&c.Slot, "slotName", "cdc_sink", "the replication slot in the source database")
 	f.StringVar(&c.SourceConn, "sourceConn", "", "the source database's connection string")
 	f.StringVar(&c.Publication, "publicationName", "",

--- a/internal/source/pglogical/metrics.go
+++ b/internal/source/pglogical/metrics.go
@@ -30,10 +30,6 @@ var (
 		Name: "pglogical_dial_success_total",
 		Help: "the number of times we successfully dialed a replication connection",
 	})
-	skippedEmptyTransactionCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pglogical_skipped_empty_transactions",
-		Help: "the number of times we skipped an empty transaction",
-	})
 	emptyTransactionCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pglogical_empty_transactions",
 		Help: "the number of empty transactions we have seen",

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -89,13 +89,12 @@ func ProvideDialect(
 	sourceConfig.RuntimeParams["replication"] = "database"
 
 	return &conn{
-		columns:               &ident.TableMap[[]types.ColData]{},
-		publicationName:       config.Publication,
-		relations:             make(map[uint32]ident.Table),
-		skipEmptyTransactions: config.SkipEmptyTransactions,
-		slotName:              config.Slot,
-		sourceConfig:          sourceConfig,
-		toastedColumns:        config.ToastedColumns,
+		columns:         &ident.TableMap[[]types.ColData]{},
+		publicationName: config.Publication,
+		relations:       make(map[uint32]ident.Table),
+		slotName:        config.Slot,
+		sourceConfig:    sourceConfig,
+		toastedColumns:  config.ToastedColumns,
 	}, nil
 }
 


### PR DESCRIPTION
Removed the --skipEmptyTransactions flag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/609)
<!-- Reviewable:end -->
