### PR TITLE
script: Allow PKs used for deletion to be rewritten

### DIFF
--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -32,6 +32,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Analogous to mapJS, save that it operates on a primary-key array. A
+// null or empty slice will be interpreted as a request to elide the
+// delete operation.
+//
+// [ pk0, pk1, ..., pkN ] => [ pk0, pkN, ... ]
+type deleteKeyJS func(
+	key []any,
+	meta map[string]any,
+) ([]any, error)
+
 // A JS function to dispatch source documents onto target tables.
 //
 // Look on my Works, ye Mighty, and despair!
@@ -95,6 +105,8 @@ type targetJS struct {
 	CASColumns []string `goja:"cas"`
 	// Column to duration.
 	Deadlines map[string]string `goja:"deadlines"`
+	// PK to PK mapper.
+	DeleteKey deleteKeyJS `goja:"deleteKey"`
 	// Column to SQL expression to pass through.
 	Exprs map[string]string `goja:"exprs"`
 	// Column name.

--- a/internal/script/testdata/cdc-sink@v1.d.ts
+++ b/internal/script/testdata/cdc-sink@v1.d.ts
@@ -187,6 +187,15 @@ declare module "cdc-sink@v1" {
          */
         deadlines: { [k: Column]: Duration };
         /**
+         * A mapping function which may modify the primary key value(s)
+         * to be deleted from a target table.
+         * @param key - The element(s) of the primary key to be deleted
+         * @param meta - Source-specific metadata about the deletion.
+         * @readonly The primary key to delete, or null to elide the
+         * deletion.
+         */
+        deleteKey: (key: DocumentValue[], meta: Document) => DocumentValue[] | null;
+        /**
          * Replacement SQL expressions to use when upserting columns.
          * The placeholder <code>$0</code> will be replaced with the
          * specific value.

--- a/internal/script/testdata/main.ts
+++ b/internal/script/testdata/main.ts
@@ -55,6 +55,10 @@ api.configureTable("all_features", {
         "dl0": "1h",
         "dl1": "1m"
     },
+    // Allow deletions to be modified to suit differing schemas.
+    deleteKey: key => {
+        return [key[0], key[2]];
+    },
     // Provide alternate SQL expressions to (possibly filtered) data.
     exprs: {
         "expr0": "fnv32($0::BYTES)",
@@ -92,6 +96,16 @@ api.configureTable("all_features", {
         })
         return {apply: op.target};
     }),
+});
+
+// Elide all deletes for the table, e.g.: for archival use cases.
+api.configureTable("delete_elide", {
+    deleteKey: () => null,
+});
+
+// Swap the order of PK elements.
+api.configureTable("delete_swap", {
+    deleteKey: key => [key[1], key[0]]
 });
 
 api.configureTable("drop_all", {

--- a/internal/source/logical/logical_test.go
+++ b/internal/source/logical/logical_test.go
@@ -438,7 +438,8 @@ func TestDeletesWithNoDispatch(t *testing.T) {
 				"main.ts": &fstest.MapFile{Data: []byte(`
 import * as api from "cdc-sink@v1";
 api.configureTable("tgt", {
-  map: (doc) => doc,
+  deleteKey: key => [ key[0] ],
+  map: doc => doc,
 });
 `)}}}}
 
@@ -453,7 +454,7 @@ api.configureTable("tgt", {
 
 	r.NoError(batch.OnData(ctx, tgt.Table(), tgt, []types.Mutation{
 		{
-			Key: []byte(`[ 1 ]`),
+			Key: []byte(`[ 1, "ignored" ]`),
 		},
 	}))
 


### PR DESCRIPTION
This change allows the userscript to provide a mapping function for the primary key in a deletion. This supports use cases where the target schema has a different PK structure than the source. It is also possible to elide all deletes to a table by having the deleteKey function return null.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/652)
<!-- Reviewable:end -->
