### PR TITLE
script: Enable user-defined apply functions to work in immediate mode

### DIFF
--- a/internal/sequencer/script/provider.go
+++ b/internal/sequencer/script/provider.go
@@ -26,9 +26,12 @@ import (
 var Set = wire.NewSet(ProvideSequencer)
 
 // ProvideSequencer is called by Wire.
-func ProvideSequencer(loader *script.Loader, watchers types.Watchers) *Sequencer {
+func ProvideSequencer(
+	loader *script.Loader, targetPool *types.TargetPool, watchers types.Watchers,
+) *Sequencer {
 	return &Sequencer{
-		loader:   loader,
-		watchers: watchers,
+		loader:     loader,
+		targetPool: targetPool,
+		watchers:   watchers,
 	}
 }

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -44,7 +44,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 	if err != nil {
 		return nil, err
 	}
-	scriptSequencer := script2.ProvideSequencer(loader, watchers)
+	scriptSequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	shingleShingle := shingle.ProvideShingle(config, targetPool)
 	chaosChaos := &chaos.Chaos{
 		Config: config,

--- a/internal/sequencer/switcher/switcher.go
+++ b/internal/sequencer/switcher/switcher.go
@@ -47,6 +47,9 @@ const (
 	ModeBypass
 	ModeSerial
 	ModeShingle
+
+	MinMode = Mode(1)     // Used for testing all modes.
+	MaxMode = ModeShingle // Used for testing all modes.
 )
 
 // Switcher switches between delegate sequencers. It also adds script

--- a/internal/source/cdc/server/wire_gen.go
+++ b/internal/source/cdc/server/wire_gen.go
@@ -103,7 +103,7 @@ func NewServer(ctx *stopper.Context, config *Config) (*stdserver.Server, error) 
 	chaosChaos := &chaos.Chaos{
 		Config: sequencerConfig,
 	}
-	sequencer := script2.ProvideSequencer(loader, watchers)
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
 	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
 	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
@@ -194,7 +194,7 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 	if err != nil {
 		return nil, nil, err
 	}
-	sequencer := script2.ProvideSequencer(loader, watchers)
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
 	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
 	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -69,7 +69,7 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	if err != nil {
 		return nil, err
 	}
-	sequencer := script2.ProvideSequencer(loader, watchers)
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
 	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
 	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -74,7 +74,7 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 	if err != nil {
 		return nil, err
 	}
-	sequencer := script2.ProvideSequencer(loader, watchers)
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	mylogicalConn, err := ProvideConn(ctx, acceptor, bypassBypass, chaosChaos, config, memoMemo, sequencer, stagingPool, targetPool, watchers)
 	if err != nil {
 		return nil, err

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -74,7 +74,7 @@ func Start(context *stopper.Context, config *Config) (*PGLogical, error) {
 	if err != nil {
 		return nil, err
 	}
-	sequencer := script2.ProvideSequencer(loader, watchers)
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	conn, err := ProvideConn(context, acceptor, chaosChaos, config, bypassBypass, memoMemo, sequencer, stagingPool, targetPool, watchers)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change allows user-defined apply functions to work in immediate mode by having the script Sequencer shim create and commit a database transaction. The userscript sequencer test is expanded to cover all core sequencer modes to ensure broad compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/716)
<!-- Reviewable:end -->
