### PR TITLE
stage: Rework unstage query to improve performance

### DIFF
--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -106,7 +106,8 @@ api.configureTable("t_2", {
 		&sequencer.Config{
 			Parallelism:     2,
 			QuiescentPeriod: time.Second,
-			SweepLimit:      1000,
+			SweepLimit:      sequencer.DefaultSweepLimit,
+			TimestampLimit:  sequencer.DefaultTimestampLimit,
 		},
 		scriptCfg)
 	r.NoError(err)

--- a/internal/sequencer/serial/serial.go
+++ b/internal/sequencer/serial/serial.go
@@ -152,6 +152,7 @@ func (s *Serial) sweepOnce(
 		IgnoreLeases:   true, // Ignore any markers left by the best-effort sequencer.
 		Targets:        group.Tables,
 		TimestampLimit: s.cfg.TimestampLimit,
+		// Not setting an UpdateLimit since we need to read complete transactions.
 	}
 
 	// Open a staging database transaction to retrieve unstaged mutations.

--- a/internal/sequencer/serial/serial_test.go
+++ b/internal/sequencer/serial/serial_test.go
@@ -44,7 +44,8 @@ func TestSerial(t *testing.T) {
 		&sequencer.Config{
 			Parallelism:     2, // Has no particular effect on serial.
 			QuiescentPeriod: time.Second,
-			SweepLimit:      1000,
+			SweepLimit:      sequencer.DefaultSweepLimit,
+			TimestampLimit:  sequencer.DefaultTimestampLimit,
 		},
 		&script.Config{})
 	r.NoError(err)

--- a/internal/sequencer/shingle/shingle_test.go
+++ b/internal/sequencer/shingle/shingle_test.go
@@ -46,7 +46,8 @@ func TestShingle(t *testing.T) {
 		&sequencer.Config{
 			Parallelism:     2,
 			QuiescentPeriod: time.Second,
-			SweepLimit:      1000,
+			SweepLimit:      sequencer.DefaultSweepLimit,
+			TimestampLimit:  1,
 		},
 		&script.Config{})
 	r.NoError(err)

--- a/internal/sequencer/switcher/switcher_test.go
+++ b/internal/sequencer/switcher/switcher_test.go
@@ -56,8 +56,9 @@ func testSwitcherSmoke(t *testing.T, addChaos bool) {
 
 	cfg := &sequencer.Config{
 		Parallelism:     2,
-		QuiescentPeriod: time.Second,
-		SweepLimit:      1000,
+		QuiescentPeriod: 100 * time.Millisecond,
+		SweepLimit:      sequencer.DefaultSweepLimit,
+		TimestampLimit:  1,
 	}
 	if addChaos {
 		cfg.Chaos = 0.01

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -113,6 +113,7 @@ func (f *Fixture) PeekStaged(
 			IgnoreLeases: true,
 			StartAt:      startAt,
 			Targets:      []ident.Table{tbl},
+			UpdateLimit:  10_000, // Sanity limit to let DB "breathe".
 		}
 		for selecting := true; selecting; {
 			q, selecting, err = f.Stagers.Unstage(ctx, tx, q,

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -584,7 +584,6 @@ func TestConcurrentHandlers(t *testing.T) {
 func testMassBackfillWithForeignKeys(
 	t *testing.T, rowCount, fixtureCount int, fns ...func(*Config),
 ) {
-	t.Parallel()
 	r := require.New(t)
 
 	baseFixture, err := all.NewFixture(t)

--- a/internal/staging/stage/queries/unstage.tmpl
+++ b/internal/staging/stage/queries/unstage.tmpl
@@ -3,83 +3,94 @@
 WITH {{- sp -}}
 
 {{- /*
-Select timestamps with unapplied mutations from the source table.
+Start by identifying candidate rows to update.
 
-We start scanning at some timestamp, but after a starting key, which
-could be a zero-length string.
+The starting points for this query are passed as three arrays ($1, $2,
+$3) which pass the nanos, logical, and start-after key for the given
+staging table.
 
-hlc_0 AS (
-  SELECT nanos, logical FROM staging_table
-  WHERE (nanos, logical, key) > (start_at_nanos, start_at_logical, start_after_key)
-  AND (nanos, locical) < (end_before_nanos, end_before_logical)
-  AND NOT applied
-  GROUP BY nanos, logical -- We want multi-column distinct behavior
-  ORDER BY nanos, logical
+When the caller provides a limit for the total number of rows requested,
+we'll set a scan limit here. In all cases, we'le going to SELECT FOR
+UPDATE to give the UPDATE clause at the bottom of the query clear access
+to updated the applied column.
+
+candidates_N AS (
+SELECT nanos, logical, key, lease
+FROM staging_table
+WHERE (nanos, logical, key) > ( .... )
+AND (nanos, logical) < ($3, $4)
+AND NOT applied
+[
+  ORDER BY nanos, logical, key
   LIMIT N
+]
+FOR UPDATE
 )
 
 */ -}}
 {{- range  $idx, $tgt := .Cursor.Targets -}}
 {{- $arrIdx := add $idx 1 -}}
 {{- if $idx -}}, {{- nl -}}{{- end -}}
-hlc_{{ $idx }} (n, l) AS (
-SELECT nanos, logical
+candidates_{{ $idx }} AS (
+SELECT nanos, logical, key, lease
 FROM {{ $top.StagingTable $tgt }}
 WHERE (nanos, logical, key) > (($1::INT8[])[ {{- $arrIdx -}} ], ($2::INT8[])[ {{- $arrIdx -}} ], ($5::STRING[])[ {{- $arrIdx -}} ])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT {{ or $top.Cursor.TimestampLimit 1 }}
+{{- if $top.Cursor.UpdateLimit -}} {{- nl -}}
+ORDER BY nanos, logical, key
+LIMIT {{ $top.Cursor.UpdateLimit }}
+{{- end -}}{{- nl -}}
+FOR UPDATE
 )
 {{- end -}}
 
 {{- /*
-Select the earliest timestamps across all source tables.
+Pick the N earliest distinct timestamps.
 
 hlc_all AS (
-SELECT n, l FROM (
-  SELECT n, l FROM hlc_0 UNION ALL
-  SELECT n, l FROM hlc_1 UNION ALL ...
-  SELECT n, l FROM hlc_N
+SELECT nanos, logical FROM (
+  SELECT nanos, logical FROM candidates_0 UNION ALL
+  SELECT nanos, logical FROM candidates_1 UNION ALL
+  ...
+  SELECT nanos, logical FROM candidates_N UNION ALL
 )
 GROUP BY n, l
 ORDER BY n, l
-LIMIT N
-),
+LIMIT N -- Set to 1 if TimestampLimit is 0.
+)
 
 */ -}}
 , {{- nl -}}
 hlc_all AS (
-SELECT n, l FROM (
+SELECT nanos, logical FROM (
 {{- range $idx, $tgt := .Cursor.Targets -}}
 {{- if $idx }} UNION ALL {{- nl -}}{{- end -}}
-SELECT n, l FROM hlc_{{ $idx }}
+SELECT nanos, logical FROM candidates_{{ $idx }}
 {{- end -}}
 )
-GROUP BY n, l
-ORDER BY n, l
+GROUP BY nanos, logical
+ORDER BY nanos, logical
 LIMIT {{ or $top.Cursor.TimestampLimit 1 }}
 )
 
 {{- /*
-Identify keys that should be blocked due to active leases. This prevents
-a key from rolling backwards if an update at an earlier time, T+0, is
-deferred and a subsequent update to that key could be applied at a later
-time, T+1.
+Optionally identify distinct keys within the candidates with an active
+lease that should be ignored. This ensures that if a key at T1 has a
+lease, then that key at T2 should not be returned.
 
-blocked_0 AS (
-  SELECT key FROM staging_table
-  JOIN hlc_all ON (nanos, logical) = (n, l)
-  WHERE (lease IS NOT NULL AND lease > now())
+blocked_N AS (
+SELECT key FROM candidates_N
+WHERE (lease IS NOT NULL AND lease > now())
+GROUP BY key
 )
+
 */ -}}
 {{- if not $.IgnoreLeases -}}
 {{- range $idx, $tgt := .Cursor.Targets -}}
 , {{- nl -}}
 blocked_{{ $idx }} AS (
-SELECT key FROM {{ $top.StagingTable $tgt }}
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_{{ $idx }}
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 )
@@ -87,45 +98,67 @@ GROUP BY key
 {{- end -}}
 
 {{- /*
-Set the applied column and return the data.
+Thin the candidate rows using the target timestamp(s) and blocked key(s).
+
+target_N AS (
+SELECT * FROM candidates_N c
+JOIN hlc_all USING (nanos, logical)
+[ WHERE NOT EXISTS (SELECT 1 FROM blocked_N b WHERE b.key = c.key ]
+)
+
+*/ -}}
+{{- range  $idx, $tgt := .Cursor.Targets -}}
+, {{- nl -}}
+target_{{ $idx }} AS (
+SELECT * FROM candidates_{{ $idx }} c
+JOIN hlc_all USING (nanos, logical)
+{{- if not $.IgnoreLeases -}}{{- nl -}}
+WHERE NOT EXISTS (SELECT 1 FROM blocked_{{ $idx }} b WHERE b.key = c.key)
+{{- end -}}
+)
+{{- end -}}
+
+{{- /*
+Set the applied or lease column and return the data.
 
 We want to update any non-applied mutations after the starting key
 and within the HLC timestamp(s) that we're operating on.
 
-data_0 AS (
-  UPDATE staging_table SET [ (applied=true, lease=NULL) | lease=deadline ]
-  FROM hlc_all
-  WHERE (nanos, logical) IN (hlc_all)
-    AND (nanos, logical, key) > (start_at_nanos, start_at_logical, start_after_key)
-    AND NOT applied
-    [ AND key NOT IN (SELECT key FROM blocked_0) ]
-  [ ORDER BY nanos, logical, key
-    LIMIT n ]
-  RETURNING nanos, logical, key, mut, before
+data_N AS (
+UPDATE staging_table s
+[
+  SET applied=true, lease=NULL
+|
+  SET lease=( ... )
+]
+FROM target_N t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+[
+  ORDER BY s.nanos, s.logical, s.key
+  LIMIT N
+]
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
 )
 */ -}}
 {{- range $idx, $tgt := .Cursor.Targets -}}
 {{- $arrIdx := add $idx 1 -}}
 , {{- nl -}}
 data_{{ $idx }} AS (
-UPDATE {{ $top.StagingTable $tgt }} {{- nl -}}
+UPDATE {{ $top.StagingTable $tgt }} s {{- nl -}}
 {{- if $top.SetApplied -}}
 SET applied=true, lease=NULL {{- nl -}}
 {{- else if $top.SetLeaseExpiry -}}
 {{- /* https://www.cockroachlabs.com/docs/stable/timestamp#convert-an-int-microseconds-since-epoch-to-timestamp */ -}}
 SET lease=TIMESTAMP 'epoch' + ({{ $top.SetLeaseExpiry.UnixMilli }}::float / 1000)::INTERVAL {{- nl -}}
 {{- end -}}
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[ {{- $arrIdx -}} ], ($2::INT8[])[ {{- $arrIdx -}} ], ($5::STRING[])[ {{- $arrIdx -}} ])
-AND NOT applied
-{{- if not $top.IgnoreLeases -}}
-{{- nl -}} AND key NOT IN (SELECT key FROM blocked_{{ $idx }})
-{{- end -}}
+FROM target_{{ $idx }} t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
 {{- if $top.Cursor.UpdateLimit -}} {{- nl -}}
-ORDER BY nanos, logical, key
+ORDER BY s.nanos, s.logical, s.key
 LIMIT {{ $top.Cursor.UpdateLimit }}
 {{- end -}}
-{{- nl -}} RETURNING nanos, logical, key, mut, before)
+{{- nl -}} RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+)
 {{- end -}}
 {{- nl -}}
 
@@ -133,9 +166,9 @@ LIMIT {{ $top.Cursor.UpdateLimit }}
 Top-level query aggregates the updates in table order.
 
 SELECT * FROM (
-  SELECT 0 idx, * FROM data_0 UNION ALL
-  SELECT 1 idx, * FROM data_1 UNION ALL ...
-  SELECT N idx, * FROM data_N
+  SELECT 0 idx, ... FROM data_0 UNION ALL
+  SELECT 1 idx, ... FROM data_1 UNION ALL ...
+  SELECT N idx, ... FROM data_N
 )
 ORDER BY nanos, logical, idx, key
 

--- a/internal/staging/stage/testdata/ignore_lease.sql
+++ b/internal/staging/stage/testdata/ignore_lease.sql
@@ -1,80 +1,84 @@
-WITH hlc_0 (n, l) AS (
-SELECT nanos, logical
+WITH candidates_0 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl0"
 WHERE (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_1 (n, l) AS (
-SELECT nanos, logical
+candidates_1 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl1"
 WHERE (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_2 (n, l) AS (
-SELECT nanos, logical
+candidates_2 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl2"
 WHERE (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_3 (n, l) AS (
-SELECT nanos, logical
+candidates_3 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl3"
 WHERE (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
+FOR UPDATE
+),
+hlc_all AS (
+SELECT nanos, logical FROM (SELECT nanos, logical FROM candidates_0 UNION ALL
+SELECT nanos, logical FROM candidates_1 UNION ALL
+SELECT nanos, logical FROM candidates_2 UNION ALL
+SELECT nanos, logical FROM candidates_3)
 GROUP BY nanos, logical
 ORDER BY nanos, logical
 LIMIT 1
 ),
-hlc_all AS (
-SELECT n, l FROM (SELECT n, l FROM hlc_0 UNION ALL
-SELECT n, l FROM hlc_1 UNION ALL
-SELECT n, l FROM hlc_2 UNION ALL
-SELECT n, l FROM hlc_3)
-GROUP BY n, l
-ORDER BY n, l
-LIMIT 1
-),
+target_0 AS (
+SELECT * FROM candidates_0 c
+JOIN hlc_all USING (nanos, logical)),
+target_1 AS (
+SELECT * FROM candidates_1 c
+JOIN hlc_all USING (nanos, logical)),
+target_2 AS (
+SELECT * FROM candidates_2 c
+JOIN hlc_all USING (nanos, logical)),
+target_3 AS (
+SELECT * FROM candidates_3 c
+JOIN hlc_all USING (nanos, logical)),
 data_0 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl0" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
-AND NOT applied
-RETURNING nanos, logical, key, mut, before),
+FROM target_0 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_1 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl1" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
-AND NOT applied
-RETURNING nanos, logical, key, mut, before),
+FROM target_1 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_2 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl2" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
-AND NOT applied
-RETURNING nanos, logical, key, mut, before),
+FROM target_2 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_3 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl3" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
-AND NOT applied
-RETURNING nanos, logical, key, mut, before)
+FROM target_3 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+)
 SELECT * FROM (
 SELECT 0 idx, nanos, logical, key, mut, before FROM data_0 UNION ALL
 SELECT 1 idx, nanos, logical, key, mut, before FROM data_1 UNION ALL

--- a/internal/staging/stage/testdata/lease.sql
+++ b/internal/staging/stage/testdata/lease.sql
@@ -1,108 +1,108 @@
-WITH hlc_0 (n, l) AS (
-SELECT nanos, logical
+WITH candidates_0 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl0"
 WHERE (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_1 (n, l) AS (
-SELECT nanos, logical
+candidates_1 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl1"
 WHERE (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_2 (n, l) AS (
-SELECT nanos, logical
+candidates_2 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl2"
 WHERE (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_3 (n, l) AS (
-SELECT nanos, logical
+candidates_3 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl3"
 WHERE (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
+FOR UPDATE
+),
+hlc_all AS (
+SELECT nanos, logical FROM (SELECT nanos, logical FROM candidates_0 UNION ALL
+SELECT nanos, logical FROM candidates_1 UNION ALL
+SELECT nanos, logical FROM candidates_2 UNION ALL
+SELECT nanos, logical FROM candidates_3)
 GROUP BY nanos, logical
 ORDER BY nanos, logical
 LIMIT 1
 ),
-hlc_all AS (
-SELECT n, l FROM (SELECT n, l FROM hlc_0 UNION ALL
-SELECT n, l FROM hlc_1 UNION ALL
-SELECT n, l FROM hlc_2 UNION ALL
-SELECT n, l FROM hlc_3)
-GROUP BY n, l
-ORDER BY n, l
-LIMIT 1
-),
 blocked_0 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl0"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_0
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_1 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl1"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_1
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_2 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl2"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_2
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_3 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl3"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_3
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
+target_0 AS (
+SELECT * FROM candidates_0 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_0 b WHERE b.key = c.key)),
+target_1 AS (
+SELECT * FROM candidates_1 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_1 b WHERE b.key = c.key)),
+target_2 AS (
+SELECT * FROM candidates_2 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_2 b WHERE b.key = c.key)),
+target_3 AS (
+SELECT * FROM candidates_3 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_3 b WHERE b.key = c.key)),
 data_0 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl0" s
 SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_0)
-RETURNING nanos, logical, key, mut, before),
+FROM target_0 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_1 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl1" s
 SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_1)
-RETURNING nanos, logical, key, mut, before),
+FROM target_1 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_2 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl2" s
 SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_2)
-RETURNING nanos, logical, key, mut, before),
+FROM target_2 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_3 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl3" s
 SET lease=TIMESTAMP 'epoch' + (1707338896000::float / 1000)::INTERVAL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_3)
-RETURNING nanos, logical, key, mut, before)
+FROM target_3 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+)
 SELECT * FROM (
 SELECT 0 idx, nanos, logical, key, mut, before FROM data_0 UNION ALL
 SELECT 1 idx, nanos, logical, key, mut, before FROM data_1 UNION ALL

--- a/internal/staging/stage/testdata/unstage.sql
+++ b/internal/staging/stage/testdata/unstage.sql
@@ -1,108 +1,108 @@
-WITH hlc_0 (n, l) AS (
-SELECT nanos, logical
+WITH candidates_0 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl0"
 WHERE (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_1 (n, l) AS (
-SELECT nanos, logical
+candidates_1 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl1"
 WHERE (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_2 (n, l) AS (
-SELECT nanos, logical
+candidates_2 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl2"
 WHERE (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 1
+FOR UPDATE
 ),
-hlc_3 (n, l) AS (
-SELECT nanos, logical
+candidates_3 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl3"
 WHERE (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
+FOR UPDATE
+),
+hlc_all AS (
+SELECT nanos, logical FROM (SELECT nanos, logical FROM candidates_0 UNION ALL
+SELECT nanos, logical FROM candidates_1 UNION ALL
+SELECT nanos, logical FROM candidates_2 UNION ALL
+SELECT nanos, logical FROM candidates_3)
 GROUP BY nanos, logical
 ORDER BY nanos, logical
 LIMIT 1
 ),
-hlc_all AS (
-SELECT n, l FROM (SELECT n, l FROM hlc_0 UNION ALL
-SELECT n, l FROM hlc_1 UNION ALL
-SELECT n, l FROM hlc_2 UNION ALL
-SELECT n, l FROM hlc_3)
-GROUP BY n, l
-ORDER BY n, l
-LIMIT 1
-),
 blocked_0 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl0"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_0
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_1 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl1"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_1
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_2 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl2"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_2
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_3 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl3"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_3
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
+target_0 AS (
+SELECT * FROM candidates_0 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_0 b WHERE b.key = c.key)),
+target_1 AS (
+SELECT * FROM candidates_1 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_1 b WHERE b.key = c.key)),
+target_2 AS (
+SELECT * FROM candidates_2 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_2 b WHERE b.key = c.key)),
+target_3 AS (
+SELECT * FROM candidates_3 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_3 b WHERE b.key = c.key)),
 data_0 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl0" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_0)
-RETURNING nanos, logical, key, mut, before),
+FROM target_0 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_1 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl1" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_1)
-RETURNING nanos, logical, key, mut, before),
+FROM target_1 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_2 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl2" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_2)
-RETURNING nanos, logical, key, mut, before),
+FROM target_2 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_3 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl3" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_3)
-RETURNING nanos, logical, key, mut, before)
+FROM target_3 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+)
 SELECT * FROM (
 SELECT 0 idx, nanos, logical, key, mut, before FROM data_0 UNION ALL
 SELECT 1 idx, nanos, logical, key, mut, before FROM data_1 UNION ALL

--- a/internal/staging/stage/testdata/unstage_limit.sql
+++ b/internal/staging/stage/testdata/unstage_limit.sql
@@ -1,116 +1,124 @@
-WITH hlc_0 (n, l) AS (
-SELECT nanos, logical
+WITH candidates_0 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl0"
 WHERE (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 22
+ORDER BY nanos, logical, key
+LIMIT 10000
+FOR UPDATE
 ),
-hlc_1 (n, l) AS (
-SELECT nanos, logical
+candidates_1 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl1"
 WHERE (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 22
+ORDER BY nanos, logical, key
+LIMIT 10000
+FOR UPDATE
 ),
-hlc_2 (n, l) AS (
-SELECT nanos, logical
+candidates_2 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl2"
 WHERE (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
-GROUP BY nanos, logical
-ORDER BY nanos, logical
-LIMIT 22
+ORDER BY nanos, logical, key
+LIMIT 10000
+FOR UPDATE
 ),
-hlc_3 (n, l) AS (
-SELECT nanos, logical
+candidates_3 AS (
+SELECT nanos, logical, key, lease
 FROM "_cdc_sink"."public"."my_db_public_tbl3"
 WHERE (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
 AND (nanos, logical) < ($3, $4)
 AND NOT applied
+ORDER BY nanos, logical, key
+LIMIT 10000
+FOR UPDATE
+),
+hlc_all AS (
+SELECT nanos, logical FROM (SELECT nanos, logical FROM candidates_0 UNION ALL
+SELECT nanos, logical FROM candidates_1 UNION ALL
+SELECT nanos, logical FROM candidates_2 UNION ALL
+SELECT nanos, logical FROM candidates_3)
 GROUP BY nanos, logical
 ORDER BY nanos, logical
 LIMIT 22
 ),
-hlc_all AS (
-SELECT n, l FROM (SELECT n, l FROM hlc_0 UNION ALL
-SELECT n, l FROM hlc_1 UNION ALL
-SELECT n, l FROM hlc_2 UNION ALL
-SELECT n, l FROM hlc_3)
-GROUP BY n, l
-ORDER BY n, l
-LIMIT 22
-),
 blocked_0 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl0"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_0
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_1 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl1"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_1
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_2 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl2"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_2
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
 blocked_3 AS (
-SELECT key FROM "_cdc_sink"."public"."my_db_public_tbl3"
-JOIN hlc_all ON (nanos,logical) = (n,l)
+SELECT key FROM candidates_3
 WHERE (lease IS NOT NULL AND lease > now())
 GROUP BY key
 ),
+target_0 AS (
+SELECT * FROM candidates_0 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_0 b WHERE b.key = c.key)),
+target_1 AS (
+SELECT * FROM candidates_1 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_1 b WHERE b.key = c.key)),
+target_2 AS (
+SELECT * FROM candidates_2 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_2 b WHERE b.key = c.key)),
+target_3 AS (
+SELECT * FROM candidates_3 c
+JOIN hlc_all USING (nanos, logical)
+WHERE NOT EXISTS (SELECT 1 FROM blocked_3 b WHERE b.key = c.key)),
 data_0 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl0"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl0" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[1], ($2::INT8[])[1], ($5::STRING[])[1])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_0)
-ORDER BY nanos, logical, key
+FROM target_0 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+ORDER BY s.nanos, s.logical, s.key
 LIMIT 10000
-RETURNING nanos, logical, key, mut, before),
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_1 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl1"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl1" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[2], ($2::INT8[])[2], ($5::STRING[])[2])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_1)
-ORDER BY nanos, logical, key
+FROM target_1 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+ORDER BY s.nanos, s.logical, s.key
 LIMIT 10000
