### PR TITLE
logical: Correctly wire up db pool sizes

### DIFF
--- a/internal/source/logical/provider.go
+++ b/internal/source/logical/provider.go
@@ -120,7 +120,7 @@ func ProvideStagingPool(
 		stdpool.WithConnectionLifetime(5*time.Minute),
 		stdpool.WithDiagnostics(diags, "staging"),
 		stdpool.WithMetrics("staging"),
-		stdpool.WithPoolSize(128),
+		stdpool.WithPoolSize(config.StagingDBConns),
 		stdpool.WithTransactionTimeout(time.Minute), // Staging shouldn't take that much time.
 	)
 	if err != nil {
@@ -149,8 +149,7 @@ func ProvideTargetPool(
 		stdpool.WithConnectionLifetime(5 * time.Minute),
 		stdpool.WithDiagnostics(diags, "target"),
 		stdpool.WithMetrics("target"),
-		stdpool.WithPoolSize(128),
-		stdpool.WithTransactionTimeout(time.Minute), // Staging shouldn't take that much time.
+		stdpool.WithPoolSize(config.TargetDBConns),
 	}
 
 	// We want to force our longest transaction time to respect the


### PR DESCRIPTION
The existing targetDBConns flag was ignored and we didn't have a flag for staging. This change allows both to be set.

Fixes #645

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/647)
<!-- Reviewable:end -->
