### PR TITLE
stage: Add support for conditional staging

### DIFF
--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -119,7 +119,7 @@ func (h *Handler) ndjson(ctx context.Context, req *request, parser parseMutation
 		}
 		// Start a goroutine to stage the data so we can keep decoding.
 		flush = func(muts []types.Mutation) error {
-			eg.Go(func() error { return store.Store(egCtx, h.StagingPool, muts) })
+			eg.Go(func() error { return store.Stage(egCtx, h.StagingPool, muts) })
 			return nil
 		}
 		commit = eg.Wait

--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -125,7 +125,7 @@ func (h *Handler) processMutationsDeferred(
 
 		// Stage or apply the per-target mutations.
 		if err := toProcess.Range(func(target ident.Table, muts []types.Mutation) error {
-			return stores.GetZero(target).Store(ctx, tx, muts)
+			return stores.GetZero(target).Stage(ctx, tx, muts)
 		}); err != nil {
 			return err
 		}

--- a/internal/staging/stage/factory.go
+++ b/internal/staging/stage/factory.go
@@ -57,7 +57,7 @@ func (f *factory) createUnlocked(table ident.Table) (*stage, error) {
 		return ret, nil
 	}
 
-	ret, err := newStore(f.stop, f.db, f.stagingDB, table)
+	ret, err := newStage(f.stop, f.db, f.stagingDB, table)
 	if err == nil {
 		f.mu.instances.Put(table, ret)
 	}
@@ -80,11 +80,7 @@ func (f *factory) Unstage(
 	// Duplicate the cursor so callers can choose to advance.
 	cursor = cursor.Copy()
 
-	data := &templateData{
-		Cursor:        cursor,
-		StagingSchema: f.stagingDB.Schema(),
-	}
-	q, err := data.Eval()
+	q, err := newTemplateData(cursor, f.stagingDB).Eval()
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/staging/stage/metrics.go
+++ b/internal/staging/stage/metrics.go
@@ -49,17 +49,17 @@ var (
 		Name: "stage_stale_mutations_count",
 		Help: "the number of un-applied staged mutations left after retiring applied mutations",
 	}, metrics.TableLabels)
-	stageStoreCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "stage_store_mutations_total",
-		Help: "the number of mutations stored for this table",
+	stageCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "stage_mutations_total",
+		Help: "the number of mutations staged for this table",
 	}, metrics.TableLabels)
-	stageStoreDurations = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "stage_store_duration_seconds",
-		Help:    "the length of time it took to successfully store mutations",
+	stageDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "stage_duration_seconds",
+		Help:    "the length of time it took to successfully stage mutations",
 		Buckets: metrics.LatencyBuckets,
 	}, metrics.TableLabels)
-	stageStoreErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "stage_store_errors_total",
-		Help: "the number of times an error was encountered while storing mutations",
+	stageErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "stage_errors_total",
+		Help: "the number of times an error was encountered while staging mutations",
 	}, metrics.TableLabels)
 )

