### PR TITLE
script: Present database values as reified JSON values

### DIFF
--- a/internal/script/bag_wrapper.go
+++ b/internal/script/bag_wrapper.go
@@ -43,7 +43,12 @@ func (m *bagWrapper) Get(key string) goja.Value {
 	if !ok {
 		return goja.Undefined()
 	}
-	return m.rt.ToValue(v)
+	ret, err := safeValue(m.rt, v)
+	if err != nil {
+		// This will be presented as an exception.
+		panic(m.rt.NewGoError(err))
+	}
+	return ret
 }
 
 // Has implements goja.DynamicObject.

--- a/internal/script/bag_wrapper_test.go
+++ b/internal/script/bag_wrapper_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/merge"
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBagWrapper(t *testing.T) {
+	r := require.New(t)
+	rt := goja.New()
+
+	p := struct {
+		Bar  int
+		Foo  string
+		Time time.Time
+	}{
+		Bar:  1,
+		Foo:  `"1"`,
+		Time: time.UnixMilli(1708731562135).UTC(),
+	}
+
+	wrapper := &bagWrapper{
+		data: merge.NewBagOf(nil, nil, "obj", &p, "simple", 42),
+		rt:   rt,
+	}
+	r.False(wrapper.Has("nope"))
+	r.True(wrapper.Has("obj"))
+
+	keys := wrapper.Keys()
+	r.Len(keys, 2)
+	r.Contains(keys, "obj")
+	r.Contains(keys, "simple")
+
+	obj := wrapper.Get("obj").(*goja.Object)
+	r.Equal(int64(1), obj.Get("Bar").ToInteger())
+	r.Equal(`"1"`, obj.Get("Foo").String())
+
+	simple := wrapper.Get("simple").ToInteger()
+	r.Equal(int64(42), simple)
+
+	ts := obj.Get("Time").String()
+	r.Equal("2024-02-23T23:39:22.135Z", ts)
+	r.Equal("2024-02-23 23:39:22.135 +0000 UTC", p.Time.String())
+
+	wrapper.Delete("obj")
+	r.Equal(goja.Undefined(), wrapper.Get("obj"))
+
+	wrapper.Set("another", rt.ToValue("value"))
+	r.Equal("value", wrapper.Get("another").String())
+}

