### PR TITLE
script: Allow userscript to execute SQL

### DIFF
--- a/internal/script/applier.go
+++ b/internal/script/applier.go
@@ -1,0 +1,304 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/pjson"
+	"github.com/dop251/goja"
+	"github.com/pkg/errors"
+)
+
+// A JS function which is provided with an array of applyOp.
+type applyJS func(opData []*applyOp) *goja.Promise
+
+type applyOp struct {
+	Action string         `goja:"action"` // Always populated. Type must be string.
+	Data   map[string]any `goja:"data"`   // Present in upsert mode.
+	Meta   map[string]any `goja:"meta"`   // Present in upsert mode. Equivalent to map() meta.
+	PK     []any          `goja:"pk"`     // Always populated.
+}
+
+type applyAction string
+
+const (
+	actionDelete applyAction = "delete"
+	actionUpsert applyAction = "upsert"
+)
+
+// notInTransaction is used to provide a helpful error message if
+// api.getTX() is called when no transaction is available.
+func notInTransaction() error {
+	return errors.New("no transaction is currently open")
+}
+
+// applier implements [types.Applier] to allow user-defined functions to
+// be used to interact with the database, rather than using cdc-sink's
+// built-in SQL.
+type applier struct {
+	apply  applyJS
+	parent *UserScript
+	table  ident.Table
+}
+
+var _ types.Applier = (*applier)(nil)
+
+func newApplier(parent *UserScript, table ident.Table, apply applyJS) *applier {
+	return &applier{
+		apply:  apply,
+		parent: parent,
+		table:  table,
+	}
+}
+
+// Apply implements [types.Applier].
+func (a *applier) Apply(ctx context.Context, tq types.TargetQuerier, muts []types.Mutation) error {
+	ops := make([]*applyOp, len(muts))
+	pks := make([]*[]any, len(muts))
+	data := make([]*map[string]any, len(muts))
+	for idx, mut := range muts {
+		mode := actionUpsert
+		if mut.IsDelete() {
+			mode = actionDelete
+		}
+		ops[idx] = &applyOp{
+			Action: string(mode),
+			Meta:   mut.Meta,
+		}
+		pks[idx] = &ops[idx].PK
+		data[idx] = &ops[idx].Data
+	}
+
+	if err := pjson.Decode(ctx, pks, func(i int) []byte {
+		return muts[i].Key
+	}); err != nil {
+		return err
+	}
+
+	if err := pjson.Decode(ctx, data, func(i int) []byte {
+		if data := muts[i].Data; len(data) > 0 {
+			return data
+		}
+		return []byte("null")
+	}); err != nil {
+		return err
+	}
+
+	tx := &targetTX{
+		ctx:     ctx,
+		applier: a,
+		tq:      tq,
+	}
+
+	var promise *goja.Promise
+	if err := a.parent.execTrackedJS(tx, func(rt *goja.Runtime) error {
+		promise = a.apply(ops)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	_, err := a.parent.await(ctx, promise)
+	return err
+}
+
+// targetTX is a facade passed to the userscript to expose the target
+// database transaction and various other metadata.
+type targetTX struct {
+	*applier
+
+	ctx     context.Context     // Passed to database methods.
+	columns []map[string]any    // Lazily-constructed schema data.
+	tq      types.TargetQuerier // The database transaction.
+	mu      sync.Mutex          // Serializes access to methods on tq.
+}
+
+var _ asyncTracker = (*targetTX)(nil)
+
+// Columns is exported to the userscript. It will lazily populate the
+// columns field.
+func (tx *targetTX) Columns() []map[string]any {
+	if len(tx.columns) > 0 {
+		return tx.columns
+	}
+	cols := tx.parent.watcher.Get().Columns.GetZero(tx.table)
+	for _, col := range cols {
+		// Keep in sync with .d.ts file.
+		m := map[string]any{
+			"ignored": col.Ignored,
+			"name":    col.Name.String(),
+			"primary": col.Primary,
+			"type":    col.Type,
+		}
+		// It's JS-idiomatic for the string to be null than empty.
+		if col.DefaultExpr != "" {
+			m["defaultExpr"] = col.DefaultExpr
+		}
+		tx.columns = append(tx.columns, m)
+	}
+	return tx.columns
+}
+
+// Enter implements [asyncTracker]. It will inject the targetTX into the
+// runtime so the user code may use it.
+func (tx *targetTX) enter(script *UserScript) error {
+	return script.apiModule.Set("getTX", func() *targetTX {
+		return tx
+	})
+}
+
+// Exec is exported to the userscript.
+func (tx *targetTX) Exec(q string, args ...any) *goja.Promise {
+	// Only called from JS, so we know that rtMu is locked.
+	promise, resolve, reject := tx.parent.rt.NewPromise()
+
+	// Execute the SQL in a (pooled) background goroutine.
+	tx.parent.execTask(func() {
+		tx.mu.Lock()
+		_, err := tx.tq.ExecContext(tx.ctx, q, args...)
+		tx.mu.Unlock()
+		err = errors.Wrap(err, q)
+
+		// Ignoring error since closure never returns an error.
+		_ = tx.parent.execJS(func(rt *goja.Runtime) error {
+			if err == nil {
+				resolve(goja.Undefined())
+			} else {
+				reject(err)
+			}
+			return nil
+		})
+	})
+
+	return promise
+}
+
+// Exit implements [asyncTracker]. It will clean up the references set
+// by [targetTX.enter].
+func (tx *targetTX) exit(script *UserScript) error {
+	return script.apiModule.Set("getTX", notInTransaction)
+}
+
+// Query is exported to the userscript.
+func (tx *targetTX) Query(q string, args ...any) *goja.Promise {
+	// Only called from JS, so we know that rtMu is locked.
+	promise, resolve, reject := tx.parent.rt.NewPromise()
+
+	// Execute the SQL in a (pooled) background goroutine.
+	tx.parent.execTask(func() {
+		tx.mu.Lock()
+		rows, err := tx.tq.QueryContext(tx.ctx, q, args...)
+		tx.mu.Unlock()
+
+		// Extract the number of columns for the result iterator.
+		var numCols int
+		if err == nil {
+			var names []string
+			names, err = rows.Columns()
+			numCols = len(names)
+		}
+		err = errors.Wrap(err, q)
+
+		// Once the results are ready, re-enter the JS runtime mutex to
+		// fulfil the promise. Ignoring error since closure never
+		// returns an error.
+		_ = tx.parent.execJS(func(rt *goja.Runtime) error {
+			if err != nil {
+				reject(err)
+				return nil
+			}
+
+			// Construct the iterator JS object by setting
+			// Symbol.iterator to a function that returns a value which
+			// implements the iterator protocol (i.e. has a next()
+			// function).
+			obj := rt.NewObject()
+			if err := obj.SetSymbol(goja.SymIterator, func() *rowsIter {
+				return &rowsIter{numCols, rows}
+			}); err != nil {
+				return errors.WithStack(err)
+			}
+			resolve(obj)
+			return nil
+		})
+	})
+
+	return promise
+}
+
+// Schema is exported to the userscript.
+func (tx *targetTX) Schema() string {
+	return tx.table.Schema().String()
+}
+
+// Table is exported to the userscript.
+func (tx *targetTX) Table() string {
+	return tx.table.String()
+}
+
+// rowsIter exports a [sql.Rows] into a JS API that conforms to the
+// iterator protocol. Note that goja does not (as of this writing)
+// support the async iterable protocol.
+//
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+// https://pkg.go.dev/github.com/dop251/goja#example-Object.SetSymbol
+type rowsIter struct {
+	colCount int
+	rows     *sql.Rows
+}
+
+// Next implements the JS iterator protocol.
+func (it *rowsIter) Next() (*rowsIterResult, error) {
+	next := it.rows.Next()
+	err := it.rows.Err()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if !next {
+		return &rowsIterResult{Done: true}, nil
+	}
+
+	data := make([]any, it.colCount)
+	ptrs := make([]any, len(data))
+	for idx := range ptrs {
+		ptrs[idx] = &data[idx]
+	}
+	if err := it.rows.Scan(ptrs...); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &rowsIterResult{Value: data}, nil
+}
+
+// Return implements the JS iterator protocol and will be called
+// if the iterator is not being read to completion. This allows us
+// to preemptively close the rowset.
+func (it *rowsIter) Return() *rowsIterResult {
+	_ = it.rows.Close()
+	return &rowsIterResult{Done: true}
+}
+
+// Implements the JS iteration result protocol.
+type rowsIterResult struct {
+	Done  bool  `goja:"done"`
+	Value []any `goja:"value"`
+}

--- a/internal/script/injector.go
+++ b/internal/script/injector.go
@@ -21,6 +21,7 @@ package script
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
@@ -45,6 +46,7 @@ func Evaluate(
 func newScriptFromFixture(*all.Fixture, *Config, TargetSchema) (*UserScript, error) {
 	panic(wire.Build(
 		Set,
-		wire.FieldsOf(new(*all.Fixture), "Diagnostics", "Configs", "Watchers"),
+		wire.FieldsOf(new(*base.Fixture), "Context"),
+		wire.FieldsOf(new(*all.Fixture), "Configs", "Diagnostics", "Fixture", "Watchers"),
 	))
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -29,8 +29,10 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/merge"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
 	"github.com/dop251/goja"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // A Dispatch function receives a source mutation and assigns mutations
@@ -81,6 +83,9 @@ type Target struct {
 	Map Map `json:"-"`
 }
 
+// errUserExec is used to interrupt the JS runtime.
+var errUseExec = errors.New("UserScript.execJS() must be used when calling JS code")
+
 // UserScript encapsulates a user-provided configuration expressed as a
 // JavaScript program.
 //
@@ -97,19 +102,58 @@ type UserScript struct {
 	Sources *ident.Map[*Source]
 	Targets *ident.TableMap[*Target]
 
-	rt      *goja.Runtime // The JavaScript VM. See execJS.
-	rtMu    *sync.Mutex   // Serialize access to the VM.
-	target  ident.Schema  // The schema being populated.
-	watcher types.Watcher // Access to target schema.
+	apiModule *goja.Object         // The cdc-sink JS module.
+	rt        *goja.Runtime        // The JavaScript VM. See execJS.
+	rtExit    notify.Var[struct{}] // Forms an ersatz event loop for checking promise status.
+	rtMu      *sync.RWMutex        // Serialize access to the VM or its side-effects.
+	tasks     *errgroup.Group      // Limits number of concurrent background tasks.
+	target    ident.Schema         // The schema being populated.
+	tracker   asyncTracker         // Assists async promise chains. See execTrackedJS.
+	watcher   types.Watcher        // Access to target schema.
 }
 
-var _ diag.Diagnostic = (*UserScript)(nil)
+var (
+	_ diag.Diagnostic          = (*UserScript)(nil)
+	_ goja.AsyncContextTracker = (*UserScript)(nil)
+)
 
 // Diagnostic implements [diag.Diagnostic].
 func (s *UserScript) Diagnostic(_ context.Context) any {
 	return map[string]any{
 		"sources": s.Sources,
 		"targets": s.Targets,
+	}
+}
+
+// Exited implements [goja.AsyncContextTracker]. If [UserScript.tracker]
+// is non-nil, it will be exited and the reference cleared.
+func (s *UserScript) Exited() {
+	if trk := s.tracker; trk != nil {
+		s.tracker = nil
+		if err := trk.exit(s); err != nil {
+			// This will be converted into a JS exception by the runtime.
+			panic(err)
+		}
+	}
+}
+
+// Grab implements [goja.AsyncContextTracker]. The object returned from
+// this method, an [asyncTracker], will be associated with any promise
+// chains that may be created by the user script.
+func (s *UserScript) Grab() any {
+	return s.tracker
+}
+
+// Resumed implements [goja.AsyncContextTracker]. If the object is an
+// [asyncTracker], its [asyncTracker.enter] method will be called with
+// the receiver.
+func (s *UserScript) Resumed(obj any) {
+	if trk, ok := obj.(asyncTracker); ok {
+		s.tracker = trk
+		if err := trk.enter(s); err != nil {
+			// This will be converted to a JS exception by the runtime.
+			panic(err)
+		}
 	}
 }
 
@@ -159,7 +203,11 @@ func (s *UserScript) bind(loader *Loader) error {
 		}
 		tgt := &Target{Config: *applycfg.NewConfig()}
 		s.Targets.Put(table, tgt)
-
+		if bag.Apply != nil {
+			tgt.Delegate = newApplier(s, table, bag.Apply)
+			// If we're using a Delegate, no other options are valid.
+			continue
+		}
 		for _, cas := range bag.CASColumns {
 			tgt.CASColumns = append(tgt.CASColumns, ident.New(cas))
 		}
@@ -208,7 +256,7 @@ func (s *UserScript) bindDispatch(fnName string, dispatch dispatchJS) Dispatch {
 
 		// Execute the user function to route the mutation.
 		var dispatches map[string][]map[string]any
-		if err := s.execJS(func() (err error) {
+		if err := s.execJS(func(*goja.Runtime) (err error) {
 			meta := mut.Meta
 			if meta == nil {
 				meta = make(map[string]any)
@@ -295,7 +343,7 @@ func (s *UserScript) bindMap(table ident.Table, mapper mapJS) Map {
 
 		// Execute the user code to return the replacement values.
 		var rawMapped map[string]any
-		if err := s.execJS(func() (err error) {
+		if err := s.execJS(func(*goja.Runtime) (err error) {
 			meta := mut.Meta
 			if meta == nil {
 				meta = make(map[string]any)
@@ -398,22 +446,22 @@ func (s *UserScript) bindMerge(table ident.Table, merger goja.Value) (merge.Merg
 		// Execute the callback while holding a lock on the runtime to
 		// ensure single-threaded access.
 		var jsResult *mergeResult
-		if err := s.execJS(func() error {
+		if err := s.execJS(func(rt *goja.Runtime) error {
 			// Export the conflict as the js merge operation.
 			op := &mergeOp{
 				Meta:     con.Proposed.Meta,
-				Target:   s.rt.NewDynamicObject(&bagWrapper{con.Target, s.rt}),
-				Proposed: s.rt.NewDynamicObject(&bagWrapper{con.Proposed, s.rt}),
+				Target:   s.rt.NewDynamicObject(&bagWrapper{con.Target, rt}),
+				Proposed: s.rt.NewDynamicObject(&bagWrapper{con.Proposed, rt}),
 			}
 			if con.Before != nil {
-				op.Before = s.rt.NewDynamicObject(&bagWrapper{con.Before, s.rt})
+				op.Before = s.rt.NewDynamicObject(&bagWrapper{con.Before, rt})
 			}
 			if len(con.Unmerged) > 0 {
 				unmerged := make([]any, len(con.Unmerged))
 				for idx, ident := range con.Unmerged {
 					unmerged[idx] = ident.Raw()
 				}
-				op.Unmerged = s.rt.NewArray(unmerged...)
+				op.Unmerged = rt.NewArray(unmerged...)
 			}
 
 			// Invoke the JS by way of the golang func binding.
@@ -472,13 +520,97 @@ func (s *UserScript) bindMerge(table ident.Table, merger goja.Value) (merge.Merg
 	return ret, nil
 }
 
-// execJS ensures that the callback has exclusive access to the JS VM.
-func (s *UserScript) execJS(fn func() error) error {
+// await is a helper method to safely wait for a promise to be resolved
+// or rejected. The JS runtime will update the promise from whichever
+// goroutine is executing within execJS, so we can only read the promise
+// state when no JS code is running.
+func (s *UserScript) await(ctx context.Context, promise *goja.Promise) (goja.Value, error) {
+	for {
+		// We only need a read barrier for any updates that were made
+		// during the last call to execJS.
+		s.rtMu.RLock()
+		// The wake channel will be closed whenever the next time execJS
+		// exits. This forms an ersatz event loop.
+		_, wake := s.rtExit.Get()
+		// Read the promise state.
+		state := promise.State()
+		value := promise.Result()
+		s.rtMu.RUnlock()
+
+		switch state {
+		case goja.PromiseStateFulfilled:
+			// Success.
+			return value, nil
+		case goja.PromiseStateRejected:
+			// Return the JS error as a golang error.
+			return nil, errors.Errorf("userscript promise rejected: %v", value)
+		case goja.PromiseStatePending:
+			// Wait for the next time execJS is finished or for context
+			// cancellation.
+			select {
+			case <-wake:
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		default:
+			return nil, errors.Errorf("unimplemented: %v", state)
+		}
+	}
+}
+
+// execJS is a shortcut for execTrackedJS(nil, fn).
+func (s *UserScript) execJS(fn func(rt *goja.Runtime) error) error {
+	return s.execTrackedJS(nil, fn)
+}
+
+// execTask runs a background goroutine, but limits the total number of
+// active tasks to a reasonable value.
+func (s *UserScript) execTask(fn func()) {
+	s.tasks.Go(func() error {
+		fn()
+		return nil
+	})
+}
+
+// An asyncTracker receives entry and exit callbacks to configure the
+// UserScript so that a chain of asynchronous callbacks (e.g. promises)
+// may operate with a consistent ambient environment (e.g. database
+// transaction).
+type asyncTracker interface {
+	enter(*UserScript) error
+	exit(*UserScript) error
+}
+
+// execTrackedJS ensures that the callback has exclusive access to the
+// JS VM. An asyncTracker may be provided to enable continuation-passing
+// when resuming a promise callback or other async behavior. The VM will
+// be left in an interrupted state to return a useful error message if
+// execJS is not called. The rtExit variable will be notified when the
+// callback has finished executing to create an event loop.
+func (s *UserScript) execTrackedJS(
+	tracker asyncTracker, fn func(rt *goja.Runtime) error,
+) (err error) {
 	s.rtMu.Lock()
 	s.rt.ClearInterrupt()
 	defer func() {
-		s.rt.Interrupt(context.Canceled)
+		s.rt.Interrupt(errUseExec)
 		s.rtMu.Unlock()
+		s.rtExit.Notify()
 	}()
-	return fn()
+
+	if tracker != nil {
+		s.tracker = tracker
+		defer func() {
+			if exitErr := tracker.exit(s); exitErr != nil && err == nil {
+				// Only overwrite error if one is not already set.
+				err = exitErr
+			}
+			s.tracker = nil
+		}()
+		if err := tracker.enter(s); err != nil {
+			return err
+		}
+	}
+	return fn(s.rt)
 }

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -19,6 +19,7 @@ package script
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -77,6 +78,9 @@ func TestScript(t *testing.T) {
 		fmt.Sprintf("CREATE TABLE %s.all_features(msg VARCHAR(%d) PRIMARY KEY)", schema, size))
 	r.NoError(err)
 	r.NoError(fixture.Watcher.Refresh(ctx, fixture.TargetPool))
+	_, err = fixture.TargetPool.ExecContext(ctx,
+		fmt.Sprintf("CREATE TABLE %s.sql_test(pk INT PRIMARY KEY, val INT NOT NULL)", schema))
+	r.NoError(err)
 
 	var opts mapOptions
 
@@ -86,8 +90,9 @@ func TestScript(t *testing.T) {
 		Options:  &opts,
 	}, TargetSchema(schema))
 	r.NoError(err)
+	r.NoError(s.watcher.Refresh(ctx, fixture.TargetPool))
 	a.Equal(3, s.Sources.Len())
-	a.Equal(5, s.Targets.Len())
+	a.Equal(6, s.Targets.Len())
 	a.Equal(map[string]string{"hello": "world"}, opts.data)
 
 	tbl1 := ident.NewTable(schema, ident.New("table1"))
@@ -230,4 +235,59 @@ func TestScript(t *testing.T) {
 			a.Equal(&merge.Resolution{DLQ: "dead"}, result)
 		}
 	}
+
+	// The SQL in the test script is opinionated.
+	t.Run("sql_test", func(t *testing.T) {
+		if fixture.TargetPool.Product != types.ProductCockroachDB {
+			t.Skip("user script has opinionated SQL")
+		}
+		r := require.New(t)
+		tbl = ident.NewTable(schema, ident.New("sql_test"))
+		cfg := s.Targets.GetZero(tbl)
+		r.NotNil(cfg)
+		del := cfg.Delegate
+		r.IsType(new(applier), del)
+		r.NoError(del.Apply(ctx, fixture.TargetPool, []types.Mutation{
+			{
+				Data: json.RawMessage(`{"pk":0,"val":0}`),
+				Key:  json.RawMessage(`[0]`),
+			},
+			{
+				Data: json.RawMessage(`{"pk":1,"val":1}`),
+				Key:  json.RawMessage(`[1]`),
+			},
+			{
+				Data: json.RawMessage(`{"pk":2,"val":2}`),
+				Key:  json.RawMessage(`[2]`),
+			},
+		}))
+		rows, err := fixture.TargetPool.QueryContext(ctx,
+			fmt.Sprintf("SELECT pk, val FROM %s ORDER BY pk", tbl))
+		r.NoError(err)
+		ct := 0
+		for rows.Next() {
+			ct++
+			var pk, val int
+			r.NoError(rows.Scan(&pk, &val))
+			r.Equal(pk, -1*val)
+		}
+		r.NoError(rows.Err())
+		r.Equal(3, ct)
+
+		// Check deletion
+		r.NoError(del.Apply(ctx, fixture.TargetPool, []types.Mutation{
+			{
+				Key: json.RawMessage(`[0]`),
+			},
+			{
+				Key: json.RawMessage(`[1]`),
+			},
+			{
+				Key: json.RawMessage(`[2]`),
+			},
+		}))
+		r.NoError(fixture.TargetPool.QueryRow(fmt.Sprintf(
+			"SELECT count(*) FROM %s", tbl)).Scan(&ct))
+		r.Equal(0, ct)
+	})
 }

--- a/internal/script/testdata/tsconfig.json
+++ b/internal/script/testdata/tsconfig.json
@@ -1,2 +1,11 @@
+// This improves code introspection in GoLand. It's not used by cdc-sink
+// code itself.
 {
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "DOM",
+      "ES2022"
+    ]
+  }
 }

--- a/internal/script/wire_gen.go
+++ b/internal/script/wire_gen.go
@@ -22,7 +22,7 @@ import (
 
 // Evaluate the loaded script.
 func Evaluate(ctx *stopper.Context, loader *Loader, configs *applycfg.Configs, diags *diag.Diagnostics, targetSchema TargetSchema, watchers types.Watchers) (*UserScript, error) {
-	userScript, err := ProvideUserScript(configs, loader, diags, targetSchema, watchers)
+	userScript, err := ProvideUserScript(ctx, configs, loader, diags, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +30,8 @@ func Evaluate(ctx *stopper.Context, loader *Loader, configs *applycfg.Configs, d
 }
 
 func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema TargetSchema) (*UserScript, error) {
+	baseFixture := fixture.Fixture
+	context := baseFixture.Context
 	configs := fixture.Configs
 	loader, err := ProvideLoader(config)
 	if err != nil {
@@ -37,7 +39,7 @@ func newScriptFromFixture(fixture *all.Fixture, config *Config, targetSchema Tar
 	}
 	diagnostics := fixture.Diagnostics
 	watchers := fixture.Watchers
-	userScript, err := ProvideUserScript(configs, loader, diagnostics, targetSchema, watchers)
+	userScript, err := ProvideUserScript(context, configs, loader, diagnostics, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/fslogical/wire_gen.go
+++ b/internal/source/fslogical/wire_gen.go
@@ -51,7 +51,7 @@ func Start(context *stopper.Context, config *Config) (*FSLogical, error) {
 	if err != nil {
 		return nil, err
 	}
-	userScript, err := script.ProvideUserScript(configs, loader, diagnostics, targetSchema, watchers)
+	userScript, err := script.ProvideUserScript(context, configs, loader, diagnostics, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func startLoopsFromFixture(fixture *all.Fixture, config *Config) ([]*logical.Loo
 	if err != nil {
 		return nil, err
 	}
-	userScript, err := script.ProvideUserScript(configs, loader, diagnostics, targetSchema, watchers)
+	userScript, err := script.ProvideUserScript(context, configs, loader, diagnostics, targetSchema, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -282,6 +282,25 @@ func TestApply(t *testing.T) {
 
 		a.NoError(fixture.Configs.Set(jumbleName, nil))
 	})
+
+	t.Run("delegate_apply", func(t *testing.T) {
+		r := require.New(t)
+		tbl := ident.NewTable(fixture.TargetSchema.Schema(), ident.New("fake_table"))
+		fake := &fakeApplier{}
+
+		cfg := applycfg.NewConfig()
+		cfg.Delegate = fake
+		a.NoError(fixture.Configs.Set(tbl, cfg))
+		found, err := fixture.Appliers.Get(ctx, tbl)
+		r.NoError(err)
+		r.Same(fake, found)
+	})
+}
+
+type fakeApplier struct{}
+
+func (f *fakeApplier) Apply(context.Context, types.TargetQuerier, []types.Mutation) error {
+	return nil
 }
 
 type dataTypeTestCase struct {

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -50,7 +50,7 @@ func ProvideFactory(
 		stop:     ctx,
 		watchers: watchers,
 	}
-	f.mu.instances = &ident.TableMap[*apply]{}
+	f.mu.instances = &ident.TableMap[types.Applier]{}
 	if err := diags.Register("apply", f); err != nil {
 		return nil, err
 	}

--- a/internal/util/applycfg/conf_test.go
+++ b/internal/util/applycfg/conf_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/merge"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,7 @@ func TestCopyEquals(t *testing.T) {
 	cfg := &Config{
 		CASColumns: TargetColumns{ident.New("cas")},
 		Deadlines:  ident.MapOf[time.Duration](ident.New("dl"), time.Hour),
+		Delegate:   types.Applier(nil),
 		Exprs:      ident.MapOf[string]("expr", "foo"),
 		Extras:     ident.New("extras"),
 		Ignore:     ident.MapOf[bool]("ign", true),


### PR DESCRIPTION
This change allows the userscript to replace the default upsert and delete
behaviors in the apply package by supplying JS functions via
`api.configureTable()`. These functions are provided with a facade around a
target database transaction and the documents to be upserted or the primary
keys to be deleted.

Database access is asynchronous from the perspective of the userscript. The
database API is modeled using Promises, which allows us to release the
exclusive lock on the JS runtime while the database commands are executed in
another goroutine.  Results of database queries are provided using the
iteration protocal that allows the `for..of` syntax and which can respond to a
`break` statement by releasing the underlying database resources. The
background databases accesses are performed using a limited-size goroutine
pool.

The `UserScript.execJS()` method now provides a signal, via a `notify.Var` that
JS code has finished executing. This allows the new `UserScript.await()` method
to see if its Promise argument has resolved. The JS runtime is left in an
interrupted state with a more useful error message to indicate coding errors
where `execJS()` was not used.

The ESBuild loader configuration now targets ES2022 since our newer goja
dependency natively supports promises and other syntaxes that the original
dependency did not.

Review notes:
* Start with the changes to the `.d.ts` and `main.ts` files. This will show the API being implemented.
* The `applycfg.ApplyDelegate` override may also be useful for simplifying tests that want to verify other transformations in the apply pipeline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/616)
<!-- Reviewable:end -->