--- a/internal/staging/stage/queries/unstage.tmpl
+++ b/internal/staging/stage/queries/unstage.tmpl
@@ -12,7 +12,7 @@ hlc_0 AS (
   SELECT nanos, logical FROM staging_table
   WHERE (nanos, logical, key) > (start_at_nanos, start_at_logical, start_after_key)
   AND (nanos, locical) < (end_before_nanos, end_before_logical)
-  AND NOT APPLIED
+  AND NOT applied
   GROUP BY nanos, logical -- We want multi-column distinct behavior
   ORDER BY nanos, logical
   LIMIT N
@@ -54,17 +54,42 @@ SELECT n, l FROM hlc_{{ $idx }}
 hlc_min AS (SELECT n, l FROM hlc_all GROUP BY n, l ORDER BY n, l LIMIT {{ or .Cursor.TimestampLimit 1 }})
 
 {{- /*
+Identify keys that should be blocked due to active leases. This prevents
+a key from rolling backwards if an update at an earlier time, T+0, is
+deferred and a subsequent update to that key could be applied at a later
+time, T+1.
+
+blocked_0 AS (
+  SELECT key FROM staging_table
+  JOIN hlc_min ON (nanos, logical) = (n, l)
+  WHERE (lease IS NOT NULL AND lease > now())
+)
+*/ -}}
+{{- if not $.IgnoreLeases -}}
+{{- range $idx, $tgt := .Cursor.Targets -}}
+, {{- nl -}}
+blocked_{{ $idx }} AS (
+SELECT key FROM {{ $top.StagingTable $tgt }}
+JOIN hlc_min ON (nanos,logical) = (n,l)
+WHERE (lease IS NOT NULL AND lease > now())
+GROUP BY key
+)
+{{- end -}}
+{{- end -}}
+
+{{- /*
 Set the applied column and return the data.
 
 We want to update any non-applied mutations after the starting key
 and within the HLC timestamp that we're operating on.
 
 data_0 AS (
-  UPDATE staging_table SET applied=true
+  UPDATE staging_table SET [ (applied=true, lease=NULL) | lease=deadline ]
   FROM hlc_min
   WHERE (nanos, logical) IN (hlc_min)
     AND (nanos, logical, key) > (start_at_nanos, start_at_logical, start_after_key)
-    AND NOT APPLIED
+    AND NOT applied
+    [ AND key NOT IN (SELECT key FROM blocked_0) ]
   [ ORDER BY nanos, logical, key
     LIMIT n ]
   RETURNING nanos, logical, key, mut, before
@@ -73,12 +98,20 @@ data_0 AS (
 {{- range $idx, $tgt := .Cursor.Targets -}}
 , {{- nl -}}
 data_{{ $idx }} AS (
-UPDATE {{ $top.StagingTable $tgt }}
-SET applied=true
+UPDATE {{ $top.StagingTable $tgt }} {{- nl -}}
+{{- if $top.SetApplied -}}
+SET applied=true, lease=NULL {{- nl -}}
+{{- else if $top.SetLeaseExpiry -}}
+{{- /* https://www.cockroachlabs.com/docs/stable/timestamp#convert-an-int-microseconds-since-epoch-to-timestamp */ -}}
+SET lease=TIMESTAMP 'epoch' + ({{ $top.SetLeaseExpiry.UnixMilli }}::float / 1000)::INTERVAL {{- nl -}}
+{{- end -}}
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[ {{- add $idx 1 -}} ])
 AND NOT applied
+{{- if not $top.IgnoreLeases -}}
+{{- nl -}} AND key NOT IN (SELECT key FROM blocked_{{ $idx }})
+{{- end -}}
 {{- if $top.Cursor.UpdateLimit -}} {{- nl -}}
 ORDER BY nanos, logical, key
 LIMIT {{ $top.Cursor.UpdateLimit }}

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -19,11 +19,13 @@ package stage_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/sinktest"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
@@ -33,6 +35,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +87,7 @@ func TestPutAndDrain(t *testing.T) {
 	}
 
 	// Insert.
-	r.NoError(s.Store(ctx, pool, muts))
+	r.NoError(s.Stage(ctx, pool, muts))
 
 	// Sanity-check table.
 	count, err := base.GetRowCount(ctx, pool, stagingTable)