--- a/internal/script/safe_value.go
+++ b/internal/script/safe_value.go
@@ -1,0 +1,179 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/pkg/errors"
+)
+
+// The maximum safe numeric value in JavaScript.
+const maxInt = 1 << 53
+
+// safeValue returns a JS runtime value that contains the given value
+// as though it had been stringified and then parsed.
+//
+// Numbers will be converted to a string representation to ensure
+// minimum loss of fidelity when round-tripped through the userscript.
+// If the user actually wants to perform math in JavaScript, the Number
+// API is available, or the JS idiom of `+value` can be used.
+//
+// Goja does not, yet, have builtin support for BigInt. If and when this
+// happens, we should revisit this code to emit the numbers as such.
+func safeValue(rt *goja.Runtime, value any) (goja.Value, error) {
+	// This should cover the 80% use case of values returned from a
+	// database query.
+	var buf []byte
+	switch t := value.(type) {
+	case goja.Value:
+		return t, nil
+
+	case nil:
+		return goja.Null(), nil
+
+	case bool, string:
+		return rt.ToValue(t), nil
+
+	case int:
+		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
+	case int8:
+		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
+	case int16:
+		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
+	case int32:
+		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
+	case int64:
+		return rt.ToValue(strconv.FormatInt(t, 10)), nil
+
+	case uint:
+		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
+	case uint8:
+		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
+	case uint16:
+		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
+	case uint32:
+		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
+	case uint64:
+		return rt.ToValue(strconv.FormatUint(t, 10)), nil
+
+	case float32:
+		return rt.ToValue(strconv.FormatFloat(float64(t), 'f', -1, 32)), nil
+	case float64:
+		return rt.ToValue(strconv.FormatFloat(t, 'f', -1, 64)), nil
+
+	case time.Time:
+		// Very common case and we can encode to our desired format.
+		return rt.ToValue(t.UTC().Format(time.RFC3339Nano)), nil
+
+	case json.RawMessage:
+		// Parse raw message as-is.
+		buf = t
+
+	case []byte:
+		// Parse raw message as-is.
+		buf = t
+
+	default:
+		// Marshal other random types.
+		var err error
+		buf, err = json.Marshal(value)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
+	// Use our number-preserving unmarshal function.
+top:
+	switch buf[0] {
+	case 0x20, 0x0D, 0x0A, 0x09:
+		// Whitespace constants per JSON spec.
+		buf = buf[1:]
+		if len(buf) == 0 {
+			return nil, errors.New("only whitespace in input")
+		}
+		goto top
+
+	case '{':
+		m := make(map[string]any)
+		if err := unmarshal(buf, &m); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return rt.ToValue(m), nil
+
+	case '[':
+		var arr []any
+		if err := unmarshal(buf, &arr); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return rt.ToValue(arr), nil
+
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
+		var n json.Number
+		if err := unmarshal(buf, &n); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return rt.ToValue(n.String()), nil
+
+	case 'f':
+		return rt.ToValue(false), nil
+
+	case 't':
+		return rt.ToValue(true), nil
+
+	case 'n':
+		return goja.Null(), nil
+
+	default:
+		// We're going to call the JSON.parse function within the
+		// runtime. This seems to be the least-worst way to re-parse
+		// strings and any quoted characters therein.
+		var ret goja.Value
+		if err := rt.Try(func() {
+			jsonObj := rt.GlobalObject().Get("JSON").(*goja.Object)
+			parse := jsonObj.Get("parse").Export().(func(call goja.FunctionCall) goja.Value)
+			ret = parse(goja.FunctionCall{
+				Arguments: []goja.Value{
+					rt.ToValue(string(buf)),
+				},
+			})
+		}); err != nil {
+			return nil, err
+		}
+		return ret, nil
+	}
+}
+
+// unmarshal should be used instead of [json.Unmarshal] to ensure that
+// numeric types are decoded with minimum loss of precision.
+func unmarshal(data []byte, v any) error {
+	reader := bytes.NewReader(data)
+	dec := json.NewDecoder(reader)
+	dec.UseNumber()
+	err := dec.Decode(v)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if dec.More() {
+		return errors.New("invalid JSON input")
+	}
+	return nil
+}

--- a/internal/script/safe_value_test.go
+++ b/internal/script/safe_value_test.go
@@ -1,0 +1,227 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeValue(t *testing.T) {
+	rt := goja.New()
+	now := time.UnixMilli(1708731562135).UTC()
+
+	tcs := []struct {
+		input      any
+		exportType string
+		err        string
+		jsString   string
+		test       func(a *assert.Assertions, value goja.Value)
+	}{
+		{
+			input:    nil,
+			jsString: "null",
+		},
+		{
+			input:      false,
+			exportType: "bool",
+			jsString:   "false",
+		},
+		{
+			input:      true,
+			exportType: "bool",
+			jsString:   "true",
+		},
+		{
+			input:      "foo",
+			exportType: "string",
+			jsString:   "foo",
+		},
+		{
+			input:      int(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      int8(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      int16(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      int32(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      int64(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      uint(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      uint8(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      uint16(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      uint32(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      uint64(42),
+			exportType: "string",
+			jsString:   "42",
+		},
+		{
+			input:      maxInt + 1,
+			exportType: "string",
+			jsString:   fmt.Sprintf("%d", maxInt+1),
+		},
+		{
+			input:      uint(maxInt + 1),
+			exportType: "string",
+			jsString:   fmt.Sprintf("%d", maxInt+1),
+		},
+		{
+			input:      json.Number("12345"),
+			exportType: "string",
+			jsString:   "12345",
+		},
+		{
+			input:      now,
+			exportType: "string",
+			jsString:   "2024-02-23T23:39:22.135Z",
+			test: func(a *assert.Assertions, _ goja.Value) {
+				a.Equal("2024-02-23 23:39:22.135 +0000 UTC", now.String())
+			},
+		},
+		{
+			input:      []any{now, now},
+			exportType: "[]interface {}",
+			jsString:   "2024-02-23T23:39:22.135Z,2024-02-23T23:39:22.135Z",
+		},
+		{
+			input:      float32(3.141592),
+			exportType: "string",
+			jsString:   "3.141592",
+		},
+		{
+			input:      float64(3.141592),
+			exportType: "string",
+			jsString:   "3.141592",
+		},
+		{
+			input:      json.RawMessage("    3.141592"),
+			exportType: "string",
+			jsString:   "3.141592",
+		},
+		{
+			input:      json.RawMessage("    -3.141592"),
+			exportType: "string",
+			jsString:   "-3.141592",
+		},
+		{
+			input:      json.RawMessage(`  "    3.141592"`),
+			exportType: "string",
+			jsString:   "    3.141592",
+		},
+		{
+			input:    json.RawMessage("null"),
+			jsString: "null",
+		},
+		{
+			input:      json.RawMessage("true"),
+			exportType: "bool",
+			jsString:   "true",
+		},
+		{
+			input:      json.RawMessage("false"),
+			exportType: "bool",
+			jsString:   "false",
+		},
+		{
+			input:      json.RawMessage(`{"BigInt":9007199254740995}`),
+			exportType: "map[string]interface {}",
+			jsString:   "[object Object]",
+			test: func(a *assert.Assertions, value goja.Value) {
+				obj := value.(*goja.Object)
+				a.Equal(`9007199254740995`, obj.Get("BigInt").String())
+			},
+		},
+		{
+			input:      json.RawMessage(`[9007199254740995]`),
+			exportType: "[]interface {}",
+			jsString:   "9007199254740995",
+			test: func(a *assert.Assertions, value goja.Value) {
+				obj := value.(*goja.Object)
+				a.Equal(`9007199254740995`, obj.Get("0").String())
+			},
+		},
+		{
+			input: json.RawMessage(`     `),
+			err:   "only whitespace in input",
+		},
+		{
+			input: json.RawMessage(`-123{456`),
+			err:   "invalid JSON input",
+		},
+		{
+			input:    goja.Undefined(),
+			jsString: "undefined",
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			a := assert.New(t)
+			value, err := safeValue(rt, tc.input)
+			if tc.err != "" {
+				a.ErrorContains(err, tc.err)
+			} else if a.NoError(err) {
+				if tc.exportType == "" {
+					a.Nil(value.ExportType())
+				} else {
+					a.Equal(tc.exportType, value.ExportType().String())
+				}
+				a.Equal(tc.jsString, value.String())
+				if tc.test != nil {
+					tc.test(a, value)
+				}
+			}
+		})
+	}
+}

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -272,7 +272,7 @@ func (s *UserScript) bindDeleteKey(table ident.Table, deleteKey deleteKeyJS) Del
 	return func(ctx context.Context, mut types.Mutation) (types.Mutation, bool, error) {
 		// Unpack key into slice.
 		var key []any
-		if err := json.Unmarshal(mut.Key, &key); err != nil {
+		if err := unmarshal(mut.Key, &key); err != nil {
 			return mut, false, errors.WithStack(err)
 		}
 		meta := mut.Meta
@@ -337,7 +337,7 @@ func (s *UserScript) bindDispatch(fnName string, dispatch dispatchJS) Dispatch {
 	return func(ctx context.Context, mut types.Mutation) (*ident.TableMap[[]types.Mutation], error) {
 		// Unmarshal the mutation's data as a generic map.
 		data := make(map[string]any)
-		if err := json.Unmarshal(mut.Data, &data); err != nil {
+		if err := unmarshal(mut.Data, &data); err != nil {
 			return nil, errors.WithStack(err)
 		}
 
@@ -424,7 +424,7 @@ func (s *UserScript) bindMap(table ident.Table, mapper mapJS) Map {
 	return func(ctx context.Context, mut types.Mutation) (types.Mutation, bool, error) {
 		// Unpack data into generic map.
 		data := make(map[string]any)
-		if err := json.Unmarshal(mut.Data, &data); err != nil {
+		if err := unmarshal(mut.Data, &data); err != nil {
 			return mut, false, errors.WithStack(err)
 		}
 


### PR DESCRIPTION
This change corrects an inconsistency in how values loaded from the target database versus those from incoming changefeed values are presented to the userscript. Previously, types such as time.Time would be presented as a basic string when received from a changefeed, while the values loaded from the database were presented as a proxied time.Time. Large magnitude numbers were also impacted by JavaScript's 53-bit mantissa limitation.

All values presented to the userscript are passed through a utility function which ensures a consistent, JSON-like presentation of the value to the script.

The apply.IsMergeSupported() function is added to improve test readability.

Breaking change: Performing math using basic JavaScript numeric types should not be undertaken lightly, due to potential loss of precision, so numeric values are now always presented as strings, which the user may choose to coerce to a numeric type.

Fixes #664

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/721)
<!-- Reviewable:end -->
