### PR TITLE
cdc: Decouple from HTTP request context

### DIFF
--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -495,12 +495,14 @@ func TestRejectedAuth(t *testing.T) {
 	// Verify that auth checks don't require other services.
 	h := &Handler{
 		Authenticator: reject.New(),
+		Config:        &Config{},
 		TargetPool: &types.TargetPool{
 			PoolInfo: types.PoolInfo{
 				Product: types.ProductCockroachDB,
 			},
 		},
 	}
+	require.NoError(t, h.Config.Preflight())
 
 	tcs := []struct {
 		path string


### PR DESCRIPTION
This change avoids using the HTTP request context and instead uses a context with a configurable timeout. This will help to insulate cdc-sink from HTTP requests that are abandonded by the client (or which have a network blip). It is likely the case that the client will re-deliver the payload, but cdc-sink is already prepared to deal with the at-least-once behavior of CDC changefeeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/715)
<!-- Reviewable:end -->