@@ -92,7 +95,7 @@ func TestPutAndDrain(t *testing.T) {
 	a.Equal(total, count)
 
 	// Ensure that data insertion is idempotent.
-	r.NoError(s.Store(ctx, pool, muts))
+	r.NoError(s.Stage(ctx, pool, muts))
 
 	// Sanity-check table.
 	count, err = base.GetRowCount(ctx, pool, stagingTable)
@@ -140,6 +143,104 @@ func TestPutAndDrain(t *testing.T) {
 	r.NoError(s.Retire(ctx, pool, hlc.New(muts[len(muts)-1].Time.Nanos()+1, 0)))
 }
 
+func TestStoreIfExists(t *testing.T) {
+	r := require.New(t)
+
+	fixture, err := all.NewFixture(t)
+	r.NoError(err)
+
+	ctx := fixture.Context
+	pool := fixture.StagingPool
+	targetDB := fixture.StagingDB.Schema()
+
+	dummyTarget := ident.NewTable(targetDB, ident.New("target"))
+
+	s, err := fixture.Stagers.Get(ctx, dummyTarget)
+	r.NoError(err)
+
+	// Store a seed mutation.
+	r.NoError(s.Stage(ctx, pool, []types.Mutation{
+		{
+			Data: json.RawMessage(`{pk:1}`),
+			Key:  json.RawMessage(`[1]`),
+			Time: hlc.New(1, 0),
+		},
+	}))
+
+	found, err := fixture.PeekStaged(ctx, dummyTarget, hlc.Zero(), hlc.New(100, 0))
+	r.NoError(err)
+	r.Len(found, 1)
+
+	proposed := []types.Mutation{
+		// New entry, should not be staged.
+		{
+			Data: json.RawMessage(`{pk:0}`),
+			Key:  json.RawMessage(`[0]`),
+			Time: hlc.New(2, 0),
+		},
+		// This should be staged.
+		{
+			Data: json.RawMessage(`{pk:1}`),
+			Key:  json.RawMessage(`[1]`),
+			Time: hlc.New(2, 0),
+		},
+		// New entry, should not be staged.
+		{
+			Data: json.RawMessage(`{pk:2}`),
+			Key:  json.RawMessage(`[2]`),
+			Time: hlc.New(2, 0),
+		},
+	}
+
+	pending, err := s.StageIfExists(ctx, pool, proposed)
+	r.NoError(err)
+	r.Equal([]types.Mutation{proposed[0], proposed[2]}, pending)
+
+	found, err = fixture.PeekStaged(ctx, dummyTarget, hlc.Zero(), hlc.New(100, 0))
+	r.NoError(err)
+	r.Len(found, 2)
+
+	// Bump the timestamp and try again. We should see the same
+	// keys be selected.
+	for idx := range proposed {
+		proposed[idx].Time = hlc.New(3, 0)
+	}
+
+	pending, err = s.StageIfExists(ctx, pool, proposed)
+	r.NoError(err)
+	r.Equal([]types.Mutation{proposed[0], proposed[2]}, pending)
+
+	found, err = fixture.PeekStaged(ctx, dummyTarget, hlc.Zero(), hlc.New(100, 0))
+	r.NoError(err)
+	r.Len(found, 3)
+
+	// Unstage the mutations.
+	var count int
+	cursor := &types.UnstageCursor{
+		StartAt:        hlc.Zero(),
+		EndBefore:      hlc.New(100, 0),
+		Targets:        []ident.Table{dummyTarget},
+		TimestampLimit: 100,
+	}
+	_, read, err := fixture.Stagers.Unstage(ctx, pool, cursor, func(context.Context, ident.Table, types.Mutation) error {
+		count++
+		return nil
+	})
+	r.NoError(err)
+	r.True(read)
+	r.Equal(3, count)
+
+	found, err = fixture.PeekStaged(ctx, dummyTarget, hlc.Zero(), hlc.New(100, 0))
+	r.NoError(err)
+	r.Empty(found)
+
+	// Since the staging table is effectively empty, this call should be
+	// a no-op.
+	pending, err = s.StageIfExists(ctx, pool, proposed)
+	r.NoError(err)
+	r.Equal(proposed, pending)
+}
+
 func TestUnstage(t *testing.T) {
 	const entries = 100
 	const tableCount = 10
@@ -179,6 +280,7 @@ func TestUnstage(t *testing.T) {
 	// * Individual entries from t=[2*entries, 3*entries]
 	// * Large batch at t=10*entries
 	// * Individual entries at t=[12*entries, 13*entries]
+	const distinctTimestamps = 2 + 2*entries
 	muts := make([]types.Mutation, 0, 4*entries)
 	for i := 0; i < entries; i++ {
 		muts = append(muts,
@@ -225,10 +327,65 @@ func TestUnstage(t *testing.T) {
 	})
 
 	// Stage some data for each table.
+	stagingTables := &ident.TableMap[ident.Table]{}
 	for _, table := range tables {
 		stager, err := fixture.Stagers.Get(ctx, table)
 		r.NoError(err)
-		r.NoError(stager.Store(ctx, fixture.StagingPool, muts))
+		r.NoError(stager.Stage(ctx, fixture.StagingPool, muts))
+		stagingTables.Put(table, stager.(interface{ GetTable() ident.Table }).GetTable())
+	}
+
+	// checkCount is a helper function to verify that the cursor returns
+	// a specific number of mutations. The StartAfterKey field in the
+	// cursor will be cleared and the timestamp limit will be raised to
+	// a large value.
+	checkCount := func(a *assert.Assertions, tx types.StagingQuerier, q *types.UnstageCursor, expectCount int) {
+		q = q.Copy()
+		q.TimestampLimit = math.MaxInt32
+		q.StartAfterKey = ident.TableMap[json.RawMessage]{}
+		var count int
+		for hasMore := true; hasMore; {
+			_, hasMore, err = fixture.Stagers.Unstage(ctx, tx, q,
+				func(context.Context, ident.Table, types.Mutation) error {
+					count++
+					return nil
+				})
+			if !a.NoError(err) {
+				return
+			}
+		}
+		a.Equal(expectCount, count)
+	}
+
+	// checkEmpty is a helper function to verify that the cursor returns
+	// no data. The StartAfterKey field will be cleared.
+	checkEmpty := func(a *assert.Assertions, tx types.StagingQuerier, q *types.UnstageCursor) {
+		q = q.Copy()
+		q.StartAfterKey = ident.TableMap[json.RawMessage]{}
+		_, hasMore, err := fixture.Stagers.Unstage(ctx, tx, q,
+			func(context.Context, ident.Table, types.Mutation) error {
+				return errors.New("no mutations should be visible")
+			})
+		if a.NoError(err) {
+			a.False(hasMore, "should not have more mutations to return")
+		}
+	}
+
+	// unstage reads from the given cursor until no more data is
+	// available. It returns the data for each table and the number of
+	// times the unstaging callback function was invoked.
+	unstage := func(r *require.Assertions, tx types.StagingQuerier, q *types.UnstageCursor) (data *ident.TableMap[[]types.Mutation], numSelections int) {
+		data = &ident.TableMap[[]types.Mutation]{}
+		for selecting := true; selecting; {
+			q, selecting, err = fixture.Stagers.Unstage(ctx, tx, q,
+				func(ctx context.Context, tbl ident.Table, mut types.Mutation) error {
+					data.Put(tbl, append(data.GetZero(tbl), mut))
+					return nil
+				})
+			r.NoError(err)
+			numSelections++
+		}
+		return
 	}
 
 	t.Run("transactional", func(t *testing.T) {
@@ -246,22 +403,12 @@ func TestUnstage(t *testing.T) {
 		r.NoError(err)
 		defer func() { _ = tx.Rollback(ctx) }()
 
-		entriesByTable := &ident.TableMap[[]types.Mutation]{}
-		numSelections := 0
-		for selecting := true; selecting; {
-			q, selecting, err = fixture.Stagers.Unstage(ctx, tx, q,
-				func(ctx context.Context, tbl ident.Table, mut types.Mutation) error {
-					entriesByTable.Put(tbl, append(entriesByTable.GetZero(tbl), mut))
-					return nil
-				})
-			r.NoError(err)
-			numSelections++
-		}
+		entriesByTable, numSelections := unstage(r, tx, q)
 		// Refer to comment about the distribution of timestamps.
 		// There are two large batches, then each mutation has two
 		// unique timestamps, and then there's a final call that returns
 		// false.
-		a.Equal(2+2*entries+1, numSelections)
+		a.Equal(distinctTimestamps+1, numSelections)
 
 		r.NoError(entriesByTable.Range(func(_ ident.Table, seen []types.Mutation) error {
 			if a.Len(seen, len(expectedMutOrder)) {
@@ -269,6 +416,9 @@ func TestUnstage(t *testing.T) {
 			}
 			return nil
 		}))
+
+		// Ensure a re-read returns no data.
+		checkEmpty(a, tx, q)
 	})
 
 	// Read the middle two tranches of updates.
@@ -288,17 +438,7 @@ func TestUnstage(t *testing.T) {
 		r.NoError(err)
 		defer func() { _ = tx.Rollback(ctx) }()
 
-		entriesByTable := &ident.TableMap[[]types.Mutation]{}
-		numSelections := 0
-		for selecting := true; selecting; {
-			q, selecting, err = fixture.Stagers.Unstage(ctx, tx, q,
-				func(ctx context.Context, tbl ident.Table, mut types.Mutation) error {
-					entriesByTable.Put(tbl, append(entriesByTable.GetZero(tbl), mut))
-					return nil
-				})
-			r.NoError(err)
-			numSelections++
-		}
+		entriesByTable, numSelections := unstage(r, tx, q)
 		// We expect to see one large batch, a timestamp for each entry,
 		// and the final zero-results call.
 		a.Equal(1+entries+1, numSelections)
@@ -308,6 +448,9 @@ func TestUnstage(t *testing.T) {
 			}
 			return nil
 		}))
+
+		// Ensure a re-read returns no data.
+		checkEmpty(a, tx, q)
 	})
 
 	// Read from the staging tables using the limit, to simulate
@@ -328,17 +471,7 @@ func TestUnstage(t *testing.T) {
 		r.NoError(err)
 		defer func() { _ = tx.Rollback(ctx) }()
 
-		entriesByTable := &ident.TableMap[[]types.Mutation]{}
-		numSelections := 0
-		for selecting := true; selecting; {
-			q, selecting, err = fixture.Stagers.Unstage(ctx, tx, q,
-				func(ctx context.Context, tbl ident.Table, mut types.Mutation) error {
-					entriesByTable.Put(tbl, append(entriesByTable.GetZero(tbl), mut))
-					return nil
-				})
-			r.NoError(err)
-			numSelections++
-		}
+		entriesByTable, numSelections := unstage(r, tx, q)
 		a.Equal(211, numSelections)
 		r.NoError(entriesByTable.Range(func(_ ident.Table, seen []types.Mutation) error {
 			if a.Len(seen, len(expectedMutOrder)) {
@@ -346,6 +479,98 @@ func TestUnstage(t *testing.T) {
 			}
 			return nil
 		}))
+
+		// Ensure a re-read returns no data.
+		checkEmpty(a, tx, q)
+	})
+
+	// Ensure that having a lease on a staged row prevents it from being
+	// read again.
+	t.Run("lease", func(t *testing.T) {
+		a := assert.New(t)
+		r := require.New(t)
+
+		q := &types.UnstageCursor{
+			EndBefore:      hlc.New(100*entries, 0), // Past any existing time.
+			Targets:        tables,
+			LeaseExpiry:    time.Now().Add(time.Hour),
+			TimestampLimit: 99,
+		}
+
+		// Run the select in a discarded transaction to avoid
+		// contaminating future tests with side effects.
+		tx, err := fixture.StagingPool.BeginTx(ctx, pgx.TxOptions{})
+		r.NoError(err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		entriesByTable, numSelections := unstage(r, tx, q)
+
+		// +1 each for non-divisible timestamp limit and the final, no-data callback.
+		a.Equal(distinctTimestamps/q.TimestampLimit+2, numSelections)
+		r.NoError(entriesByTable.Range(func(_ ident.Table, seen []types.Mutation) error {
+			if a.Len(seen, len(expectedMutOrder)) {
+				a.Equal(expectedMutOrder, seen)
+			}
+			return nil
+		}))
+
+		// Ensure that a re-read returns no data.
+		checkEmpty(a, tx, q)
+
+		// Peek at the table structure directly to ensure that we set
+		// the lease column, but not the applied column.
+		for _, table := range tables {
+			var ct int
+			q := fmt.Sprintf(
+				`SELECT count(*) FROM %s WHERE NOT applied AND lease IS NOT NULL`,
+				stagingTables.GetZero(table))
+			r.NoError(tx.QueryRow(ctx, q).Scan(&ct))
+			a.Equal(len(muts), ct, q)
+		}
+
+		// Sanity check the case where we deferred a mutation at
+		// timestamp T, but where we might also have a staged mutation
+		// at T+1. The presence of a lease at timestamp T should prevent
+		// the update at T+1 from being returned. We'll manipulate the
+		// table directly to set this case up.
+		for _, table := range tables {
+			q := fmt.Sprintf(`UPDATE %s SET lease = NULL WHERE nanos > 1`, stagingTables.GetZero(table))
+			tag, err := tx.Exec(ctx, q)
+			r.NoError(err)
+			a.Equal(int64(3*entries), tag.RowsAffected())
+		}
+		checkEmpty(a, tx, q)
+
+		// Verify that setting the applied column on those T=1 mutations
+		// will make the remainder visible.
+		for _, table := range tables {
+			q := fmt.Sprintf(`UPDATE %s SET applied=TRUE, lease=NULL WHERE nanos = 1`, stagingTables.GetZero(table))
+			tag, err := tx.Exec(ctx, q)
+			r.NoError(err)
+			a.Equal(int64(entries), tag.RowsAffected())
+		}
+		checkCount(a, tx, q, 3*entries*tableCount)
+
+		// Mark all mutations as having been applied.
+		r.NoError(entriesByTable.Range(func(tbl ident.Table, muts []types.Mutation) error {
+			stage, err := fixture.Stagers.Get(ctx, tbl)
+			r.NoError(err)
+			return stage.MarkApplied(ctx, tx, muts)
+
+		}))
+		// Peek at the table structure directly to ensure that we
+		// cleared and set the applied column.
+		for _, table := range tables {
+			var ct int
+			q := fmt.Sprintf(
+				`SELECT count(*) FROM %s WHERE applied AND lease IS NULL`,
+				stagingTables.GetZero(table))
+			r.NoError(tx.QueryRow(ctx, q).Scan(&ct))
+			a.Equal(len(muts), ct, q)
+		}
+
+		// Ensure that a re-read returns no data.
+		checkEmpty(a, tx, q)
 	})
 }
 
@@ -392,7 +617,7 @@ func benchmarkStage(b *testing.B, batchSize int) {
 				batch[i] = mut
 				allBytes.Add(int64(len(mut.Data) + len(mut.Key)))
 			}
-			if err := s.Store(ctx, fixture.StagingPool, batch); err != nil {
+			if err := s.Stage(ctx, fixture.StagingPool, batch); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/internal/staging/stage/templates.go
+++ b/internal/staging/stage/templates.go
@@ -20,6 +20,7 @@ import (
 	"embed"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
@@ -41,8 +42,21 @@ var (
 )
 
 type templateData struct {
-	Cursor        *types.UnstageCursor // Required input.
-	StagingSchema ident.Schema         // Required input.
+	Cursor         *types.UnstageCursor // Required input.
+	IgnoreLeases   bool                 // Don't block leased keys.
+	SetApplied     bool                 // Set the applied column to true.
+	SetLeaseExpiry time.Time            // Set the lease column to this value.
+	StagingSchema  ident.Schema         // Required input.
+}
+
+func newTemplateData(cursor *types.UnstageCursor, stagingSchema ident.Schema) *templateData {
+	return &templateData{
+		Cursor:         cursor,
+		IgnoreLeases:   cursor.IgnoreLeases,
+		SetApplied:     cursor.LeaseExpiry.IsZero(),
+		SetLeaseExpiry: cursor.LeaseExpiry,
+		StagingSchema:  stagingSchema,
+	}
 }
 
 func (d *templateData) Eval() (string, error) {

--- a/internal/staging/stage/testdata/lease.sql
+++ b/internal/staging/stage/testdata/lease.sql
@@ -69,7 +69,7 @@ GROUP BY key
 ),
 data_0 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
-SET applied=true, lease=NULL
+SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[1])
@@ -78,7 +78,7 @@ AND key NOT IN (SELECT key FROM blocked_0)
 RETURNING nanos, logical, key, mut, before),
 data_1 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
-SET applied=true, lease=NULL
+SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[2])
@@ -87,7 +87,7 @@ AND key NOT IN (SELECT key FROM blocked_1)
 RETURNING nanos, logical, key, mut, before),
 data_2 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
