### PR TITLE
Rename bypass sequencer to immediate

### DIFF
--- a/internal/sequencer/immediate/immediate.go
+++ b/internal/sequencer/immediate/immediate.go
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package bypass contains a trivial [sequencer.Sequencer]
+// Package immediate contains a trivial [sequencer.Sequencer]
 // implementation which writes data directly to the configured acceptor.
-package bypass
+package immediate
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
@@ -28,15 +28,15 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/stopvar"
 )
 
-// Bypass is a trivial implementation of [sequencer.Sequencer] that
+// Immediate is a trivial implementation of [sequencer.Sequencer] that
 // writes through to the underlying acceptor.
-type Bypass struct{}
+type Immediate struct{}
 
-var _ sequencer.Sequencer = (*Bypass)(nil)
+var _ sequencer.Sequencer = (*Immediate)(nil)
 
 // Start implements [sequencer.Sequencer]. The emitted stat will advance
 // all tables in the group to the ends of the resolving bounds.
-func (b *Bypass) Start(
+func (i *Immediate) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
 	ret := &notify.Var[sequencer.Stat]{}

--- a/internal/sequencer/immediate/immediate_test.go
+++ b/internal/sequencer/immediate/immediate_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package bypass_test
+package immediate_test
 
 import (
 	"encoding/json"
@@ -34,12 +34,12 @@ import (
 )
 
 // This can be seen as a skeleton for more interesting sequencers.
-func TestBypass(t *testing.T) {
+func TestImmediate(t *testing.T) {
 	r := require.New(t)
 	fixture, err := all.NewFixture(t)
 	r.NoError(err)
 	ctx := fixture.Context
-	fakeTable := ident.NewTable(fixture.TargetSchema.Schema(), ident.New("bypass_table"))
+	fakeTable := ident.NewTable(fixture.TargetSchema.Schema(), ident.New("immediate_table"))
 
 	seqFixture, err := seqtest.NewSequencerFixture(fixture,
 		&sequencer.Config{
@@ -49,14 +49,14 @@ func TestBypass(t *testing.T) {
 		},
 		&script.Config{})
 	r.NoError(err)
-	bypass := seqFixture.Bypass
+	imm := seqFixture.Immediate
 
 	bounds := &notify.Var[hlc.Range]{}
-	acc, stats, err := bypass.Start(ctx, &sequencer.StartOptions{
+	acc, stats, err := imm.Start(ctx, &sequencer.StartOptions{
 		Bounds:   bounds,
 		Delegate: types.OrderedAcceptorFrom(fixture.ApplyAcceptor, fixture.Watchers),
 		Group: &types.TableGroup{
-			Name:   ident.New("bypass_group"),
+			Name:   ident.New("immediate_group"),
 			Tables: []ident.Table{fakeTable},
 		},
 	})

--- a/internal/sequencer/immediate/provider.go
+++ b/internal/sequencer/immediate/provider.go
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package bypass
+package immediate
 
 import "github.com/google/wire"
 
 // Set is used by Wire.
 var Set = wire.NewSet(
-	wire.Struct(new(Bypass)),
+	wire.Struct(new(Immediate)),
 )

--- a/internal/sequencer/seqtest/seqtest.go
+++ b/internal/sequencer/seqtest/seqtest.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
@@ -42,7 +42,7 @@ type Fixture struct {
 	*all.Fixture
 
 	BestEffort *besteffort.BestEffort
-	Bypass     *bypass.Bypass
+	Immediate  *immediate.Immediate
 	Retire     *retire.Retire
 	Serial     *serial.Serial
 	Script     *script.Sequencer
@@ -58,8 +58,8 @@ func (f *Fixture) SequencerFor(
 	switch mode {
 	case switcher.ModeBestEffort:
 		return f.BestEffort, nil
-	case switcher.ModeBypass:
-		return f.Bypass, nil
+	case switcher.ModeImmediate:
+		return f.Immediate, nil
 	case switcher.ModeSerial:
 		return f.Serial, nil
 	case switcher.ModeShingle:

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
@@ -35,7 +35,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 	targetPool := baseFixture.TargetPool
 	watchers := fixture.Watchers
 	bestEffort := besteffort.ProvideBestEffort(config, leases, stagingPool, stagers, targetPool, watchers)
-	bypassBypass := &bypass.Bypass{}
+	immediateImmediate := &immediate.Immediate{}
 	retireRetire := retire.ProvideRetire(config, stagingPool, stagers)
 	serialSerial := serial.ProvideSerial(config, leases, stagers, stagingPool, targetPool)
 	configs := fixture.Configs
@@ -49,11 +49,11 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 	chaosChaos := &chaos.Chaos{
 		Config: config,
 	}
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, scriptSequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, scriptSequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	seqtestFixture := &Fixture{
 		Fixture:    fixture,
 		BestEffort: bestEffort,
-		Bypass:     bypassBypass,
+		Immediate:  immediateImmediate,
 		Retire:     retireRetire,
 		Serial:     serialSerial,
 		Script:     scriptSequencer,

--- a/internal/sequencer/switcher/group.go
+++ b/internal/sequencer/switcher/group.go
@@ -128,8 +128,8 @@ func (g *groupSequencer) switchModeLocked(
 	switch next {
 	case ModeBestEffort:
 		nextSeq = g.bestEffort
-	case ModeBypass:
-		nextSeq = g.bypass
+	case ModeImmediate:
+		nextSeq = g.immediate
 	case ModeSerial:
 		nextSeq = g.serial
 	case ModeShingle:

--- a/internal/sequencer/switcher/mode_string.go
+++ b/internal/sequencer/switcher/mode_string.go
@@ -10,14 +10,15 @@ func _() {
 	var x [1]struct{}
 	_ = x[ModeUnknown-0]
 	_ = x[ModeBestEffort-1]
-	_ = x[ModeBypass-2]
+	_ = x[ModeImmediate-2]
 	_ = x[ModeSerial-3]
 	_ = x[ModeShingle-4]
+	_ = x[MinMode-1]
 }
 
-const _Mode_name = "ModeUnknownModeBestEffortModeBypassModeSerialModeShingle"
+const _Mode_name = "ModeUnknownModeBestEffortModeImmediateModeSerialModeShingle"
 
-var _Mode_index = [...]uint8{0, 11, 25, 35, 45, 56}
+var _Mode_index = [...]uint8{0, 11, 25, 38, 48, 59}
 
 func (i Mode) String() string {
 	if i < 0 || i >= Mode(len(_Mode_index)-1) {

--- a/internal/sequencer/switcher/provider.go
+++ b/internal/sequencer/switcher/provider.go
@@ -18,8 +18,8 @@ package switcher
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/shingle"
@@ -31,7 +31,7 @@ import (
 // Set is used by Wire.
 var Set = wire.NewSet(
 	besteffort.Set,
-	bypass.Set,
+	immediate.Set,
 	chaos.Set,
 	script.Set,
 	serial.Set,
@@ -43,9 +43,9 @@ var Set = wire.NewSet(
 // ProvideSequencer is called by Wire.
 func ProvideSequencer(
 	best *besteffort.BestEffort,
-	bypass *bypass.Bypass,
 	chaos *chaos.Chaos,
 	diags *diag.Diagnostics,
+	imm *immediate.Immediate,
 	script *script.Sequencer,
 	serial *serial.Serial,
 	shingle *shingle.Shingle,
@@ -54,7 +54,7 @@ func ProvideSequencer(
 ) *Switcher {
 	return &Switcher{
 		bestEffort:  best,
-		bypass:      bypass,
+		immediate:   imm,
 		chaos:       chaos,
 		diags:       diags,
 		script:      script,

--- a/internal/sequencer/switcher/switcher.go
+++ b/internal/sequencer/switcher/switcher.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/shingle"
@@ -44,7 +44,7 @@ type Mode int
 const (
 	ModeUnknown Mode = iota
 	ModeBestEffort
-	ModeBypass
+	ModeImmediate
 	ModeSerial
 	ModeShingle
 
@@ -56,9 +56,9 @@ const (
 // bindings into the sequencer stack.
 type Switcher struct {
 	bestEffort  *besteffort.BestEffort
-	bypass      *bypass.Bypass
 	chaos       *chaos.Chaos
 	diags       *diag.Diagnostics
+	immediate   *immediate.Immediate
 	serial      *serial.Serial
 	script      *script.Sequencer
 	shingle     *shingle.Shingle

--- a/internal/source/cdc/server/wire_gen.go
+++ b/internal/source/cdc/server/wire_gen.go
@@ -9,8 +9,8 @@ package server
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
@@ -99,14 +99,14 @@ func NewServer(ctx *stopper.Context, config *Config) (*stdserver.Server, error) 
 		return nil, err
 	}
 	bestEffort := besteffort.ProvideBestEffort(sequencerConfig, typesLeases, stagingPool, stagers, targetPool, watchers)
-	bypassBypass := &bypass.Bypass{}
 	chaosChaos := &chaos.Chaos{
 		Config: sequencerConfig,
 	}
+	immediateImmediate := &immediate.Immediate{}
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
 	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	targets, err := cdc.ProvideTargets(ctx, acceptor, cdcConfig, checkpoints, retireRetire, stagingPool, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err
@@ -185,10 +185,10 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 		return nil, nil, err
 	}
 	bestEffort := besteffort.ProvideBestEffort(sequencerConfig, typesLeases, stagingPool, stagers, targetPool, watchers)
-	bypassBypass := &bypass.Bypass{}
 	chaosChaos := &chaos.Chaos{
 		Config: sequencerConfig,
 	}
+	immediateImmediate := &immediate.Immediate{}
 	scriptConfig := cdc.ProvideScriptConfig(cdcConfig)
 	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
 	if err != nil {
@@ -197,7 +197,7 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
 	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	targets, err := cdc.ProvideTargets(context, acceptor, cdcConfig, checkpoints, retireRetire, stagingPool, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, nil, err

--- a/internal/source/cdc/targets.go
+++ b/internal/source/cdc/targets.go
@@ -187,7 +187,7 @@ func (t *Targets) metrics(info *targetInfo) {
 
 func (t *Targets) modeSelector(info *targetInfo) {
 	if t.cfg.Immediate {
-		info.mode.Set(switcher.ModeBypass)
+		info.mode.Set(switcher.ModeImmediate)
 		return
 	} else if t.cfg.BestEffortOnly {
 		info.mode.Set(switcher.ModeBestEffort)

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -9,8 +9,8 @@ package cdc
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
@@ -60,10 +60,10 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 		return nil, err
 	}
 	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
-	bypassBypass := &bypass.Bypass{}
 	chaosChaos := &chaos.Chaos{
 		Config: sequencerConfig,
 	}
+	immediateImmediate := &immediate.Immediate{}
 	scriptConfig := ProvideScriptConfig(config)
 	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
 	if err != nil {
@@ -72,7 +72,7 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
 	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, bypassBypass, chaosChaos, diagnostics, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	targets, err := ProvideTargets(context, acceptor, config, checkpoints, retireRetire, stagingPool, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err

--- a/internal/source/mylogical/injector.go
+++ b/internal/source/mylogical/injector.go
@@ -23,8 +23,8 @@ import (
 	"context"
 
 	scriptRuntime "github.com/cockroachdb/cdc-sink/internal/script"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	scriptSequencer "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sinkprod"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
@@ -43,7 +43,7 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 		wire.FieldsOf(new(*Config), "Script"),
 		wire.FieldsOf(new(*EagerConfig), "DLQ", "Sequencer", "Staging", "Target"),
 		Set,
-		bypass.Set,
+		immediate.Set,
 		chaos.Set,
 		diag.New,
 		scriptRuntime.Set,

--- a/internal/source/mylogical/provider.go
+++ b/internal/source/mylogical/provider.go
@@ -19,8 +19,8 @@ package mylogical
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	scriptSeq "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/types"
@@ -44,9 +44,9 @@ var Set = wire.NewSet(
 func ProvideConn(
 	ctx *stopper.Context,
 	acc *apply.Acceptor,
-	bypass *bypass.Bypass,
 	chaos *chaos.Chaos,
 	config *Config,
+	imm *immediate.Immediate,
 	memo types.Memo,
 	scriptSeq *scriptSeq.Sequencer,
 	stagingPool *types.StagingPool,
@@ -72,7 +72,7 @@ func ProvideConn(
 		TLSConfig: config.tlsConfig,
 	}
 
-	seq, err := scriptSeq.Wrap(ctx, bypass)
+	seq, err := scriptSeq.Wrap(ctx, imm)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -8,8 +8,8 @@ package mylogical
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sinkprod"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
@@ -56,11 +56,11 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 	if err != nil {
 		return nil, err
 	}
-	bypassBypass := &bypass.Bypass{}
 	sequencerConfig := &eagerConfig.Sequencer
 	chaosChaos := &chaos.Chaos{
 		Config: sequencerConfig,
 	}
+	immediateImmediate := &immediate.Immediate{}
 	stagingConfig := &eagerConfig.Staging
 	stagingPool, err := sinkprod.ProvideStagingPool(ctx, stagingConfig, diagnostics, targetConfig)
 	if err != nil {
@@ -75,7 +75,7 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 		return nil, err
 	}
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	mylogicalConn, err := ProvideConn(ctx, acceptor, bypassBypass, chaosChaos, config, memoMemo, sequencer, stagingPool, targetPool, watchers)
+	mylogicalConn, err := ProvideConn(ctx, acceptor, chaosChaos, config, immediateImmediate, memoMemo, sequencer, stagingPool, targetPool, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/pglogical/injector.go
+++ b/internal/source/pglogical/injector.go
@@ -23,8 +23,8 @@ import (
 	"context"
 
 	scriptRuntime "github.com/cockroachdb/cdc-sink/internal/script"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	scriptSequencer "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sinkprod"
 	"github.com/cockroachdb/cdc-sink/internal/staging"
@@ -43,7 +43,7 @@ func Start(*stopper.Context, *Config) (*PGLogical, error) {
 		wire.FieldsOf(new(*Config), "Script"),
 		wire.FieldsOf(new(*EagerConfig), "DLQ", "Sequencer", "Staging", "Target"),
 		Set,
-		bypass.Set,
+		immediate.Set,
 		chaos.Set,
 		diag.New,
 		scriptRuntime.Set,

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -19,8 +19,8 @@ package pglogical
 import (
 	scriptRT "github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/target/apply"
 	"github.com/cockroachdb/cdc-sink/internal/types"
@@ -50,7 +50,7 @@ func ProvideConn(
 	acc *apply.Acceptor,
 	chaos *chaos.Chaos,
 	config *Config,
-	bypass *bypass.Bypass,
+	imm *immediate.Immediate,
 	memo types.Memo,
 	scriptSeq *script.Sequencer,
 	stagingPool *types.StagingPool,
@@ -103,7 +103,7 @@ func ProvideConn(
 	sourceConfig := source.Config().Config.Copy()
 	sourceConfig.RuntimeParams["replication"] = "database"
 
-	seq, err := scriptSeq.Wrap(ctx, bypass)
+	seq, err := scriptSeq.Wrap(ctx, imm)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -8,8 +8,8 @@ package pglogical
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/bypass"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sinkprod"
 	"github.com/cockroachdb/cdc-sink/internal/staging/memo"
@@ -60,7 +60,7 @@ func Start(context *stopper.Context, config *Config) (*PGLogical, error) {
 	chaosChaos := &chaos.Chaos{
 		Config: sequencerConfig,
 	}
-	bypassBypass := &bypass.Bypass{}
+	immediateImmediate := &immediate.Immediate{}
 	stagingConfig := &eagerConfig.Staging
 	stagingPool, err := sinkprod.ProvideStagingPool(context, stagingConfig, diagnostics, targetConfig)
 	if err != nil {
@@ -75,7 +75,7 @@ func Start(context *stopper.Context, config *Config) (*PGLogical, error) {
 		return nil, err
 	}
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	conn, err := ProvideConn(context, acceptor, chaosChaos, config, bypassBypass, memoMemo, sequencer, stagingPool, targetPool, watchers)
+	conn, err := ProvideConn(context, acceptor, chaosChaos, config, immediateImmediate, memoMemo, sequencer, stagingPool, targetPool, watchers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change renames the bypass sequencer to immediate to be consistent with documentation. Other uses of the phrase "bypass" have also been renamed. There are no functional changes in this commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/722)
<!-- Reviewable:end -->
