### PR TITLE
notify: Add ErrNoUpdate

### DIFF
--- a/internal/util/notify/var_test.go
+++ b/internal/util/notify/var_test.go
@@ -94,6 +94,20 @@ func TestVar(t *testing.T) {
 	default:
 	}
 
+	// Verify ErrNoUpdate returns a nil error.
+	current, chNoUpdate, err = v.Update(func(old int) (int, error) {
+		r.Equal(2, old)
+		return -1, ErrNoUpdate
+	})
+	r.Equal(2, current)
+	r.NoError(err)
+	r.Equal(ch3, chNoUpdate)
+	select {
+	case <-ch3:
+		r.Fail("no update, so channel should not have closed")
+	default:
+	}
+
 	// Just invalidate the channel.
 	v.Notify()
 	select {


### PR DESCRIPTION
This change adds a sentinel error value that is suppressed by notify.Var.Update(). This provides a clean way for a callback to decline to update the variable without the caller having to perform a sentinel check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/677)
<!-- Reviewable:end -->