-RETURNING nanos, logical, key, mut, before),
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_2 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl2"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl2" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[3], ($2::INT8[])[3], ($5::STRING[])[3])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_2)
-ORDER BY nanos, logical, key
+FROM target_2 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+ORDER BY s.nanos, s.logical, s.key
 LIMIT 10000
-RETURNING nanos, logical, key, mut, before),
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+),
 data_3 AS (
-UPDATE "_cdc_sink"."public"."my_db_public_tbl3"
+UPDATE "_cdc_sink"."public"."my_db_public_tbl3" s
 SET applied=true, lease=NULL
-WHERE (nanos,logical) IN (SELECT n, l FROM hlc_all)
-AND (nanos, logical, key) > (($1::INT8[])[4], ($2::INT8[])[4], ($5::STRING[])[4])
-AND NOT applied
-AND key NOT IN (SELECT key FROM blocked_3)
-ORDER BY nanos, logical, key
+FROM target_3 t
+WHERE (s.nanos, s.logical, s.key) = (t.nanos, t.logical, t.key)
+ORDER BY s.nanos, s.logical, s.key
 LIMIT 10000
-RETURNING nanos, logical, key, mut, before)
+RETURNING s.nanos, s.logical, s.key, s.mut, s.before
+)
 SELECT * FROM (
 SELECT 0 idx, nanos, logical, key, mut, before FROM data_0 UNION ALL
 SELECT 1 idx, nanos, logical, key, mut, before FROM data_1 UNION ALL

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -26,6 +26,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
@@ -208,6 +209,17 @@ type UnstageCursor struct {
 	// multiplied by the number of tables listed in Targets. This will
 	// return all rows within the selected timestamp(s) if unset.
 	UpdateLimit int
+}
+
+// String is for debugging use only.
+func (c *UnstageCursor) String() string {
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", " ")
+	if err := enc.Encode(c); err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return buf.String()
 }
 
 // UnstageOffset is used within an [UnstageCursor] to provide


### PR DESCRIPTION
This change improves the performance of the unstage query when running against large amounts of staged data. Previously, we tried to identify the candidate timestamps to operate on and then the staged rows to update. In this new query, we identify candidate rows that might be updated by the query and then filter with the first N timestamps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/714)
<!-- Reviewable:end -->
