### PR TITLE
checkpoint: Accept duplicate checkpoint timestamps

### DIFF
--- a/internal/staging/checkpoint/checkpoint_test.go
+++ b/internal/staging/checkpoint/checkpoint_test.go
@@ -60,6 +60,10 @@ func TestResolved(t *testing.T) {
 		r := require.New(t)
 		for i := minNanos; i <= maxNanos; i++ {
 			r.NoError(g1.Advance(ctx, hlc.New(i, 0)))
+
+			// Accept cases where a duplicate message is received, as
+			// long as it's the tail.
+			r.NoError(g1.Advance(ctx, hlc.New(i, 0)))
 		}
 
 		// Fast refresh of other group.


### PR DESCRIPTION
This change allows multiple calls to `Advance()` with the same timestamp, as long as the duplicate value is still the maximum. It appears that CockroachDB changefeeds can re-emit duplicate resolved timestamps when catching up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/703)
<!-- Reviewable:end -->
