### PR TITLE
hlc: Add Range type and Time.Next method

### DIFF
--- a/internal/util/hlc/hlc.go
+++ b/internal/util/hlc/hlc.go
@@ -87,6 +87,9 @@ func (t Time) Logical() int { return t.logical }
 // Nanos returns the nanosecond wall time.
 func (t Time) Nanos() int64 { return t.nanos }
 
+// Next returns the time plus one logical tick.
+func (t Time) Next() Time { return Time{t.nanos, t.logical + 1} }
+
 // MarshalJSON represents the time as a JSON string. This is used when
 // logging timestamps.
 func (t Time) MarshalJSON() ([]byte, error) {

--- a/internal/util/hlc/hlc_test.go
+++ b/internal/util/hlc/hlc_test.go
@@ -37,6 +37,19 @@ func TestCompare(t *testing.T) {
 	a.True(Compare(Time{1, 1}, Time{1, 2}) < 0)
 }
 
+func TestNext(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal(New(1, 1), New(1, 0).Next())
+}
+
+func TestRange(t *testing.T) {
+	a := assert.New(t)
+
+	a.True(Range{Time{1, 0}, Time{1, 0}}.Empty())
+	a.False(Range{Time{1, 0}, Time{1, 1}}.Empty())
+}
+
 func TestParse(t *testing.T) {
 	// Implementation copied from sink_table_test.go
 

--- a/internal/util/hlc/range.go
+++ b/internal/util/hlc/range.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hlc
+
+import "fmt"
+
+// Range represents a half-open range of HLC values, inclusive of Min
+// and exclusive of Max.
+type Range [2]Time
+
+// Empty returns true if the Min time is greater than or equal to the
+// Max value.
+func (r Range) Empty() bool { return Compare(r[0], r[1]) >= 0 }
+
+// Min returns the inclusive, minimum value.
+func (r Range) Min() Time { return r[0] }
+
+// Max returns the exclusive, maximum value.
+func (r Range) Max() Time { return r[1] }
+
+func (r Range) String() string {
+	return fmt.Sprintf("[ %s -> %s )", r[0], r[1])
+}


### PR DESCRIPTION
This change adds a "plus one" method to hlc.Time and a Range type that represents a half-open range of timestamps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/675)
<!-- Reviewable:end -->
