### PR TITLE
logical: Remove logical.State.Stopping() method

### DIFF
--- a/internal/source/logical/fake_dialect.go
+++ b/internal/source/logical/fake_dialect.go
@@ -17,20 +17,19 @@
 package logical
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cdc-sink/internal/util/stamp"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/pkg/errors"
 )
 
 // See discussion in Factory.Immediate.
 type fakeDialect struct{}
 
-func (f *fakeDialect) ReadInto(_ context.Context, _ chan<- Message, _ State) error {
+func (f *fakeDialect) ReadInto(_ *stopper.Context, _ chan<- Message, _ State) error {
 	return errors.New("fake")
 }
 
-func (f *fakeDialect) Process(_ context.Context, _ <-chan Message, _ Events) error {
+func (f *fakeDialect) Process(_ *stopper.Context, _ <-chan Message, _ Events) error {
 	return errors.New("fake")
 }
 

--- a/internal/source/logical/fan_events.go
+++ b/internal/source/logical/fan_events.go
@@ -53,8 +53,3 @@ func (f *fanEvents) OnBegin(ctx context.Context) (Batch, error) {
 func (f *fanEvents) SetConsistentPoint(ctx context.Context, cp stamp.Stamp) error {
 	return f.loop.SetConsistentPoint(ctx, cp)
 }
-
-// Stopping implements State and delegates to the enclosing loop.
-func (f *fanEvents) Stopping() <-chan struct{} {
-	return f.loop.Stopping()
-}

--- a/internal/source/logical/serial_events.go
+++ b/internal/source/logical/serial_events.go
@@ -61,11 +61,6 @@ func (e *serialEvents) SetConsistentPoint(ctx context.Context, cp stamp.Stamp) e
 	return e.loop.SetConsistentPoint(ctx, cp)
 }
 
-// Stopping implements State and delegates to the enclosing loop.
-func (e *serialEvents) Stopping() <-chan struct{} {
-	return e.loop.Stopping()
-}
-
 // A serialBatch corresponds exactly to a database transaction.
 type serialBatch struct {
 	parent *serialEvents


### PR DESCRIPTION
The need for this method can be obviated by passing a stopper.Context into the Dialect implementations. There is no net change in functionality, since logical.State.Stopping() just delegated to the stopper.Context in the logical loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/625)
<!-- Reviewable:end -->
