### PR TITLE
userscripts: allowing users to provide arbitrary transformations of mutations

### DIFF
--- a/internal/script/applier.go
+++ b/internal/script/applier.go
@@ -18,95 +18,45 @@ package script
 
 import (
 	"context"
-	"database/sql"
-	"sync"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/cockroachdb/cdc-sink/internal/util/pjson"
 	"github.com/dop251/goja"
-	"github.com/pkg/errors"
 )
 
 // A JS function which is provided with an array of applyOp.
 type applyJS func(opData []*applyOp) *goja.Promise
 
-type applyOp struct {
-	Action string         `goja:"action"` // Always populated. Type must be string.
-	Data   map[string]any `goja:"data"`   // Present in upsert mode.
-	Meta   map[string]any `goja:"meta"`   // Present in upsert mode. Equivalent to map() meta.
-	PK     []any          `goja:"pk"`     // Always populated.
-}
-
-type applyAction string
-
-const (
-	actionDelete applyAction = "delete"
-	actionUpsert applyAction = "upsert"
-)
-
-// notInTransaction is used to provide a helpful error message if
-// api.getTX() is called when no transaction is available.
-func notInTransaction() error {
-	return errors.New("no transaction is currently open")
-}
-
 // applier implements [types.Applier] to allow user-defined functions to
 // be used to interact with the database, rather than using cdc-sink's
 // built-in SQL.
 type applier struct {
-	apply  applyJS
-	parent *UserScript
-	table  ident.Table
+	*tableEnv
+	apply applyJS
 }
 
 var _ types.Applier = (*applier)(nil)
 
 func newApplier(parent *UserScript, table ident.Table, apply applyJS) *applier {
 	return &applier{
-		apply:  apply,
-		parent: parent,
-		table:  table,
+		apply: apply,
+		tableEnv: &tableEnv{
+			parent: parent,
+			table:  table,
+		},
 	}
 }
 
 // Apply implements [types.Applier].
 func (a *applier) Apply(ctx context.Context, tq types.TargetQuerier, muts []types.Mutation) error {
-	ops := make([]*applyOp, len(muts))
-	pks := make([]*[]any, len(muts))
-	data := make([]*map[string]any, len(muts))
-	for idx, mut := range muts {
-		mode := actionUpsert
-		if mut.IsDelete() {
-			mode = actionDelete
-		}
-		ops[idx] = &applyOp{
-			Action: string(mode),
-			Meta:   mut.Meta,
-		}
-		pks[idx] = &ops[idx].PK
-		data[idx] = &ops[idx].Data
-	}
-
-	if err := pjson.Decode(ctx, pks, func(i int) []byte {
-		return muts[i].Key
-	}); err != nil {
+	ops, err := applyOpsFromMuts(ctx, muts)
+	if err != nil {
 		return err
 	}
-
-	if err := pjson.Decode(ctx, data, func(i int) []byte {
-		if data := muts[i].Data; len(data) > 0 {
-			return data
-		}
-		return []byte("null")
-	}); err != nil {
-		return err
-	}
-
 	tx := &targetTX{
-		ctx:     ctx,
-		applier: a,
-		tq:      tq,
+		ctx:      ctx,
+		tableEnv: a.tableEnv,
+		tq:       tq,
 	}
 
 	var promise *goja.Promise
@@ -117,188 +67,6 @@ func (a *applier) Apply(ctx context.Context, tq types.TargetQuerier, muts []type
 		return err
 	}
 
-	_, err := a.parent.await(ctx, promise)
+	_, err = a.parent.await(ctx, promise)
 	return err
-}
-
-// targetTX is a facade passed to the userscript to expose the target
-// database transaction and various other metadata.
-type targetTX struct {
-	*applier
-
-	ctx     context.Context     // Passed to database methods.
-	columns []map[string]any    // Lazily-constructed schema data.
-	tq      types.TargetQuerier // The database transaction.
-	mu      sync.Mutex          // Serializes access to methods on tq.
-}
-
-var _ asyncTracker = (*targetTX)(nil)
-
-// Columns is exported to the userscript. It will lazily populate the
-// columns field.
-func (tx *targetTX) Columns() []map[string]any {
-	if len(tx.columns) > 0 {
-		return tx.columns
-	}
-	cols := tx.parent.watcher.Get().Columns.GetZero(tx.table)
-	for _, col := range cols {
-		// Keep in sync with .d.ts file.
-		m := map[string]any{
-			"ignored": col.Ignored,
-			"name":    col.Name.String(),
-			"primary": col.Primary,
-			"type":    col.Type,
-		}
-		// It's JS-idiomatic for the string to be null than empty.
-		if col.DefaultExpr != "" {
-			m["defaultExpr"] = col.DefaultExpr
-		}
-		tx.columns = append(tx.columns, m)
-	}
-	return tx.columns
-}
-
-// Enter implements [asyncTracker]. It will inject the targetTX into the
-// runtime so the user code may use it.
-func (tx *targetTX) enter(script *UserScript) error {
-	return script.apiModule.Set("getTX", func() *targetTX {
-		return tx
-	})
-}
-
-// Exec is exported to the userscript.
-func (tx *targetTX) Exec(q string, args ...any) *goja.Promise {
-	// Only called from JS, so we know that rtMu is locked.
-	promise, resolve, reject := tx.parent.rt.NewPromise()
-
-	// Execute the SQL in a (pooled) background goroutine.
-	tx.parent.execTask(func() {
-		tx.mu.Lock()
-		_, err := tx.tq.ExecContext(tx.ctx, q, args...)
-		tx.mu.Unlock()
-		err = errors.Wrap(err, q)
-
-		// Ignoring error since closure never returns an error.
-		_ = tx.parent.execJS(func(rt *goja.Runtime) error {
-			if err == nil {
-				resolve(goja.Undefined())
-			} else {
-				reject(err)
-			}
-			return nil
-		})
-	})
-
-	return promise
-}
-
-// Exit implements [asyncTracker]. It will clean up the references set
-// by [targetTX.enter].
-func (tx *targetTX) exit(script *UserScript) error {
-	return script.apiModule.Set("getTX", notInTransaction)
-}
-
-// Query is exported to the userscript.
-func (tx *targetTX) Query(q string, args ...any) *goja.Promise {
-	// Only called from JS, so we know that rtMu is locked.
-	promise, resolve, reject := tx.parent.rt.NewPromise()
-
-	// Execute the SQL in a (pooled) background goroutine.
-	tx.parent.execTask(func() {
-		tx.mu.Lock()
-		rows, err := tx.tq.QueryContext(tx.ctx, q, args...)
-		tx.mu.Unlock()
-
-		// Extract the number of columns for the result iterator.
-		var numCols int
-		if err == nil {
-			var names []string
-			names, err = rows.Columns()
-			numCols = len(names)
-		}
-		err = errors.Wrap(err, q)
-
-		// Once the results are ready, re-enter the JS runtime mutex to
-		// fulfil the promise. Ignoring error since closure never
-		// returns an error.
-		_ = tx.parent.execJS(func(rt *goja.Runtime) error {
-			if err != nil {
-				reject(err)
-				return nil
-			}
-
-			// Construct the iterator JS object by setting
-			// Symbol.iterator to a function that returns a value which
-			// implements the iterator protocol (i.e. has a next()
-			// function).
-			obj := rt.NewObject()
-			if err := obj.SetSymbol(goja.SymIterator, func() *rowsIter {
-				return &rowsIter{numCols, rows}
-			}); err != nil {
-				return errors.WithStack(err)
-			}
-			resolve(obj)
-			return nil
-		})
-	})
-
-	return promise
-}
-
-// Schema is exported to the userscript.
-func (tx *targetTX) Schema() string {
-	return tx.table.Schema().String()
-}
-
-// Table is exported to the userscript.
-func (tx *targetTX) Table() string {
-	return tx.table.String()
-}
-
-// rowsIter exports a [sql.Rows] into a JS API that conforms to the
-// iterator protocol. Note that goja does not (as of this writing)
-// support the async iterable protocol.
-//
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
-// https://pkg.go.dev/github.com/dop251/goja#example-Object.SetSymbol
-type rowsIter struct {
-	colCount int
-	rows     *sql.Rows
-}
-
-// Next implements the JS iterator protocol.
-func (it *rowsIter) Next() (*rowsIterResult, error) {
-	next := it.rows.Next()
-	err := it.rows.Err()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if !next {
-		return &rowsIterResult{Done: true}, nil
-	}
-
-	data := make([]any, it.colCount)
-	ptrs := make([]any, len(data))
-	for idx := range ptrs {
-		ptrs[idx] = &data[idx]
-	}
-	if err := it.rows.Scan(ptrs...); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return &rowsIterResult{Value: data}, nil
-}
-
-// Return implements the JS iterator protocol and will be called
-// if the iterator is not being read to completion. This allows us
-// to preemptively close the rowset.
-func (it *rowsIter) Return() *rowsIterResult {
-	_ = it.rows.Close()
-	return &rowsIterResult{Done: true}
-}
-
-// Implements the JS iteration result protocol.
-type rowsIterResult struct {
-	Done  bool  `goja:"done"`
-	Value []any `goja:"value"`
 }

--- a/internal/script/applyop.go
+++ b/internal/script/applyop.go
@@ -1,0 +1,73 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/pjson"
+)
+
+type applyOp struct {
+	Action string         `goja:"action"` // Always populated. Type must be string.
+	Data   map[string]any `goja:"data"`   // Present in upsert mode.
+	Meta   map[string]any `goja:"meta"`   // Present in upsert mode. Equivalent to map() meta.
+	PK     []any          `goja:"pk"`     // Always populated.
+}
+
+// applyOpsFromMuts converts a slice of types.Mutation into a
+// slice of *applyOp, suitable to be used in  a userscript.
+func applyOpsFromMuts(ctx context.Context, muts []types.Mutation) ([]*applyOp, error) {
+	ops := make([]*applyOp, len(muts))
+	pks := make([]*[]any, len(muts))
+	data := make([]*map[string]any, len(muts))
+	for idx, mut := range muts {
+		mode := actionUpsert
+		if mut.IsDelete() {
+			mode = actionDelete
+		}
+		ops[idx] = &applyOp{
+			Action: string(mode),
+			Meta:   mut.Meta,
+		}
+		pks[idx] = &ops[idx].PK
+		data[idx] = &ops[idx].Data
+	}
+	if err := pjson.Decode(ctx, pks, func(i int) []byte {
+		return muts[i].Key
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := pjson.Decode(ctx, data, func(i int) []byte {
+		if data := muts[i].Data; len(data) > 0 {
+			return data
+		}
+		return []byte("null")
+	}); err != nil {
+		return nil, err
+	}
+	return ops, nil
+}
+
+type applyAction string
+
+const (
+	actionDelete applyAction = "delete"
+	actionUpsert applyAction = "upsert"
+)

--- a/internal/script/applyop_test.go
+++ b/internal/script/applyop_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyOps verifies that we can roundtrip from Mutations to applyOps
+func TestApplyOps(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		muts []types.Mutation
+	}{
+		{
+			"insert",
+			[]types.Mutation{
+				{
+					Before: nil,
+					Data:   []byte(`{"pk":2,"value":"two"}`),
+					Key:    []byte(`[2]`),
+					Meta:   map[string]any{"insert": 1},
+				},
+				{
+					Before: nil,
+					Data:   []byte(`{"pk":3,"value":"three"}`),
+					Key:    []byte(`[3]`),
+					Meta:   map[string]any{"insert": 1},
+				},
+				{
+					Before: []byte(`{"pk":3,"value":"three"}`),
+					Data:   nil,
+					Key:    []byte(`[3]`),
+					Meta:   map[string]any{"delete": 1},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		r := require.New(t)
+		a := assert.New(t)
+		t.Run(tt.name, func(t *testing.T) {
+			ops, err := applyOpsFromMuts(ctx, tt.muts)
+			r.NoError(err)
+			muts, err := mutsFromApplyOps(ctx, ops)
+			r.NoError(err)
+			r.Equal(len(tt.muts), len(muts))
+			for idx, mut := range tt.muts {
+				if mut.Before == nil {
+					a.Nil(muts[idx].Before)
+				} else {
+					a.JSONEq(string(mut.Before), string(muts[idx].Before))
+				}
+				if mut.Data == nil {
+					a.Nil(muts[idx].Data)
+				} else {
+					a.JSONEq(string(mut.Data), string(muts[idx].Data))
+				}
+				if mut.Key == nil {
+					a.Nil(muts[idx].Key)
+				} else {
+					a.JSONEq(string(mut.Key), string(muts[idx].Key))
+				}
+				r.Equal(mut.Meta, muts[idx].Meta)
+			}
+		})
+	}
+}

--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -105,7 +105,7 @@ type targetJS struct {
 	CASColumns []string `goja:"cas"`
 	// Column to duration.
 	Deadlines map[string]string `goja:"deadlines"`
-	// PK to PK mapper.
+	// PK to PK mapper. Deprecated in favor of opMap.
 	DeleteKey deleteKeyJS `goja:"deleteKey"`
 	// Column to SQL expression to pass through.
 	Exprs map[string]string `goja:"exprs"`
@@ -113,11 +113,14 @@ type targetJS struct {
 	Extras string `goja:"extras"`
 	// Column names.
 	Ignore map[string]bool `goja:"ignore"`
-	// Mutation to mutation.
+	// Mutation to mutation. Deprecated in favor of opMap.
 	Map mapJS `goja:"map"`
 	// Two- or three-way merge operator. The bindMerge method will
 	// validate the type of value.
 	Merge goja.Value `goja:"merge"`
+
+	// Mutation to mutation.
+	OpMap opMapJS `goja:"opMap"`
 }
 
 // Loader is responsible for the first-pass execution of the user

--- a/internal/script/opmap.go
+++ b/internal/script/opmap.go
@@ -1,0 +1,99 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/dop251/goja"
+	"github.com/pkg/errors"
+)
+
+// A opMap is a function that allows transformations
+// between different kinds of operations on mutations.
+//
+//	{ Iterable<ApplyOp>) }  => { Promise<Iterable<ApplyOp>> }
+type opMapJS func(opData []*applyOp) *goja.Promise
+
+// mapper allows user to process incoming mutation and transform them as needed before
+// they are applied to the target.
+type mapper struct {
+	*tableEnv
+	op opMapJS
+}
+
+var _ types.ApplyMapper = (*mapper)(nil)
+
+// newMapper creates a new mapper
+func newMapper(parent *UserScript, table ident.Table, op opMapJS) *mapper {
+	return &mapper{
+		op: op,
+		tableEnv: &tableEnv{
+			parent: parent,
+			table:  table,
+		},
+	}
+}
+
+// Map implements [types.ApplyMapper].
+func (m *mapper) Map(
+	ctx context.Context, tq types.TargetQuerier, muts []types.Mutation,
+) ([]types.Mutation, error) {
+	ops, err := applyOpsFromMuts(ctx, muts)
+	if err != nil {
+		return nil, err
+	}
+	tx := &targetTX{
+		ctx:      ctx,
+		tq:       tq,
+		tableEnv: m.tableEnv,
+	}
+
+	var promise *goja.Promise
+	if err := m.parent.execTrackedJS(tx, func(rt *goja.Runtime) error {
+		promise = m.op(ops)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	res, err := m.parent.await(ctx, promise)
+	if err != nil {
+		return nil, err
+	}
+	switch exported := res.Export().(type) {
+	case []*applyOp:
+		return mutsFromApplyOps(ctx, exported)
+	case []any:
+		// If we create a new array within the javascript env
+		// the result type is []any.
+		// We need to check every element.
+		ops := make([]*applyOp, len(exported))
+		for idx, r := range exported {
+			if o, ok := r.(*applyOp); ok {
+				ops[idx] = o
+			} else {
+				return nil, errors.Errorf("unexpected type %T", r)
+			}
+		}
+		return mutsFromApplyOps(ctx, ops)
+	default:
+		return nil, errors.Errorf("unexpected type %T", exported)
+	}
+}

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -73,6 +73,11 @@ var identity Map = func(_ context.Context, mut types.Mutation) (types.Mutation, 
 	return mut, true, nil
 }
 
+// A OpMap function may modify the mutations that are applied to a
+// specific table. Map functions are internally synchronized to
+// ensure single-threaded access to the underlying JS VM.
+type OpMap func(ctx context.Context, mut []types.Mutation) ([]types.Mutation, error)
+
 // A Source holds user-provided configuration options for a
 // generic data-source.
 type Source struct {
@@ -254,6 +259,9 @@ func (s *UserScript) bind(loader *Loader) error {
 			if err != nil {
 				return err
 			}
+		}
+		if bag.OpMap != nil {
+			tgt.OpMap = newMapper(s, table, bag.OpMap)
 		}
 		for k, v := range bag.Ignore {
 			if v {

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/merge"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,6 +86,10 @@ func TestScript(t *testing.T) {
 		fmt.Sprintf("CREATE TABLE %s.delete_swap(pk0 INT, pk1 INT, PRIMARY KEY (pk0, pk1))", schema))
 	r.NoError(err)
 
+	_, err = fixture.TargetPool.ExecContext(ctx,
+		fmt.Sprintf("CREATE TABLE %s.soft_delete(pk INT, deleted VARCHAR(1), PRIMARY KEY (pk))", schema))
+	r.NoError(err)
+
 	var opts mapOptions
 
 	s, err := newScriptFromFixture(fixture, &Config{
@@ -95,7 +100,7 @@ func TestScript(t *testing.T) {
 	r.NoError(err)
 	r.NoError(s.watcher.Refresh(ctx, fixture.TargetPool))
 	a.Equal(3, s.Sources.Len())
-	a.Equal(8, s.Targets.Len())
+	a.Equal(9, s.Targets.Len())
 	a.Equal(map[string]string{"hello": "world"}, opts.data)
 
 	tbl1 := ident.NewTable(schema, ident.New("table1"))
@@ -217,6 +222,47 @@ func TestScript(t *testing.T) {
 		}
 	}
 
+	// Hard delete becoming a soft delete
+	// Skipping for Oracle SQL doesn't support "SELECT 1" in the script.
+	if fixture.TargetPool.Product != types.ProductOracle {
+		tbl = ident.NewTable(schema, ident.New("soft_delete"))
+		if cfg := s.Targets.GetZero(tbl); a.NotNil(cfg) {
+			op := cfg.OpMap
+			r.IsType(new(mapper), op)
+			meta := map[string]any{"test": 1}
+			if filter := cfg.OpMap; a.NotNil(filter) {
+				muts, err := op.Map(context.Background(),
+					fixture.TargetPool,
+					[]types.Mutation{
+						{
+							Before: []byte(`{"pk":1,"deleted":"N"}`),
+							Data:   nil,
+							Key:    []byte(`[1]`),
+							Meta:   meta,
+						},
+						{
+							Before: nil,
+							Data:   []byte(`{"pk":2,"deleted":"N"}`),
+							Key:    []byte(`[2]`),
+							Meta:   meta,
+						},
+					})
+				r.NoError(err)
+				r.Equal(2, len(muts))
+				// First muts is a delete, converted to a soft delete
+				a.JSONEq(`{"pk":1,"deleted":"Y"}`, string(muts[0].Data))
+				a.JSONEq(`{"pk":1,"deleted":"N"}`, string(muts[0].Before))
+				r.Equal(meta, muts[0].Meta)
+				r.Equal(json.RawMessage(`[1]`), muts[0].Key)
+				// Second muts is an insert, verify it is unchanged.
+				a.JSONEq(`{"pk":2,"deleted":"N"}`, string(muts[1].Data))
+				log.Info(string(muts[1].Before))
+				r.Equal(json.RawMessage(nil), muts[1].Before)
+				r.Equal(meta, muts[1].Meta)
+				r.Equal(json.RawMessage(`[2]`), muts[1].Key)
+			}
+		}
+	}
 	// A merge function that sends all conflicts to a DLQ.
 	tbl = ident.NewTable(schema, ident.New("merge_dlq_all"))
 	if cfg := s.Targets.GetZero(tbl); a.NotNil(cfg) {

--- a/internal/script/testdata/main.ts
+++ b/internal/script/testdata/main.ts
@@ -125,6 +125,31 @@ api.configureTable("merge_or_dlq", {
     merge: api.standardMerge(() => ({dlq: "dead"}))
 });
 
+
+// Demonstrate how to turn a hard delete into a soft delete
+api.configureTable("soft_delete", {
+    opMap: async (ops: Iterable<ApplyOp>): Promise<Iterable<ApplyOp>> => {
+        //Verify  that we can access the target database.
+        let tx = api.getTX();
+        let rows = tx.query("SELECT 1");
+        for (let row of await rows) {
+            console.log("rows query", JSON.stringify(row));
+        }
+        // creating a new array
+        let result : ApplyOp[] = [];
+        for (let op of ops) {
+            if (op.action == "delete") {
+                op.action = "upsert"
+                // clone op.before into op.data
+                op.data =  { ...op.before }
+                op.data["deleted"] = "Y"
+            }
+            result.push(op)
+        }
+        return result
+    }
+});
+
 // Demonstrate how upsert and delete SQL operations can be entirely
 // overridden by the userscript. In this test, we perform some basic
 // arithmetic on the keys and values to validate that this script is

--- a/internal/script/txn.go
+++ b/internal/script/txn.go
@@ -1,0 +1,221 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/dop251/goja"
+	"github.com/pkg/errors"
+)
+
+// notInTransaction is used to provide a helpful error message if
+// api.getTX() is called when no transaction is available.
+func notInTransaction() error {
+	return errors.New("no transaction is currently open")
+}
+
+type tableEnv struct {
+	parent *UserScript
+	table  ident.Table
+}
+
+// targetTX is a facade passed to the userscript to expose the target
+// database transaction and various other metadata.
+type targetTX struct {
+	*tableEnv
+
+	ctx     context.Context     // Passed to database methods.
+	columns []map[string]any    // Lazily-constructed schema data.
+	tq      types.TargetQuerier // The database transaction.
+	mu      sync.Mutex          // Serializes access to methods on tq.
+}
+
+var _ asyncTracker = (*targetTX)(nil)
+
+// Columns is exported to the userscript. It will lazily populate the
+// columns field.
+func (tx *targetTX) Columns() []map[string]any {
+	if len(tx.columns) > 0 {
+		return tx.columns
+	}
+	cols := tx.parent.watcher.Get().Columns.GetZero(tx.table)
+	for _, col := range cols {
+		// Keep in sync with .d.ts file.
+		m := map[string]any{
+			"ignored": col.Ignored,
+			"name":    col.Name.String(),
+			"primary": col.Primary,
+			"type":    col.Type,
+		}
+		// It's JS-idiomatic for the string to be null than empty.
+		if col.DefaultExpr != "" {
+			m["defaultExpr"] = col.DefaultExpr
+		}
+		tx.columns = append(tx.columns, m)
+	}
+	return tx.columns
+}
+
+// Enter implements [asyncTracker]. It will inject the targetTX into the
+// runtime so the user code may use it.
+func (tx *targetTX) enter(script *UserScript) error {
+	return script.apiModule.Set("getTX", func() *targetTX {
+		return tx
+	})
+}
+
+// Exec is exported to the userscript.
+func (tx *targetTX) Exec(q string, args ...any) *goja.Promise {
+	// Only called from JS, so we know that rtMu is locked.
+	promise, resolve, reject := tx.parent.rt.NewPromise()
+
+	// Execute the SQL in a (pooled) background goroutine.
+	tx.parent.execTask(func() {
+		tx.mu.Lock()
+		_, err := tx.tq.ExecContext(tx.ctx, q, args...)
+		tx.mu.Unlock()
+		err = errors.Wrap(err, q)
+
+		// Ignoring error since closure never returns an error.
+		_ = tx.parent.execJS(func(rt *goja.Runtime) error {
+			if err == nil {
+				resolve(goja.Undefined())
+			} else {
+				reject(err)
+			}
+			return nil
+		})
+	})
+
+	return promise
+}
+
+// Exit implements [asyncTracker]. It will clean up the references set
+// by [targetTX.enter].
+func (tx *targetTX) exit(script *UserScript) error {
+	return script.apiModule.Set("getTX", notInTransaction)
+}
+
+// Query is exported to the userscript.
+func (tx *targetTX) Query(q string, args ...any) *goja.Promise {
+	// Only called from JS, so we know that rtMu is locked.
+	promise, resolve, reject := tx.parent.rt.NewPromise()
+
+	// Execute the SQL in a (pooled) background goroutine.
+	tx.parent.execTask(func() {
+		tx.mu.Lock()
+		rows, err := tx.tq.QueryContext(tx.ctx, q, args...)
+		tx.mu.Unlock()
+
+		// Extract the number of columns for the result iterator.
+		var numCols int
+		if err == nil {
+			var names []string
+			names, err = rows.Columns()
+			numCols = len(names)
+		}
+		err = errors.Wrap(err, q)
+
+		// Once the results are ready, re-enter the JS runtime mutex to
+		// fulfil the promise. Ignoring error since closure never
+		// returns an error.
+		_ = tx.parent.execJS(func(rt *goja.Runtime) error {
+			if err != nil {
+				reject(err)
+				return nil
+			}
+
+			// Construct the iterator JS object by setting
+			// Symbol.iterator to a function that returns a value which
+			// implements the iterator protocol (i.e. has a next()
+			// function).
+			obj := rt.NewObject()
+			if err := obj.SetSymbol(goja.SymIterator, func() *rowsIter {
+				return &rowsIter{numCols, rows}
+			}); err != nil {
+				return errors.WithStack(err)
+			}
+			resolve(obj)
+			return nil
+		})
+	})
+
+	return promise
+}
+
+// Schema is exported to the userscript.
+func (tx *targetTX) Schema() string {
+	return tx.table.Schema().String()
+}
+
+// Table is exported to the userscript.
+func (tx *targetTX) Table() string {
+	return tx.table.String()
+}
+
+// rowsIter exports a [sql.Rows] into a JS API that conforms to the
+// iterator protocol. Note that goja does not (as of this writing)
+// support the async iterable protocol.
+//
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+// https://pkg.go.dev/github.com/dop251/goja#example-Object.SetSymbol
+type rowsIter struct {
+	colCount int
+	rows     *sql.Rows
+}
+
+// Next implements the JS iterator protocol.
+func (it *rowsIter) Next() (*rowsIterResult, error) {
+	next := it.rows.Next()
+	err := it.rows.Err()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if !next {
+		return &rowsIterResult{Done: true}, nil
+	}
+
+	data := make([]any, it.colCount)
+	ptrs := make([]any, len(data))
+	for idx := range ptrs {
+		ptrs[idx] = &data[idx]
+	}
+	if err := it.rows.Scan(ptrs...); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &rowsIterResult{Value: data}, nil
+}
+
+// Return implements the JS iterator protocol and will be called
+// if the iterator is not being read to completion. This allows us
+// to preemptively close the rowset.
+func (it *rowsIter) Return() *rowsIterResult {
+	_ = it.rows.Close()
+	return &rowsIterResult{Done: true}
+}
+
+// Implements the JS iteration result protocol.
+type rowsIterResult struct {
+	Done  bool  `goja:"done"`
+	Value []any `goja:"value"`
+}

--- a/internal/target/apply/column_mapping.go
+++ b/internal/target/apply/column_mapping.go
@@ -43,6 +43,7 @@ type columnMapping struct {
 	Exprs                *ident.Map[string]           // Value-replacement expressions.
 	ExtrasColIdx         int                          // Position of the extras column, or -1 if unconfigured.
 	Ignore               ident.Idents                 // Named columns to ignore in the input.
+	OpMap                types.ApplyMapper            // Generic mutation mapper.
 	Merger               merge.Merger                 // Conflict-resolution callback.
 	Positions            *ident.Map[positionalColumn] // Map of idents to column info and position.
 	Product              types.Product                // Target database product.
@@ -70,6 +71,7 @@ func newColumnMapping(
 		Deadlines:    &ident.Map[time.Duration]{},
 		Exprs:        &ident.Map[string]{},
 		ExtrasColIdx: -1,
+		OpMap:        cfg.OpMap,
 		Positions:    &ident.Map[positionalColumn]{},
 		Product:      product,
 		Renames:      &ident.Map[ident.Ident]{},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -117,6 +117,18 @@ type Leases interface {
 	Singleton(ctx context.Context, name string, fn func(ctx context.Context) error)
 }
 
+// ApplyMapper transforms mutations. It allows user to provide logic, via
+// a scripting language to interact with a batch of mutations
+// before they are applied to the target database. The user may generate
+// new mutations, change the type of the mutations (e.g. changing a hard delete
+// to a soft delete), or update any of the fields within the mutation.
+// The script may also access the target database via the TargetQuerier
+// interface.
+type ApplyMapper interface {
+	// Map transforms mutations based on a user specified logic.
+	Map(context.Context, TargetQuerier, []Mutation) ([]Mutation, error)
+}
+
 // A Memo is a key store that persists a value associated to a key
 type Memo interface {
 	// Get retrieves the value associate to the given key.

--- a/internal/util/applycfg/conf.go
+++ b/internal/util/applycfg/conf.go
@@ -51,6 +51,7 @@ type Config struct {
 	Exprs       *ident.Map[string]        // Synthetic or replacement SQL expressions.
 	Extras      TargetColumn              // JSONB column to store unmapped values in.
 	Ignore      *ident.Map[bool]          // Source column names to ignore.
+	OpMap       types.ApplyMapper         // Generic mapper with access to the target database.
 	Merger      merge.Merger              // Conflict resolution.
 	SourceNames *ident.Map[SourceColumn]  // Look for alternate name in the incoming data.
 }
@@ -75,6 +76,7 @@ func (t *Config) Copy() *Config {
 	t.Exprs.CopyInto(ret.Exprs)
 	ret.Extras = t.Extras
 	t.Ignore.CopyInto(ret.Ignore)
+	ret.OpMap = t.OpMap
 	ret.Merger = t.Merger
 	t.SourceNames.CopyInto(ret.SourceNames)
 
@@ -84,8 +86,8 @@ func (t *Config) Copy() *Config {
 // Equal returns true if the other Config is equivalent to the receiver.
 //
 // This method is intended for testing only. It does not compare the
-// Merger field, since not all implementations of that interface are
-// guaranteed to have a defined comparison operation (e.g. merge.Func).
+// Delegate, Merger and OpMap fields, since not all implementations
+// of that interface are guaranteed to have a defined comparison operation (e.g. merge.Func).
 func (t *Config) Equal(o *Config) bool {
 	return t == o || // Identity or nil-nil.
 		(t != nil) && (o != nil) &&
@@ -108,6 +110,7 @@ func (t *Config) IsZero() bool {
 		t.Exprs.Len() == 0 &&
 		t.Extras.Empty() &&
 		t.Ignore.Len() == 0 &&
+		t.OpMap == nil &&
 		t.Merger == nil &&
 		t.SourceNames.Len() == 0
 }
@@ -130,6 +133,9 @@ func (t *Config) Patch(other *Config) *Config {
 	}
 	if other.Ignore != nil {
 		other.Ignore.CopyInto(t.Ignore)
+	}
+	if other.OpMap != nil {
+		t.OpMap = other.OpMap
 	}
 	if other.Merger != nil {
 		t.Merger = other.Merger

--- a/internal/util/applycfg/conf_test.go
+++ b/internal/util/applycfg/conf_test.go
@@ -37,6 +37,7 @@ func TestCopyEquals(t *testing.T) {
 		Exprs:      ident.MapOf[string]("expr", "foo"),
 		Extras:     ident.New("extras"),
 		Ignore:     ident.MapOf[bool]("ign", true),
+		OpMap:      types.ApplyMapper(nil),
 		Merger: merge.Func(func(context.Context, *merge.Conflict) (*merge.Resolution, error) {
 			panic("unused")
 		}),


### PR DESCRIPTION
This change adds a new entry point in the userscript:
  `opMap: (Iterable<ApplyOp>) => Promise<Iterable<ApplyOp>>`

The user may provide an async opMap function that will be called before the mutations are processed by the target. In the function supplied, the user may choose to remove some mutations, modify values in the mutations, or change the type of operation (upsert vs delete). The function will have access to SQL bindings to run queries against the target, if needed.

Summary of changes:
- javascript api: added the opMap function definition to the cdc-sink@v1 module.
- types package: introduced a new Mapper interface.
- script package: refactoring code to move some common functionality in txn.go (access to the target db) and applyop.go (conversion mutation/applyop and viceversa). opmap.go implements Mapper.
- target/apply package: wired in the call to the opMap function, if present.

Fixes #667

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/673)
<!-- Reviewable:end -->
