### PR TITLE
logical: Disable the backfillWindow flag

### DIFF
--- a/internal/source/logical/config.go
+++ b/internal/source/logical/config.go
@@ -115,8 +115,13 @@ func (c *BaseConfig) Bind(f *pflag.FlagSet) {
 
 	f.DurationVar(&c.ApplyTimeout, "applyTimeout", defaultApplyTimeout,
 		"the maximum amount of time to wait for an update to be applied")
-	f.DurationVar(&c.BackfillWindow, "backfillWindow", defaultBackfillWindow,
-		"use a high-throughput, but non-transactional mode if replication is this far behind (0 disables this feature)")
+	// Disable the use of backfill mode, which is subtly incorrect and obviated by the work on
+	// https://github.com/cockroachdb/cdc-sink/issues/504
+	var ignoreBackfill time.Duration
+	f.DurationVar(&ignoreBackfill, "backfillWindow", defaultBackfillWindow, "deprecated")
+	if err := f.MarkDeprecated("backfillWindow", "backfill mode is not presently available"); err != nil {
+		panic(err)
+	}
 	f.IntVar(&c.BytesInFlight, "bytesInFlight", defaultBytesInFlight,
 		"apply backpressure when amount of in-flight mutation data reaches this limit")
 	f.BoolVar(&c.Immediate, "immediate", false,


### PR DESCRIPTION
Backfill mode had indirectly dependended on the use of SELECT FOR UPDATE to ensure that mutations for two keys could not be in flight at once. When we removed the use of SFU because the locks weren't reliable during range transfers, backfill mode no longer had any particular guarantees about execution order.

The work to unify the non-transaction modes per issue #504 will provide a suitable replacement for the intended behavior of backfill mode. It will provide the option of allowing non-overlapping transactions to be applied concurrently in order to improve throughput.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/651)
<!-- Reviewable:end -->
