### PR TITLE
cdc: Ignore empty path elements in feed URLs

### DIFF
--- a/internal/source/cdc/request.go
+++ b/internal/source/cdc/request.go
@@ -178,7 +178,12 @@ func (r *request) parseURL(urlInput *url.URL) error {
 		if dir == "" {
 			break
 		}
-		remaining = dir[:len(dir)-1] // Strip trailing separator.
+		// Strip trailing separator from dir.
+		remaining = dir[:len(dir)-1]
+		// Ignore empty or dangling path elements e.g.: /my_db/public/
+		if file == "" {
+			continue
+		}
 		unescapedSegment, err := url.QueryUnescape(file)
 		if err != nil {
 			return errors.Wrap(err, "could not unescape path")

--- a/internal/source/cdc/url_test.go
+++ b/internal/source/cdc/url_test.go
@@ -87,6 +87,18 @@ func TestParseChangefeedURL(t *testing.T) {
 			url:      strings.Join([]string{"", dbName, schemaName}, "/"),
 		},
 		{
+			name:     "webhook to schema dangling slash",
+			decision: "webhook schema",
+			target:   schemaIdent,
+			url:      strings.Join([]string{"", dbName, schemaName, ""}, "/"),
+		},
+		{
+			name:     "webhook to schema many empty slashes",
+			decision: "webhook schema",
+			target:   schemaIdent,
+			url:      strings.Join([]string{"", dbName, "", "", schemaName, ""}, "/"),
+		},
+		{
 			name:     "webhook to table",
 			decision: "webhook table",
 			target:   tableIdent,
@@ -151,6 +163,12 @@ func TestParseChangefeedURL(t *testing.T) {
 			decision: "ndjson table",
 			target:   tableIdent,
 			url:      strings.Join([]string{"", dbName, schemaName, tableName, ndjson}, "/"),
+		},
+		{
+			name:     "ndjson to table extra slashes",
+			decision: "ndjson table",
+			target:   tableIdent,
+			url:      strings.Join([]string{"", dbName, schemaName, "", "", tableName, "", ndjson, ""}, "/"),
 		},
 		{
 			name:     "ndjson full to table",


### PR DESCRIPTION
This change updates the path parsing code to ignore empty path elements in the changefeed URLs. This avoids a mis-parsing when a user creates a changefeed into `/some/schema/` instead of `/some/schema`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/653)
<!-- Reviewable:end -->
