### PR TITLE
besteffort: Improve progress reporting in best-effort mode

### DIFF
--- a/internal/sequencer/besteffort/besteffort_test.go
+++ b/internal/sequencer/besteffort/besteffort_test.go
@@ -68,7 +68,7 @@ CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %s(parent)
 
 	bestEffort := seqFixture.BestEffort
 	// We only want BestEffort to do work when told.
-	bestEffort.DisableProactive()
+	bestEffort.SetTimeSource(hlc.Zero)
 
 	// Sweep the staged mutations into the destination. We expect the
 	// entries for {child:1, parent:1} to be applied. The entries
@@ -315,8 +315,8 @@ CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %s(parent)
 		&sequencer.Config{
 			Parallelism:     8,
 			QuiescentPeriod: 100 * time.Millisecond,
-			TimestampLimit:  sequencer.DefaultTimestampLimit,
-			SweepLimit:      sequencer.DefaultSweepLimit,
+			TimestampLimit:  batches/10 + 1,
+			SweepLimit:      batches/10 + 1,
 		},
 		&script.Config{})
 	r.NoError(err)

--- a/internal/sequencer/besteffort/metrics.go
+++ b/internal/sequencer/besteffort/metrics.go
@@ -44,6 +44,10 @@ var (
 		Name: "best_effort_sweep_active_bool",
 		Help: "non-zero if this instance of cdc-sink is processing the table",
 	}, metrics.TableLabels)
+	sweepAbandonedCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "best_effort_sweep_abandoned_count",
+		Help: "number of sweep attempts that were abandoned early due to too many un-appliable mutations",
+	}, metrics.TableLabels)
 	sweepAttemptedCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "best_effort_sweep_attempt_count",
 		Help: "number of mutations found during cleanup sweep",

--- a/internal/sequencer/besteffort/provider.go
+++ b/internal/sequencer/besteffort/provider.go
@@ -17,8 +17,11 @@
 package besteffort
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/google/wire"
 )
 
@@ -42,6 +45,7 @@ func ProvideBestEffort(
 		stagingPool: stagingPool,
 		stagers:     stagers,
 		targetPool:  targetPool,
+		timeSource:  func() hlc.Time { return hlc.New(time.Now().UnixNano(), 0) },
 		watchers:    watchers,
 	}
 }

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -611,6 +611,13 @@ func testMassBackfillWithForeignKeys(
 		r.NoError(err)
 	}
 
+	// This test, in best-effort mode, hit the CI database instance
+	// pretty hard, leading to test flakes.
+	// TODO: Performance pass over Oracle target code.
+	if fixtures[0].TargetPool.Product == types.ProductOracle {
+		rowCount /= 5
+	}
+
 	loadStart := time.Now()
 	log.Info("starting data load")
 

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cdc-sink/internal/script"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/switcher"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
@@ -38,8 +39,9 @@ import (
 
 type testFixture struct {
 	*all.Fixture
-	Handler *Handler
-	Targets *Targets
+	BestEffort *besteffort.BestEffort
+	Handler    *Handler
+	Targets    *Targets
 }
 
 func newTestFixture(*all.Fixture, *Config) (*testFixture, error) {


### PR DESCRIPTION
This change allows the BestEffort sequencer report to partial progress while
it's working on checkpoint ranges of (potentially) unbounded size. This ensures
that checkpoint entries can be marked as applied during long-running catch-up
situations. Previously, the low-watermark would be updated only after an entire
scan had completed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/709)
<!-- Reviewable:end -->