-SET applied=true, lease=NULL
+SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[3])
@@ -96,7 +96,7 @@ AND key NOT IN (SELECT key FROM blocked_2)
 RETURNING nanos, logical, key, mut, before),
 data_3 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
-SET applied=true, lease=NULL
+SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[4])

--- a/internal/staging/stage/testdata/unstage_limit.sql
+++ b/internal/staging/stage/testdata/unstage_limit.sql
@@ -43,43 +43,71 @@ SELECT n, l FROM hlc_1 UNION ALL
 SELECT n, l FROM hlc_2 UNION ALL
 SELECT n, l FROM hlc_3),
 hlc_min AS (SELECT n, l FROM hlc_all GROUP BY n, l ORDER BY n, l LIMIT 22),
+blocked_0 AS (
+SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl0"
+JOIN hlc_min ON (nanos,logical) = (n,l)
+WHERE (lease IS NOT NULL AND lease > now())
+GROUP BY key
+),
+blocked_1 AS (
+SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl1"
+JOIN hlc_min ON (nanos,logical) = (n,l)
+WHERE (lease IS NOT NULL AND lease > now())
+GROUP BY key
+),
+blocked_2 AS (
+SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl2"
+JOIN hlc_min ON (nanos,logical) = (n,l)
+WHERE (lease IS NOT NULL AND lease > now())
+GROUP BY key
+),
+blocked_3 AS (
+SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl3"
+JOIN hlc_min ON (nanos,logical) = (n,l)
+WHERE (lease IS NOT NULL AND lease > now())
+GROUP BY key
+),
 data_0 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
