### PR TITLE
schemawatch: Remove deprecated go-ora time types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
-	github.com/sijms/go-ora/v2 v2.7.24
+	github.com/sijms/go-ora/v2 v2.7.26
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726/go.mod h1:3yhqj7WBBf
 github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1IoZpLZE3AIffh9veYWoVlsvA4ib55TMM=
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
-github.com/sijms/go-ora/v2 v2.7.24 h1:0env7GgMxPHw0K92umvmLQZXRPenUBnIiyNNKJUGyWA=
-github.com/sijms/go-ora/v2 v2.7.24/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
+github.com/sijms/go-ora/v2 v2.7.26 h1:+o/1ej7znA/Wpklv9eTiyp4Jqn2DU9Urw9YHrtPRP64=
+github.com/sijms/go-ora/v2 v2.7.26/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/internal/target/schemawatch/parse_helpers.go
+++ b/internal/target/schemawatch/parse_helpers.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	ora "github.com/sijms/go-ora/v2"
 )
 
 var (
@@ -65,8 +64,7 @@ var (
 				if !ok {
 					return nil, errors.Errorf("expecting string, got %T", a)
 				}
-				t, err := time.ParseInLocation(time.RFC3339Nano, s, time.UTC)
-				return ora.TimeStampTZ(t), err
+				return time.ParseInLocation(time.RFC3339Nano, s, time.UTC)
 			},
 		},
 		{
@@ -78,10 +76,9 @@ var (
 					return nil, errors.Errorf("expecting string, got %T", a)
 				}
 				if t, err := time.ParseInLocation(time.RFC3339Nano, s, time.UTC); err == nil {
-					return ora.TimeStamp(t), nil
+					return t, nil
 				}
-				t, err := time.ParseInLocation("2006-01-02T15:04:05", s, time.UTC)
-				return ora.TimeStamp(t), err
+				return time.ParseInLocation("2006-01-02T15:04:05", s, time.UTC)
 			},
 		},
 		{
@@ -91,8 +88,7 @@ var (
 				if !ok {
 					return nil, errors.Errorf("expecting string, got %T", a)
 				}
-				t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
-				return ora.TimeStamp(t), err
+				return time.ParseInLocation("2006-01-02", s, time.UTC)
 			},
 		},
 	}

--- a/internal/target/schemawatch/parse_helpers_test.go
+++ b/internal/target/schemawatch/parse_helpers_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/google/uuid"
-	ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,18 +46,17 @@ func TestOraParseHelpers(t *testing.T) {
 		{
 			typ:      "TIMESTAMP(9) WITH TIME ZONE",
 			input:    now.Format(time.RFC3339Nano),
-			expected: ora.TimeStampTZ(now),
+			expected: now,
 		},
 		{
 			typ:      "TIMESTAMP(9)",
 			input:    now.Format("2006-01-02T15:04:05.999999999"),
-			expected: ora.TimeStamp(now),
+			expected: now,
 		},
 		{
-			typ:   "DATE",
-			input: now.Format("2006-01-02"),
-			expected: ora.TimeStamp(time.Date(
-				now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)),
+			typ:      "DATE",
+			input:    now.Format("2006-01-02"),
+			expected: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC),
 		},
 	}
 


### PR DESCRIPTION
The newest version of go-ora supports time.Time directly, removing the need for the custom wrapper types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/624)
<!-- Reviewable:end -->
