### PR TITLE
stdlogical: Add Config interface

### DIFF
--- a/internal/cmd/fslogical/fslogical.go
+++ b/internal/cmd/fslogical/fslogical.go
@@ -29,8 +29,8 @@ import (
 func Command() *cobra.Command {
 	cfg := &fslogical.Config{}
 	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a Google Cloud Firestore logical replication feed",
+		Config: cfg,
+		Short:  "start a Google Cloud Firestore logical replication feed",
 		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
 			// main.go provides this stopper.
 			return fslogical.Start(ctx, cfg)

--- a/internal/cmd/mylogical/mylogical.go
+++ b/internal/cmd/mylogical/mylogical.go
@@ -29,8 +29,8 @@ import (
 func Command() *cobra.Command {
 	cfg := &mylogical.Config{}
 	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a mySQL replication feed",
+		Config: cfg,
+		Short:  "start a mySQL replication feed",
 		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
 			return mylogical.Start(ctx, cfg)
 		},

--- a/internal/cmd/pglogical/pglogical.go
+++ b/internal/cmd/pglogical/pglogical.go
@@ -29,8 +29,8 @@ import (
 func Command() *cobra.Command {
 	cfg := &pglogical.Config{}
 	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start a pg logical replication feed",
+		Config: cfg,
+		Short:  "start a pg logical replication feed",
 		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
 			return pglogical.Start(ctx, cfg)
 		},

--- a/internal/cmd/start/start.go
+++ b/internal/cmd/start/start.go
@@ -26,12 +26,12 @@ import (
 
 // Command returns the command to start the server.
 func Command() *cobra.Command {
-	var cfg server.Config
+	cfg := &server.Config{}
 	return stdlogical.New(&stdlogical.Template{
-		Bind:  cfg.Bind,
-		Short: "start the server",
+		Config: cfg,
+		Short:  "start the server",
 		Start: func(ctx *stopper.Context, cmd *cobra.Command) (any, error) {
-			return server.NewServer(ctx, &cfg)
+			return server.NewServer(ctx, cfg)
 		},
 		Use: "start",
 	})

--- a/internal/util/stdlogical/stdlogical_test.go
+++ b/internal/util/stdlogical/stdlogical_test.go
@@ -38,7 +38,6 @@ func TestSmoke(t *testing.T) {
 	ready := make(chan struct{})
 
 	cmd := New(&Template{
-		Bind:    nil, // No extra CLI flags
 		Metrics: "127.0.0.1:13013",
 		Start: func(ctx *stopper.Context, cmd *cobra.Command) (started any, err error) {
 			return nil, nil


### PR DESCRIPTION
This change solves some upcoming lifecycle and startup complexities by having the stdlogical package bind and preflight the configuration object used by a command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/678)
<!-- Reviewable:end -->
