### PR TITLE
userscript: allow users to remove mutations in dispatch.

### DIFF
--- a/internal/sequencer/script/acceptor.go
+++ b/internal/sequencer/script/acceptor.go
@@ -99,7 +99,11 @@ func (a *acceptor) doDispatch(
 			return err
 		}
 	}
-
+	// Calls to source.Dispatch may remove mutations.
+	// If the replacement batch is empty, we are done.
+	if nextBatch.Count() == 0 {
+		return nil
+	}
 	// Drop the source so that we'll always call doMap.
 	cpy := *a
 	cpy.justMap = true

--- a/internal/types/acceptors.go
+++ b/internal/types/acceptors.go
@@ -103,6 +103,9 @@ func (t *orderedAdapter) AcceptTemporalBatch(
 func (t *orderedAdapter) AcceptMultiBatch(
 	ctx context.Context, batch *MultiBatch, options *AcceptOptions,
 ) error {
+	if batch.Count() == 0 {
+		return nil
+	}
 	// Coalesce all data by destination table.
 	var commonSchema ident.Schema
 	var mutsByTable ident.TableMap[[]Mutation]

--- a/internal/types/acceptors_test.go
+++ b/internal/types/acceptors_test.go
@@ -62,6 +62,9 @@ func TestOrderedAcceptor(t *testing.T) {
 
 	rec := &recorder.Recorder{}
 	acc := types.OrderedAcceptorFrom(rec, &fakeWatchers{schemaData})
+	// We check that an empty batch works
+	r.NoError(acc.AcceptMultiBatch(ctx, &types.MultiBatch{}, &types.AcceptOptions{}))
+	// We check that the batch created before works
 	r.NoError(acc.AcceptMultiBatch(ctx, batch, &types.AcceptOptions{}))
 
 	// We expect to see exactly one call per table and the table order
@@ -95,7 +98,10 @@ type fakeWatchers struct {
 	data *types.SchemaData
 }
 
-func (w *fakeWatchers) Get(ident.Schema) (types.Watcher, error) {
+func (w *fakeWatchers) Get(sch ident.Schema) (types.Watcher, error) {
+	if sch.Empty() {
+		return nil, errors.New("empty schema")
+	}
 	return &fakeWatcher{w.data}, nil
 }
 


### PR DESCRIPTION
Previously dispatch would fail if the user provided script removed mutations. This change adds defensive check to the orderedAdapter to allow empty batches to be accepted by an Acceptor.
It also adds a check in the script.doDispatch to avoid additional processing if the results of a dispatch is empty.

Fixes #700.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/701)
<!-- Reviewable:end -->
