### PR TITLE
bypass: Advance table progress

### DIFF
--- a/internal/sequencer/bypass/bypass.go
+++ b/internal/sequencer/bypass/bypass.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/notify"
 	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopvar"
 )
 
 // Bypass is a trivial implementation of [sequencer.Sequencer] that
@@ -33,12 +34,35 @@ type Bypass struct{}
 
 var _ sequencer.Sequencer = (*Bypass)(nil)
 
-// Start implements [sequencer.Sequencer]. The emitted stat will be a
-// dummy value.
+// Start implements [sequencer.Sequencer]. The emitted stat will advance
+// all tables in the group to the ends of the resolving bounds.
 func (b *Bypass) Start(
-	_ *stopper.Context, opts *sequencer.StartOptions,
+	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
 	ret := &notify.Var[sequencer.Stat]{}
 	ret.Set(sequencer.NewStat(opts.Group, &ident.TableMap[hlc.Time]{}))
+
+	// Set each table's progress to the end of the bounds. This
+	// will allow the checkpointer to clean up resolved timestamps.
+	ctx.Go(func() error {
+		_, err := stopvar.DoWhenChanged(ctx, hlc.Range{}, opts.Bounds,
+			func(ctx *stopper.Context, old, new hlc.Range) error {
+				// Do nothing if the new end point didn't advance.
+				if hlc.Compare(new.Max(), old.Max()) <= 0 {
+					return nil
+				}
+
+				// Show each table in the group as having advanced to
+				// the end of the resolving range.
+				nextProgress := &ident.TableMap[hlc.Time]{}
+				for _, table := range opts.Group.Tables {
+					nextProgress.Put(table, new.Max())
+				}
+				ret.Set(sequencer.NewStat(opts.Group, nextProgress))
+				return nil
+			})
+		return err
+	})
+
 	return opts.Delegate, ret, nil
 }

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -116,9 +116,6 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 	// In async mode, we want to reach into the implementation to
 	// force the marked, resolved timestamp to be operated on.
 	maybeFlush := func(target ident.Schematic, expect hlc.Time) error {
-		if htc.immediate {
-			return nil
-		}
 		cdcTarget, err := h.Targets.getTarget(target.Schema())
 		if err != nil {
 			return err
@@ -314,9 +311,6 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 	// In async mode, we want to reach into the implementation to
 	// force the marked, resolved timestamp to be operated on.
 	maybeFlush := func(target ident.Schematic, expect hlc.Time) error {
-		if cfg.immediate {
-			return nil
-		}
 		cdcTarget, err := h.Targets.getTarget(target.Schema())
 		if err != nil {
 			return err


### PR DESCRIPTION
This change makes the bypass sequencer set the table progress to the end of the resolving range. This ensures that the checkpoint manager will be able to clean up old resolved timestamps that have accumulated. We know that we won't see a resolved timestamp message from a changefeed unless all previous payloads have processed. Thus, the table progress exactly matches the changefeed's cursor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/694)
<!-- Reviewable:end -->
