### PR TITLE
stopvar: Combined stopper and notify utilities

### DIFF
--- a/internal/util/stopvar/stopvar.go
+++ b/internal/util/stopvar/stopvar.go
@@ -1,0 +1,139 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stopvar contains helpers that build on both the stopper and
+// notify packages.
+package stopvar
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
+	"github.com/pkg/errors"
+)
+
+// DoWhenChanged executes the callback when the variable has changed to
+// a different value. That is, if the variable is set to existing value,
+// the callback will not be be invoked. If an error is returned from the
+// callback, the last successfully-processed value will be returned.
+func DoWhenChanged[T comparable](
+	ctx *stopper.Context,
+	start T,
+	source *notify.Var[T],
+	fn func(ctx *stopper.Context, old, new T) error,
+) (last T, err error) {
+	last = start
+	for {
+		next, _ := WaitForChange(ctx, last, source)
+		if ctx.IsStopping() {
+			return last, nil
+		}
+		if err := fn(ctx, last, next); err != nil {
+			return last, errors.Wrapf(err, "changed [%v -> %v]", last, next)
+		}
+		last = next
+	}
+}
+
+// DoWhenChangedOrInterval executes the callback when the variable has
+// changed or if the configured period of time has elapsed since the
+// last invocation. This is useful when some activity should be taken in
+// response to a change or at a somewhat regular interval. If an error
+// is returned from the callback, the last successfully-processed value
+// will be returned.
+func DoWhenChangedOrInterval[T comparable](
+	ctx *stopper.Context,
+	start T,
+	source *notify.Var[T],
+	period time.Duration,
+	fn func(ctx *stopper.Context, old, new T) error,
+) (last T, err error) {
+	last = start
+	for {
+		next, _ := WaitForChangeOrDuration(ctx, last, source, period)
+		if ctx.IsStopping() {
+			return last, nil
+		}
+		if err := fn(ctx, last, next); err != nil {
+			return last, errors.Wrapf(err, "changed [%v -> %v]", last, next)
+		}
+		last = next
+	}
+}
+
+// WaitForChange is a utility function that waits for the source to
+// change to another value. If the context is stopped, the most recent
+// value will be returned.
+func WaitForChange[T comparable](
+	ctx *stopper.Context, current T, source *notify.Var[T],
+) (next T, changed <-chan struct{}) {
+	for {
+		next, changed = source.Get()
+		if current != next {
+			return next, changed
+		}
+		select {
+		case <-changed:
+			continue
+		case <-ctx.Stopping():
+			return current, changed
+		}
+	}
+}
+
+// WaitForChangeOrDuration is a utility function that waits for the
+// source to change to another value or for the given duration to
+// elapse.
+func WaitForChangeOrDuration[T comparable](
+	ctx *stopper.Context, current T, source *notify.Var[T], d time.Duration,
+) (next T, changed <-chan struct{}) {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	for {
+		next, changed = source.Get()
+		if current != next {
+			return next, changed
+		}
+		select {
+		case <-changed:
+			continue
+		case <-timer.C:
+			return current, changed
+		case <-ctx.Stopping():
+			return current, changed
+		}
+	}
+}
+
+// WaitForValue is a utility function that waits until the source emits
+// the requested value. This is primarily intended for testing.
+func WaitForValue[T comparable](ctx *stopper.Context, expected T, source *notify.Var[T]) error {
+	for {
+		found, changed := source.Get()
+		if found == expected {
+			return nil
+		}
+		select {
+		case <-changed:
+			continue
+		case <-ctx.Stopping():
+			return errors.Errorf("context is stopping, last saw %v while expecting %v", found, expected)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/internal/util/stopvar/stopvar_test.go
+++ b/internal/util/stopvar/stopvar_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stopvar
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoWhenChanged(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var called atomic.Bool
+	var v notify.Var[int]
+
+	stop := stopper.WithContext(ctx)
+	stop.Go(func() error {
+		_, err := DoWhenChanged(stop, -1, &v, func(ctx *stopper.Context, old, new int) error {
+			switch new {
+			case 1:
+				r.Equal(-1, old)
+				v.Set(2) // This should cause us to loop around.
+			case 2:
+				r.Equal(1, old)
+				called.Store(true)
+				stop.Stop(time.Minute)
+			}
+			return nil
+		})
+		return err
+	})
+
+	v.Set(1)
+	r.NoError(stop.Wait())
+	r.True(called.Load())
+}
+
+func TestDoWhenChangedOrInterval(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var called atomic.Bool
+	var v notify.Var[int]
+
+	stop := stopper.WithContext(ctx)
+	stop.Go(func() error {
+		_, err := DoWhenChangedOrInterval(stop, -1, &v, 100*time.Millisecond,
+			func(ctx *stopper.Context, old, new int) error {
+				switch new {
+				case 1:
+					r.Equal(-1, old)
+					v.Set(2) // This should cause us to loop around.
+				case 2:
+					switch old {
+					case 1:
+					// First time through, don't do anything.
+					case 2:
+						// Called by interval tick.
+						called.Store(true)
+						stop.Stop(time.Minute)
+					default:
+						r.Failf("unexpected old value", "%d", old)
+					}
+				}
+				return nil
+			})
+		return err
+	})
+
+	v.Set(1)
+	r.NoError(stop.Wait())
+	r.True(called.Load())
+}
+
+func TestWaitForValue(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var called atomic.Bool
+	var v notify.Var[int]
+
+	stop := stopper.WithContext(ctx)
+	stop.Go(func() error {
+		if err := WaitForValue(stop, 1, &v); err != nil {
+			return err
+		}
+		called.Store(true)
+		stop.Stop(time.Minute)
+		return nil
+	})
+
+	v.Set(1)
+	r.NoError(stop.Wait())
+	r.True(called.Load())
+
+}


### PR DESCRIPTION
This change adds utilities for common patterns involving a stopper.Context and a notify.Var.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/674)
<!-- Reviewable:end -->