-SET applied=true
+SET applied=true, lease=NULL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[1])
 AND NOT applied
+AND key NOT IN (SELECT key FROM blocked_0)
 ORDER BY nanos, logical, key
 LIMIT 10000
 RETURNING nanos, logical, key, mut, before),
 data_1 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
-SET applied=true
+SET applied=true, lease=NULL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[2])
 AND NOT applied
+AND key NOT IN (SELECT key FROM blocked_1)
 ORDER BY nanos, logical, key
 LIMIT 10000
 RETURNING nanos, logical, key, mut, before),
 data_2 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
-SET applied=true
+SET applied=true, lease=NULL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[3])
 AND NOT applied
+AND key NOT IN (SELECT key FROM blocked_2)
 ORDER BY nanos, logical, key
 LIMIT 10000
 RETURNING nanos, logical, key, mut, before),
 data_3 AS (
 UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
-SET applied=true
+SET applied=true, lease=NULL
 FROM hlc_min
 WHERE (nanos,logical) = (n, l)
 AND (nanos, logical, key) > ($1, $2, ($5::STRING[])[4])
 AND NOT applied
+AND key NOT IN (SELECT key FROM blocked_3)
 ORDER BY nanos, logical, key
 LIMIT 10000
 RETURNING nanos, logical, key, mut, before)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -154,17 +154,30 @@ func (m Mutation) IsDelete() bool {
 // Stager describes a service which can durably persist some
 // number of Mutations.
 type Stager interface {
+	// MarkApplied will mark the given mutations as having been applied.
+	// This is used with lease-based unstaging or when certain mutation
+	// should be skipped.
+	MarkApplied(ctx context.Context, db StagingQuerier, muts []Mutation) error
+
 	// Retire will delete staged mutations whose timestamp is less than
 	// or equal to the given end time. Note that this call may take an
 	// arbitrarily long amount of time to complete and its effects may
 	// not occur within a single database transaction.
 	Retire(ctx context.Context, db StagingQuerier, end hlc.Time) error
 
-	// Store implementations should be idempotent.
-	Store(ctx context.Context, db StagingQuerier, muts []Mutation) error
+	// Stage writes the mutations into the staging table. This method is
+	// idempotent.
+	Stage(ctx context.Context, db StagingQuerier, muts []Mutation) error
+
+	// StageIfExists will stage a mutation only if there is already a
+	// mutation staged for its key. It returns a filtered copy of the
+	// mutations that were not staged. This method is used to implement
+	// the non-transactional mode, where we try to apply a mutation to
+	// some key if there isn't already a mutation queued for that key.
+	StageIfExists(ctx context.Context, db StagingQuerier, muts []Mutation) ([]Mutation, error)
 }
 
-// UnstageCallback is provided to Stagers.SelectMany to receive the
+// UnstageCallback is provided to [Stagers.Unstage] to receive the
 // incoming data.
 type UnstageCallback func(ctx context.Context, tbl ident.Table, mut Mutation) error
 
@@ -172,13 +185,24 @@ type UnstageCallback func(ctx context.Context, tbl ident.Table, mut Mutation) er
 // will be updated by the method, allowing callers to call Unstage
 // in a loop until it returns false.
 type UnstageCursor struct {
+	// If true, un-applied mutations with an active lease will be
+	// returned. This is intended for final cleanups and testing.
+	IgnoreLeases bool
+
+	// If non-zero, the retrieved mutations will be marked with a
+	// lease-expiration time, rather than being marked as applied.
+	// Callers making use of lease expirations must make a subsequent
+	// call to [Stagers.MarkApplied] to prevent the mutation from
+	// being applied later.
+	LeaseExpiry time.Time
+
 	// A half-open interval: [ StartAt, EndBefore )
 	StartAt, EndBefore hlc.Time
 
 	// StartAfterKey is used when processing very large batches that
 	// occur within a single timestamp, to provide an additional offset
 	// for skipping already-processed rows. The implementation of
-	// [Stagers.SelectMany] will automatically populate this field.
+	// [Stagers.Unstage] will automatically populate this field.
 	StartAfterKey ident.TableMap[json.RawMessage]
 
 	// Targets defines the order in which data for the selected tables
@@ -199,8 +223,10 @@ type UnstageCursor struct {
 // Copy returns a copy of the cursor so that it may be updated.
 func (c *UnstageCursor) Copy() *UnstageCursor {
 	cpy := &UnstageCursor{
-		StartAt:        c.StartAt,
 		EndBefore:      c.EndBefore,
+		StartAt:        c.StartAt,
+		IgnoreLeases:   c.IgnoreLeases,
+		LeaseExpiry:    c.LeaseExpiry,
 		Targets:        make([]ident.Table, len(c.Targets)),
 		TimestampLimit: c.TimestampLimit,
 		UpdateLimit:    c.UpdateLimit,


### PR DESCRIPTION
This change adds a new API to the stage package that allows mutations to be staged only if an unapplied mutation already exists for a row. This change also allows leases to be taken out on individual rows, to support the best-effort sequencer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/680)
<!-- Reviewable:end -->
