### PR TITLE
schemawatch: Exclude views from SchemaData.Order

### DIFF
--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -522,11 +522,18 @@ func TestColDataIgnoresViews(t *testing.T) {
 	}
 	viewName := vi.Name()
 
-	colData, ok := fixture.Watcher.Get().Columns.Get(tableName)
+	schemaData := fixture.Watcher.Get()
+	colData, ok := schemaData.Columns.Get(tableName)
 	a.True(ok)
 	a.NotNil(colData)
 
-	viewData, ok := fixture.Watcher.Get().Columns.Get(viewName)
+	viewData, ok := schemaData.Columns.Get(viewName)
 	a.False(ok)
 	a.Nil(viewData)
+
+	for _, level := range schemaData.Order {
+		for _, entry := range level {
+			a.False(ident.Equal(viewName, entry), "should not find view in Order")
+		}
+	}
 }

--- a/internal/target/schemawatch/dependencies.go
+++ b/internal/target/schemawatch/dependencies.go
@@ -48,6 +48,7 @@ WITH RECURSIVE
         table_catalog, table_schema, table_name
       FROM
         information_schema.tables
+      WHERE table_type = 'BASE TABLE'
     ),
   refs
     AS (
@@ -165,7 +166,8 @@ const depOrderTemplateCRDB = `
 WITH RECURSIVE
  tables AS (
    SELECT schema_name AS sch, table_name AS tbl
-   FROM [SHOW TABLES FROM %[1]s]),
+   FROM [SHOW TABLES FROM %[1]s]
+   WHERE type='table'),
  refs AS (
    SELECT
     constraint_schema AS child_sch, table_name AS child_tbl, referenced_table_name AS parent_tbl
@@ -233,6 +235,8 @@ WITH RECURSIVE
         table_catalog, table_schema, table_name
       FROM
         %[1]s.information_schema.tables
+      WHERE
+        table_type = 'BASE TABLE'
     ),
   refs
     AS (


### PR DESCRIPTION
The queries used to compute table dependency order does not exclude views. This
change updates the queries and adds a test.

X-Ref: #617

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/618)
<!-- Reviewable:end -->
