### PR TITLE
sequencer: Add common smoke test and clean up hlc.Range

### DIFF
--- a/internal/sequencer/besteffort/besteffort_test.go
+++ b/internal/sequencer/besteffort/besteffort_test.go
@@ -216,12 +216,12 @@ CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %s(parent)
 	r.Len(peeked, 5)
 
 	// Make staged data available to be processed.
-	sweepBounds.Set(hlc.Range{hlc.Zero(), hlc.New(5, 1)})
+	sweepBounds.Set(hlc.RangeIncluding(hlc.Zero(), hlc.New(5, 0)))
 	// Wait until the background process has caught for all tables.
 	sweepProgress, swept := stats.Get()
 	for {
 		progress := sequencer.CommonMin(sweepProgress)
-		done := hlc.Compare(progress, hlc.New(5, 1)) >= 0
+		done := hlc.Compare(progress, hlc.New(5, 0)) >= 0
 		if done {
 			break
 		}

--- a/internal/sequencer/marking.go
+++ b/internal/sequencer/marking.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sequencer
+
+import "github.com/cockroachdb/cdc-sink/internal/types"
+
+// MarkingAcceptor is a marker interface to indicate that a
+// [types.MultiAcceptor] will assume responsibility for calling
+// [types.Stager.MarkApplied].
+type MarkingAcceptor interface {
+	// IsMarking should return true.
+	IsMarking() bool
+}
+
+// IsMarking returns true if the acceptor implements [MarkingAcceptor]
+// or [MarkingAcceptor] is implemented by an acceptor somewhere in a
+// delegate chain.
+func IsMarking(acc types.MultiAcceptor) bool {
+	for acc != nil {
+		if marker, ok := acc.(MarkingAcceptor); ok {
+			return marker.IsMarking()
+		}
+		if wrapper, ok := acc.(interface{ Unwrap() types.MultiAcceptor }); ok {
+			acc = wrapper.Unwrap()
+		} else {
+			return false
+		}
+	}
+	return false
+}

--- a/internal/sequencer/retire/retire.go
+++ b/internal/sequencer/retire/retire.go
@@ -48,7 +48,7 @@ func (r *Retire) Start(
 	ret := &notify.Var[hlc.Time]{}
 	ctx.Go(func() error {
 		for {
-			_, err := stopvar.DoWhenChangedOrInterval(ctx, hlc.Range{}, bounds, time.Minute,
+			_, err := stopvar.DoWhenChangedOrInterval(ctx, hlc.RangeEmpty(), bounds, time.Minute,
 				func(ctx *stopper.Context, _, bounds hlc.Range) error {
 					before := bounds.Min()
 					before = hlc.New(before.Nanos()-r.cfg.RetireOffset.Nanoseconds(), before.Logical())

--- a/internal/sequencer/retire/retire_test.go
+++ b/internal/sequencer/retire/retire_test.go
@@ -110,7 +110,7 @@ func TestRetire(t *testing.T) {
 	r.Equal(rowcount, countStaged())
 
 	// Update the retirement bounds and wait for progress.
-	bounds.Set(hlc.Range{hlc.New(unstageStart+unstageCount, 0), hlc.New(rowcount*2, 0)})
+	bounds.Set(hlc.RangeIncluding(hlc.New(unstageStart+unstageCount, 0), hlc.New(rowcount*2, 0)))
 	r.NoError(stopvar.WaitForValue(ctx, hlc.New(unstageStart+unstageCount, 0), progress))
 	r.Equal(rowcount-unstageCount, countStaged())
 }

--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -138,7 +138,7 @@ api.configureTable("t_2", {
 	r.NoError(err)
 
 	const numEmits = 100
-	endTime := hlc.New(numEmits+1, 1)
+	endTime := hlc.New(numEmits+1, 0)
 	for i := 0; i < numEmits; i++ {
 		r.NoError(acc.AcceptTableBatch(ctx,
 			sinktest.TableBatchOf(
@@ -155,7 +155,7 @@ api.configureTable("t_2", {
 	}
 
 	// Make staged mutations eligible for processing.
-	bounds.Set(hlc.Range{hlc.Zero(), endTime})
+	bounds.Set(hlc.RangeIncluding(hlc.Zero(), endTime))
 
 	// Wait for (async) replication for the first table name.
 	progress, progressMade := stats.Get()

--- a/internal/sequencer/seqtest/check.go
+++ b/internal/sequencer/seqtest/check.go
@@ -1,0 +1,184 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package seqtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/script"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// CheckSequencer implements a general-purpose smoke test of a
+// [sequencer.Sequencer] implementation. The sequencer must
+// support foreign-key relationships. The post-hook may be nil.
+func CheckSequencer(
+	t *testing.T,
+	pre func(t *testing.T, fixture *all.Fixture, seqFixture *Fixture) sequencer.Sequencer,
+	post func(t *testing.T, check *Check),
+) {
+	const batches = 100
+	check := func(t *testing.T, stage bool, addChaos bool) {
+		r := require.New(t)
+
+		fixture, err := all.NewFixture(t)
+		r.NoError(err)
+		ctx := fixture.Context
+
+		// Create sequencer test fixture.
+		cfg := &sequencer.Config{
+			Parallelism:     8,
+			QuiescentPeriod: 100 * time.Millisecond,
+			TimestampLimit:  batches/10 + 1,
+			SweepLimit:      batches/10 + 1,
+		}
+
+		seqFixture, err := NewSequencerFixture(fixture, cfg, &script.Config{})
+		r.NoError(err)
+
+		seq := pre(t, fixture, seqFixture)
+		if addChaos {
+			cfg.Chaos = 0.1
+			seq, err = seqFixture.Chaos.Wrap(ctx, seq)
+			r.NoError(err)
+		}
+		basic := &Check{
+			Batches:   batches,
+			Fixture:   fixture,
+			Sequencer: seq,
+			Stage:     stage,
+		}
+		basic.Check(ctx, t)
+		if post != nil {
+			post(t, basic)
+		}
+	}
+
+	t.Run("direct", func(t *testing.T) {
+		check(t, false, false)
+	})
+	t.Run("direct-chaos", func(t *testing.T) {
+		check(t, false, true)
+	})
+	t.Run("staged", func(t *testing.T) {
+		check(t, true, false)
+	})
+	t.Run("staged-chaos", func(t *testing.T) {
+		check(t, true, true)
+	})
+}
+
+// Check implements a reusable test over a parent/child table pair.
+type Check struct {
+	// The acceptor returned by [sequencer.Sequencer.Start].
+	Acceptor types.MultiAcceptor
+	// The total number of transactions to apply.
+	Batches int
+	// Populated by Check.
+	Bounds notify.Var[hlc.Range]
+	// Access to test services.
+	Fixture *all.Fixture
+	// Populated by Check.
+	Generator *Generator
+	// Populated by Check.
+	Group *types.TableGroup
+	// The Sequencer under test.
+	Sequencer sequencer.Sequencer
+	// If true, generated data will be loaded into staging first. This
+	// is used to validate the sweeping behavior of a sequencer.
+	Stage bool
+}
+
+// Check generates data and verifies that it reaches the target tables.
+func (b *Check) Check(ctx *stopper.Context, t testing.TB) {
+	r := require.New(t)
+
+	generator, group, err := NewGenerator(ctx, b.Fixture)
+	r.NoError(err)
+	b.Group = group
+
+	seqAcc, stats, err := b.Sequencer.Start(ctx, &sequencer.StartOptions{
+		Bounds:   &b.Bounds,
+		Delegate: types.OrderedAcceptorFrom(b.Fixture.ApplyAcceptor, b.Fixture.Watchers),
+		Group:    group,
+	})
+	r.NoError(err)
+	b.Acceptor = seqAcc
+
+	now := time.Now()
+	testData := &types.MultiBatch{}
+	for i := 0; i < b.Batches; i++ {
+		generator.GenerateInto(testData, hlc.New(int64(i+1), 0))
+	}
+
+	if b.Stage {
+		// Apply data to the staging table, to test sweeping behavior.
+		for _, temporal := range testData.Data {
+			r.NoError(temporal.Data.Range(func(table ident.Table, batch *types.TableBatch) error {
+				stager, err := b.Fixture.Stagers.Get(ctx, table)
+				if err != nil {
+					return err
+				}
+				return stager.Stage(ctx, b.Fixture.StagingPool, batch.Data)
+			}))
+		}
+	} else {
+		// We're going to fragment the batch to simulate data being
+		// received piecemeal by multiple instances of cdc-sink. We
+		// ensure that the child fragments must be processed before
+		// the parent fragments.
+		fragments, err := Fragment(testData)
+		r.NoError(err)
+		r.Len(fragments, 2)
+		if _, isChild := fragments[1].Data[0].Data.Get(generator.Child.Name()); isChild {
+			fragments[0], fragments[1] = fragments[1], fragments[0]
+		}
+
+	retry:
+		for _, fragment := range fragments {
+			if err := seqAcc.AcceptMultiBatch(ctx, fragment, &types.AcceptOptions{}); err != nil {
+				if errors.Is(err, chaos.ErrChaos) {
+					goto retry
+				}
+				r.NoError(err)
+			}
+		}
+	}
+	log.Infof("accepted data in %s", time.Since(now))
+
+	// Set desired range.
+	b.Bounds.Set(generator.Range())
+	r.NoError(err)
+
+	// Wait to catch up.
+	now = time.Now()
+	r.NoError(generator.WaitForCatchUp(ctx, stats))
+	log.Infof("caught up in an additional %s", time.Since(now))
+	generator.CheckConsistent(ctx, t)
+
+}

--- a/internal/sequencer/seqtest/fragment.go
+++ b/internal/sequencer/seqtest/fragment.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package seqtest
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+)
+
+// Fragment breaks a batch up into a number of minimum-sized batches
+// which are representative of how the bulk-transfer CDC feed delivers
+// data (i.e. payloads per table). The data for any given table will
+// remain in a time-ordered fashion.
+func Fragment(batch *types.MultiBatch) ([]*types.MultiBatch, error) {
+	var tableBatches ident.TableMap[*types.MultiBatch]
+	for _, temporal := range batch.Data {
+		if err := temporal.Data.Range(func(table ident.Table, tableBatch *types.TableBatch) error {
+			tableMulti := tableBatches.GetZero(table)
+			if tableMulti == nil {
+				tableMulti = &types.MultiBatch{}
+				tableBatches.Put(table, tableMulti)
+			}
+			for _, mut := range tableBatch.Data {
+				if err := tableMulti.Accumulate(table, mut); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	ret := make([]*types.MultiBatch, 0, tableBatches.Len())
+	if err := tableBatches.Range(func(table ident.Table, tableMulti *types.MultiBatch) error {
+		ret = append(ret, tableMulti)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/internal/sequencer/seqtest/generate.go
+++ b/internal/sequencer/seqtest/generate.go
@@ -170,7 +170,7 @@ func (g *Generator) GenerateInto(batch *types.MultiBatch, time hlc.Time) {
 // Range returns a range that includes all times at which the Generator
 // created data.
 func (g *Generator) Range() hlc.Range {
-	return hlc.Range{hlc.Zero(), g.MaxTime.Next()}
+	return hlc.RangeIncluding(hlc.Zero(), g.MaxTime)
 }
 
 // WaitForCatchUp returns when the Stat shows all tables have advanced
@@ -179,7 +179,7 @@ func (g *Generator) WaitForCatchUp(ctx context.Context, stats *notify.Var[sequen
 	for {
 		stat, changed := stats.Get()
 		min := sequencer.CommonMin(stat)
-		if hlc.Compare(min, g.MaxTime) > 0 {
+		if hlc.Compare(min, g.MaxTime) >= 0 {
 			log.Debugf("caught up to %s", min)
 			return nil
 		}

--- a/internal/sequencer/seqtest/generate.go
+++ b/internal/sequencer/seqtest/generate.go
@@ -17,102 +17,141 @@
 package seqtest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"testing"
 
+	"github.com/cockroachdb/cdc-sink/internal/sequencer"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
-// GenerateBatch will generate a batch of data at a specific time. It
-// assumes that there is a parent table and a child table. The parents
-// map will be updated whenever a new parent entry is required.
-func GenerateBatch(
-	ctr *int, time hlc.Time, parents, children map[int]struct{}, parentTbl, childTbl ident.Table,
-) *types.MultiBatch {
-	pickExistingChild := func() int {
-		// Rely on random iteration order.
-		for child := range children {
-			return child
-		}
-		panic("no children")
-	}
-	pickExistingParent := func() int {
-		// Rely on random iteration order.
-		for parent := range parents {
-			return parent
-		}
-		panic("no parents")
-	}
-	pickNewChild := func() int {
-		for {
-			child := int(rand.Int31())
-			if _, exists := children[child]; exists {
-				continue
-			}
-			children[child] = struct{}{}
-			return child
-		}
-	}
-	pickNewParent := func() int {
-		for {
-			parent := int(rand.Int31())
-			if _, exists := parents[parent]; exists {
-				continue
-			}
-			parents[parent] = struct{}{}
-			return parent
-		}
+// Generator creates batches of test data. It assumes that there is a
+// parent table and a child table. The parents map will be updated
+// whenever a new parent entry is required.
+type Generator struct {
+	Fixture           *all.Fixture
+	MaxTime           hlc.Time
+	Parent, Child     base.TableInfo[*types.TargetPool]
+	Parents, Children map[int]struct{}
+
+	ctr int
+}
+
+// NewGenerator constructs a Generator that will create messages
+// for parent and child tables.
+func NewGenerator(
+	ctx context.Context, fixture *all.Fixture,
+) (*Generator, *types.TableGroup, error) {
+	parentInfo, err := fixture.CreateTargetTable(ctx, "CREATE TABLE %s (parent INT PRIMARY KEY)")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	batch := &types.MultiBatch{}
-	switch *ctr % 5 {
+	childInfo, err := fixture.CreateTargetTable(ctx, fmt.Sprintf(
+		`CREATE TABLE %%s (
+child INT PRIMARY KEY,
+parent INT NOT NULL,
+val INT DEFAULT 0 NOT NULL,
+CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %s(parent)
+)`, parentInfo.Name()))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &Generator{
+			Child:    childInfo,
+			Children: make(map[int]struct{}),
+			Fixture:  fixture,
+			Parent:   parentInfo,
+			Parents:  make(map[int]struct{}),
+		},
+		&types.TableGroup{
+			Name:      ident.New("testing"),
+			Enclosing: fixture.TargetSchema.Schema(),
+			Tables:    []ident.Table{childInfo.Name(), parentInfo.Name()},
+		},
+		nil
+}
+
+// CheckConsistent verifies that the staging tables are empty and that
+// the requisite number of rows exist in the target tables.
+func (g *Generator) CheckConsistent(ctx context.Context, t testing.TB) {
+	r := assert.New(t)
+
+	// Verify all mutations have been unstaged.
+	rng := g.Range()
+	staged, err := g.Fixture.PeekStaged(ctx, g.Parent.Name(), rng.Min(), rng.Max())
+	r.NoError(err)
+	r.Emptyf(staged, "staging table %s not empty", g.Parent)
+	staged, err = g.Fixture.PeekStaged(ctx, g.Child.Name(), rng.Min(), rng.Max())
+	r.NoError(err)
+	r.Emptyf(staged, "staging table %s not empty", g.Child)
+
+	// Verify target row counts against generated data.
+	parentCount, err := g.Parent.RowCount(ctx)
+	r.NoError(err)
+	r.Equalf(len(g.Parents), parentCount, "parent %s", g.Parent.Name())
+	childCount, err := g.Child.RowCount(ctx)
+	r.NoError(err)
+	r.Equal(len(g.Children), childCount, "child %s", g.Child.Name())
+}
+
+// GenerateInto will add mutations to the batch at the requested time.
+func (g *Generator) GenerateInto(batch *types.MultiBatch, time hlc.Time) {
+	switch g.ctr % 5 {
 	case 0: // Insert a parent row
-		parent := pickNewParent()
-		_ = batch.Accumulate(parentTbl, types.Mutation{
+		parent := g.pickNewParent()
+		_ = batch.Accumulate(g.Parent.Name(), types.Mutation{
 			Data: json.RawMessage(fmt.Sprintf(`{ "parent": %d }`, parent)),
 			Key:  json.RawMessage(fmt.Sprintf(`[ %d ]`, parent)),
 			Time: time,
 		})
 
 	case 1: // Update a parent row
-		parent := pickExistingParent()
-		_ = batch.Accumulate(parentTbl, types.Mutation{
+		parent := g.pickExistingParent()
+		_ = batch.Accumulate(g.Parent.Name(), types.Mutation{
 			Data: json.RawMessage(fmt.Sprintf(`{ "parent": %d }`, parent)),
 			Key:  json.RawMessage(fmt.Sprintf(`[ %d ]`, parent)),
 			Time: time,
 		})
 
 	case 2: // Insert a child row referencing an existing parent
-		parent := pickExistingParent()
-		child := pickNewChild()
-		_ = batch.Accumulate(childTbl, types.Mutation{
+		parent := g.pickExistingParent()
+		child := g.pickNewChild()
+		_ = batch.Accumulate(g.Child.Name(), types.Mutation{
 			Data: json.RawMessage(fmt.Sprintf(`{ "child": %d, "parent": %d }`, child, parent)),
 			Key:  json.RawMessage(fmt.Sprintf(`[ %d ]`, child)),
 			Time: time,
 		})
 
 	case 3: // Insert a new child row referencing a new parent
-		parent := pickNewParent()
-		_ = batch.Accumulate(parentTbl, types.Mutation{
+		parent := g.pickNewParent()
+		_ = batch.Accumulate(g.Parent.Name(), types.Mutation{
 			Data: json.RawMessage(fmt.Sprintf(`{ "parent": %d }`, parent)),
 			Key:  json.RawMessage(fmt.Sprintf(`[ %d ]`, parent)),
 			Time: time,
 		})
 
-		child := pickNewChild()
-		_ = batch.Accumulate(childTbl, types.Mutation{
+		child := g.pickNewChild()
+		_ = batch.Accumulate(g.Child.Name(), types.Mutation{
 			Data: json.RawMessage(fmt.Sprintf(`{ "child": %d, "parent": %d }`, child, parent)),
 			Key:  json.RawMessage(fmt.Sprintf(`[ %d ]`, child)),
 			Time: time,
 		})
 
 	case 4: // Re-parent an existing child
-		parent := pickExistingParent()
-		child := pickExistingChild()
-		_ = batch.Accumulate(childTbl, types.Mutation{
+		parent := g.pickExistingParent()
+		child := g.pickExistingChild()
+		_ = batch.Accumulate(g.Child.Name(), types.Mutation{
 			Data: json.RawMessage(fmt.Sprintf(`{ "child": %d, "parent": %d }`, child, parent)),
 			Key:  json.RawMessage(fmt.Sprintf(`[ %d ]`, child)),
 			Time: time,
@@ -122,6 +161,71 @@ func GenerateBatch(
 		panic("check your modulus")
 	}
 
-	*ctr++
-	return batch
+	g.ctr++
+	if hlc.Compare(time, g.MaxTime) > 0 {
+		g.MaxTime = time
+	}
+}
+
+// Range returns a range that includes all times at which the Generator
+// created data.
+func (g *Generator) Range() hlc.Range {
+	return hlc.Range{hlc.Zero(), g.MaxTime.Next()}
+}
+
+// WaitForCatchUp returns when the Stat shows all tables have advanced
+// beyond the highest timestamp passed to [Generator.GenerateInto].
+func (g *Generator) WaitForCatchUp(ctx context.Context, stats *notify.Var[sequencer.Stat]) error {
+	for {
+		stat, changed := stats.Get()
+		min := sequencer.CommonMin(stat)
+		if hlc.Compare(min, g.MaxTime) > 0 {
+			log.Debugf("caught up to %s", min)
+			return nil
+		}
+		log.Debugf("waiting for catch-up: %s vs %s", min, g.MaxTime)
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (g *Generator) pickExistingChild() int {
+	// Rely on random iteration order.
+	for child := range g.Children {
+		return child
+	}
+	panic("no children")
+}
+
+func (g *Generator) pickExistingParent() int {
+	// Rely on random iteration order.
+	for parent := range g.Parents {
+		return parent
+	}
+	panic("no parents")
+}
+
+func (g *Generator) pickNewChild() int {
+	for {
+		child := int(rand.Int31())
+		if _, exists := g.Children[child]; exists {
+			continue
+		}
+		g.Children[child] = struct{}{}
+		return child
+	}
+}
+
+func (g *Generator) pickNewParent() int {
+	for {
+		parent := int(rand.Int31())
+		if _, exists := g.Parents[parent]; exists {
+			continue
+		}
+		g.Parents[parent] = struct{}{}
+		return parent
+	}
 }

--- a/internal/sequencer/seqtest/seqtest.go
+++ b/internal/sequencer/seqtest/seqtest.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/script"
@@ -42,6 +43,7 @@ type Fixture struct {
 	*all.Fixture
 
 	BestEffort *besteffort.BestEffort
+	Chaos      *chaos.Chaos
 	Immediate  *immediate.Immediate
 	Retire     *retire.Retire
 	Serial     *serial.Serial

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -35,6 +35,9 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 	targetPool := baseFixture.TargetPool
 	watchers := fixture.Watchers
 	bestEffort := besteffort.ProvideBestEffort(config, leases, stagingPool, stagers, targetPool, watchers)
+	chaosChaos := &chaos.Chaos{
+		Config: config,
+	}
 	immediateImmediate := &immediate.Immediate{}
 	retireRetire := retire.ProvideRetire(config, stagingPool, stagers)
 	serialSerial := serial.ProvideSerial(config, leases, stagers, stagingPool, targetPool)
@@ -45,14 +48,12 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 		return nil, err
 	}
 	scriptSequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	shingleShingle := shingle.ProvideShingle(config, targetPool)
-	chaosChaos := &chaos.Chaos{
-		Config: config,
-	}
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, scriptSequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	shingleShingle := shingle.ProvideShingle(config, stagers, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, diagnostics, immediateImmediate, scriptSequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	seqtestFixture := &Fixture{
 		Fixture:    fixture,
 		BestEffort: bestEffort,
+		Chaos:      chaosChaos,
 		Immediate:  immediateImmediate,
 		Retire:     retireRetire,
 		Serial:     serialSerial,

--- a/internal/sequencer/serial/serial.go
+++ b/internal/sequencer/serial/serial.go
@@ -77,7 +77,8 @@ func (s *Serial) Start(
 		}()
 
 		// Ignoring error since it's always nil.
-		_, _ = stopvar.DoWhenChangedOrInterval(ctx, hlc.Range{}, opts.Bounds, s.cfg.QuiescentPeriod,
+		_, _ = stopvar.DoWhenChangedOrInterval(ctx,
+			hlc.RangeEmpty(), opts.Bounds, s.cfg.QuiescentPeriod,
 			func(ctx *stopper.Context, _, bound hlc.Range) error {
 				// Do nothing if, e.g. the caller has advanced the min time to the max time.
 				if bound.Empty() {
@@ -190,7 +191,9 @@ func (s *Serial) sweepOnce(
 	workCount := work.Count()
 	// We're done, just exit.
 	if workCount == 0 && !moreWork {
-		return q.EndBefore, false, nil
+		// This EndBefore value is exclusive, so we want to return a
+		// timestamp that was within the timestamps actually read.
+		return bounds.MaxInclusive(), false, nil
 	}
 
 	targetTx, err := s.targetPool.BeginTx(ctx, nil)
@@ -213,11 +216,13 @@ func (s *Serial) sweepOnce(
 		return hlc.Zero(), false, errors.WithStack(err)
 	}
 
-	// Without X/A transactions, we are in a vulnerable state here. If
-	// the staging transaction fails to commit, however, we'd re-apply
-	// the work that was just performed. This should wind up being a
-	// no-op in the general case.
+	// The staging transaction will be null if the delegate stack
+	// implements the MarkingAcceptor interface.
 	if stagingTx != nil {
+		// Without X/A transactions, we are in a vulnerable state here.
+		// If the staging transaction fails to commit, however, we'd
+		// re-apply the work that was just performed. This should wind
+		// up being a no-op in the general case.
 		if err := stagingTx.Commit(ctx); err != nil {
 			skew.Inc()
 			return hlc.Zero(), false, errors.Wrapf(err, "Serial.sweepOnce: skew condition")
@@ -230,12 +235,6 @@ func (s *Serial) sweepOnce(
 	duration.Observe(time.Since(start).Seconds())
 	success.SetToCurrentTime()
 
-	// If there's potentially more work to do, we can only guarantee
-	// we've processed up to the point at which the query would resume.
-	// However, if we know that we've consumed all possible data, we can
-	// jump ahead to the end of the time range.
-	if moreWork {
-		return q.StartAt, true, nil
-	}
-	return q.EndBefore, false, nil
+	// Report timestamp progress.
+	return q.MinOffset(), true, nil
 }

--- a/internal/sequencer/serial/serial_test.go
+++ b/internal/sequencer/serial/serial_test.go
@@ -31,11 +31,10 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/notify"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSerial(t *testing.T) {
+func TestStepByStep(t *testing.T) {
 	r := require.New(t)
 	fixture, err := all.NewFixture(t)
 	r.NoError(err)
@@ -166,119 +165,10 @@ val INT DEFAULT 0 NOT NULL
 	r.Equal(2, ct)
 }
 
-// TestSweepingFromStaging writes mutations to the staging table and
-// then starts the sweep process. This ensures that Serial can be
-// cold-started. Increasing the number of batches written here is also
-// an ersatz performance test of the sweep cycle.
-func TestSweepingFromStaging(t *testing.T) {
-	const batches = 10_000
-
-	r := require.New(t)
-	fixture, err := all.NewFixture(t)
-	r.NoError(err)
-	ctx := fixture.Context
-
-	parentInfo, err := fixture.CreateTargetTable(ctx, "CREATE TABLE %s (parent INT PRIMARY KEY)")
-	r.NoError(err)
-
-	childInfo, err := fixture.CreateTargetTable(ctx, fmt.Sprintf(
-		`CREATE TABLE %%s (
-child INT PRIMARY KEY,
-parent INT NOT NULL,
-val INT DEFAULT 0 NOT NULL,
-CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %s(parent)
-)`, parentInfo.Name()))
-	r.NoError(err)
-
-	group := &types.TableGroup{
-		Name:      ident.New("testing"),
-		Enclosing: fixture.TargetSchema.Schema(),
-		Tables: []ident.Table{
-			parentInfo.Name(),
-			childInfo.Name(),
+func TestSerial(t *testing.T) {
+	seqtest.CheckSequencer(t,
+		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
+			return seqFixture.Serial
 		},
-	}
-
-	// Write to staging tables directly, so we're testing the sweeping
-	// behavior without measuring the fast-path.
-	var ctr int
-	parents := make(map[int]struct{})
-	children := make(map[int]struct{})
-	now := time.Now()
-	for i := 0; i < batches; i++ {
-		batch := seqtest.GenerateBatch(
-			&ctr, hlc.New(int64(i+1), 0),
-			parents, children,
-			parentInfo.Name(), childInfo.Name())
-		for _, sub := range batch.Data {
-			r.NoError(sub.Data.Range(func(table ident.Table, data *types.TableBatch) error {
-				stager, err := fixture.Stagers.Get(ctx, table)
-				if err != nil {
-					return err
-				}
-				return stager.Stage(ctx, fixture.StagingPool, data.Data)
-			}))
-		}
-	}
-	log.Infof("staged data in %s", time.Since(now))
-	endTime := hlc.New(batches+1, 1)
-
-	// Create sequencer test fixture.
-	seqFixture, err := seqtest.NewSequencerFixture(fixture,
-		&sequencer.Config{
-			Parallelism:     8,
-			QuiescentPeriod: 100 * time.Millisecond,
-			TimestampLimit:  batches/10 + 1,
-			SweepLimit:      batches/10 + 1,
-		},
-		&script.Config{})
-	r.NoError(err)
-
-	// Set up the Serial processes.
-	bounds := &notify.Var[hlc.Range]{}
-	_, stats, err := seqFixture.Serial.Start(ctx, &sequencer.StartOptions{
-		Bounds:   bounds,
-		Delegate: types.OrderedAcceptorFrom(fixture.ApplyAcceptor, fixture.Watchers),
-		Group:    group,
-	})
-	r.NoError(err)
-
-	// Set desired range.
-	now = time.Now()
-	_, _, err = bounds.Update(func(old hlc.Range) (new hlc.Range, _ error) {
-		return hlc.Range{old.Min(), endTime}, nil
-	})
-	r.NoError(err)
-
-	// Wait to catch up.
-	for {
-		stat, changed := stats.Get()
-		min := sequencer.CommonMin(stat)
-		if hlc.Compare(min, endTime) >= 0 {
-			log.Infof("caught up in %s", time.Since(now))
-			break
-		}
-		log.Infof("waiting for catch-up: %s vs %s", min, endTime)
-		select {
-		case <-changed:
-		case <-ctx.Done():
-			r.NoError(ctx.Err())
-		}
-	}
-
-	// Verify all mutations have been unstaged.
-	staged, err := fixture.PeekStaged(ctx, parentInfo.Name(), hlc.Zero(), endTime)
-	r.NoError(err)
-	r.Empty(staged)
-	staged, err = fixture.PeekStaged(ctx, childInfo.Name(), hlc.Zero(), endTime)
-	r.NoError(err)
-	r.Empty(staged)
-
-	// Verify target row counts against generated data.
-	parentCount, err := parentInfo.RowCount(ctx)
-	r.NoError(err)
-	r.Equal(len(parents), parentCount)
-	childCount, err := childInfo.RowCount(ctx)
-	r.NoError(err)
-	r.Equal(len(children), childCount)
+		func(t *testing.T, check *seqtest.Check) {})
 }

--- a/internal/sequencer/shingle/provider.go
+++ b/internal/sequencer/shingle/provider.go
@@ -26,9 +26,16 @@ import (
 var Set = wire.NewSet(ProvideShingle)
 
 // ProvideShingle is called by Wire.
-func ProvideShingle(cfg *sequencer.Config, target *types.TargetPool) *Shingle {
+func ProvideShingle(
+	cfg *sequencer.Config,
+	stagers types.Stagers,
+	staging *types.StagingPool,
+	target *types.TargetPool,
+) *Shingle {
 	return &Shingle{
-		cfg:    cfg,
-		target: target,
+		cfg:     cfg,
+		stagers: stagers,
+		staging: staging,
+		target:  target,
 	}
 }

--- a/internal/sequencer/shingle/shingle.go
+++ b/internal/sequencer/shingle/shingle.go
@@ -29,8 +29,10 @@ import (
 // target transaction to be applied concurrently, with ordering enforced
 // on a per-key basis.
 type Shingle struct {
-	cfg    *sequencer.Config
-	target *types.TargetPool
+	cfg     *sequencer.Config
+	stagers types.Stagers
+	staging *types.StagingPool
+	target  *types.TargetPool
 }
 
 var _ sequencer.Shim = (*Shingle)(nil)

--- a/internal/sequencer/shingle/shingle_test.go
+++ b/internal/sequencer/shingle/shingle_test.go
@@ -17,141 +17,20 @@
 package shingle_test
 
 import (
-	"fmt"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/seqtest"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/switcher"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
-	"github.com/cockroachdb/cdc-sink/internal/sinktest/recorder"
-	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
-	"github.com/cockroachdb/cdc-sink/internal/util/ident"
-	"github.com/cockroachdb/cdc-sink/internal/util/notify"
 	"github.com/stretchr/testify/require"
 )
 
 func TestShingle(t *testing.T) {
-	r := require.New(t)
-
-	fixture, err := all.NewFixture(t)
-	r.NoError(err)
-	ctx := fixture.Context
-
-	seqFixture, err := seqtest.NewSequencerFixture(fixture,
-		&sequencer.Config{
-			Parallelism:     2,
-			QuiescentPeriod: time.Second,
-			SweepLimit:      sequencer.DefaultSweepLimit,
-			TimestampLimit:  1,
+	seqtest.CheckSequencer(t,
+		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
+			ret, err := seqFixture.Shingle.Wrap(fixture.Context, seqFixture.Serial)
+			require.NoError(t, err)
+			return ret
 		},
-		&script.Config{})
-	r.NoError(err)
-
-	// Create parent and child tables.
-	parentInfo, err := fixture.CreateTargetTable(ctx, "CREATE TABLE %s (parent INT PRIMARY KEY)")
-	r.NoError(err)
-
-	childInfo, err := fixture.CreateTargetTable(ctx, fmt.Sprintf(
-		`CREATE TABLE %%s (
-child INT PRIMARY KEY,
-parent INT NOT NULL REFERENCES %s,
-val INT DEFAULT 0 NOT NULL
-)`, parentInfo.Name()))
-	r.NoError(err)
-
-	sw := seqFixture.Switcher
-
-	// Write data to the database, but also record method calls.
-	rec := &recorder.Recorder{
-		Next: types.OrderedAcceptorFrom(fixture.ApplyAcceptor, fixture.Watchers),
-	}
-
-	// Control points for the sequencer.
-	bounds := &notify.Var[hlc.Range]{}
-	group := &types.TableGroup{
-		Name:   ident.New(fixture.StagingDB.Raw()),
-		Tables: []ident.Table{parentInfo.Name(), childInfo.Name()},
-	}
-	mode := &notify.Var[switcher.Mode]{}
-	mode.Set(switcher.ModeShingle) // Mode must be set before starting.
-
-	acc, stat, err := sw.Start(ctx, &sequencer.StartOptions{
-		Bounds:   bounds,
-		Delegate: rec,
-		Group:    group,
-	}, mode)
-	r.NoError(err)
-
-	// Tracking variables for generating a reasonable workload.
-	batchCounter := 0
-	expectedMutations := 0
-	hlcTime := int64(0)
-	parents := make(map[int]struct{})
-	children := make(map[int]struct{})
-
-	// Generate some number of batches.
-	sendBatches := func() error {
-		for i := int64(0); i < 100; i++ {
-			batch := seqtest.GenerateBatch(
-				&batchCounter, hlc.New(hlcTime, 0),
-				parents, children,
-				parentInfo.Name(), childInfo.Name())
-			expectedMutations += batch.Count()
-			if err := acc.AcceptMultiBatch(ctx, batch, &types.AcceptOptions{}); err != nil {
-				return err
-			}
-
-			// Incrementally advance the bounds. Since the max value is
-			// exclusive, we need to add 1.
-			bounds.Set(hlc.Range{hlc.Zero(), hlc.New(hlcTime, 1)})
-			hlcTime++
-		}
-		return nil
-	}
-	// Wait until all tables have advanced to the "current" HLC time.
-	waitForCatchUp := func(r *require.Assertions) {
-		for {
-			nextStat, changed := stat.Get()
-			caughtUp := true
-			expected := hlc.New(hlcTime-1, 1) // The hlcTime is ++'ed at the end of sendBatches()
-			for _, tbl := range group.Tables {
-				if nextStat.Progress().GetZero(tbl) != expected {
-					caughtUp = false
-					break
-				}
-			}
-			if !caughtUp {
-				select {
-				case <-changed:
-					continue
-				case <-ctx.Done():
-					r.NoError(ctx.Err())
-				}
-			}
-
-			// Verify that all staged mutations are marked as applied.
-			for _, info := range []interface{ Name() ident.Table }{parentInfo, childInfo} {
-				muts, err := fixture.PeekStaged(ctx, info.Name(), hlc.Zero(), expected)
-				r.NoError(err, info.Name().Raw())
-				r.Empty(muts, info.Name().Raw())
-			}
-
-			// Ensure that the diagnostic data is sane.
-			var diag strings.Builder
-			r.NoError(fixture.Diagnostics.Write(ctx, &diag, true))
-			return
-		}
-	}
-
-	for i := 0; i < 5; i++ {
-		r.NoError(sendBatches())
-		waitForCatchUp(r)
-		r.Equal(expectedMutations, rec.Count())
-	}
-
+		func(t *testing.T, check *seqtest.Check) {})
 }

--- a/internal/sequencer/switcher/provider.go
+++ b/internal/sequencer/switcher/provider.go
@@ -43,7 +43,6 @@ var Set = wire.NewSet(
 // ProvideSequencer is called by Wire.
 func ProvideSequencer(
 	best *besteffort.BestEffort,
-	chaos *chaos.Chaos,
 	diags *diag.Diagnostics,
 	imm *immediate.Immediate,
 	script *script.Sequencer,
@@ -54,9 +53,8 @@ func ProvideSequencer(
 ) *Switcher {
 	return &Switcher{
 		bestEffort:  best,
-		immediate:   imm,
-		chaos:       chaos,
 		diags:       diags,
+		immediate:   imm,
 		script:      script,
 		serial:      serial,
 		shingle:     shingle,

--- a/internal/sequencer/switcher/switcher.go
+++ b/internal/sequencer/switcher/switcher.go
@@ -69,6 +69,7 @@ type Switcher struct {
 var _ sequencer.Sequencer = (*Switcher)(nil)
 
 // Start a sequencer that can switch between various modes of operation.
+// Callers must call [Switcher.WithMode] before calling this method.
 func (s *Switcher) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
@@ -105,7 +106,8 @@ func (s *Switcher) Start(
 }
 
 // WithMode returns a copy of the Switcher that uses the given variable
-// for mode control.
+// for mode control. This method exists so that Switcher can satisfy the
+// [sequencer.Sequencer] interface.
 func (s *Switcher) WithMode(mode *notify.Var[Mode]) *Switcher {
 	ret := *s
 	ret.mode = mode

--- a/internal/sequencer/switcher/switcher_test.go
+++ b/internal/sequencer/switcher/switcher_test.go
@@ -17,213 +17,43 @@
 package switcher_test
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/seqtest"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/switcher"
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/all"
-	"github.com/cockroachdb/cdc-sink/internal/sinktest/recorder"
-	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
-	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/notify"
-	"github.com/stretchr/testify/require"
 )
 
-func TestSwitcherSmoke(t *testing.T) {
-	t.Run("normal", func(t *testing.T) {
-		testSwitcherSmoke(t, false)
-	})
-	t.Run("chaos", func(t *testing.T) {
-		testSwitcherSmoke(t, true)
-	})
-}
-
-func testSwitcherSmoke(t *testing.T, addChaos bool) {
-	t.Helper()
-	r := require.New(t)
-
-	fixture, err := all.NewFixture(t)
-	r.NoError(err)
-	ctx := fixture.Context
-
-	cfg := &sequencer.Config{
-		Parallelism:     2,
-		QuiescentPeriod: 100 * time.Millisecond,
-		SweepLimit:      sequencer.DefaultSweepLimit,
-		TimestampLimit:  1,
-	}
-	if addChaos {
-		cfg.Chaos = 0.01
-	}
-	seqFixture, err := seqtest.NewSequencerFixture(fixture, cfg, &script.Config{})
-	r.NoError(err)
-
-	// Create parent and child tables.
-	parentInfo, err := fixture.CreateTargetTable(ctx, "CREATE TABLE %s (parent INT PRIMARY KEY)")
-	r.NoError(err)
-
-	childInfo, err := fixture.CreateTargetTable(ctx, fmt.Sprintf(
-		`CREATE TABLE %%s (
-child INT PRIMARY KEY,
-parent INT NOT NULL REFERENCES %s,
-val INT DEFAULT 0 NOT NULL
-)`, parentInfo.Name()))
-	r.NoError(err)
-
-	sw := seqFixture.Switcher
-
-	// Write data to the database, but also record method calls.
-	rec := &recorder.Recorder{
-		Next: types.OrderedAcceptorFrom(fixture.ApplyAcceptor, fixture.Watchers),
-	}
-
-	// Control points for the sequencer.
-	bounds := &notify.Var[hlc.Range]{}
-	group := &types.TableGroup{
-		Name:   ident.New(fixture.StagingDB.Raw()),
-		Tables: []ident.Table{parentInfo.Name(), childInfo.Name()},
-	}
-	mode := &notify.Var[switcher.Mode]{}
-
-	mode.Set(switcher.ModeBestEffort) // Mode must be set before starting.
-	opts := &sequencer.StartOptions{
-		Bounds:   bounds,
-		Delegate: rec,
-		Group:    group,
-	}
-	acc, stat, err := sw.Start(ctx, opts, mode)
-	r.NoError(err)
-
-	// Tracking variables for generating a reasonable workload.
-	batchCounter := 0
-	expectedMutations := 0
-	hlcTime := int64(0)
-	parents := make(map[int]struct{})
-	children := make(map[int]struct{})
-
-	// Generate some number of batches.
-	sendBatches := func() error {
-		for i := int64(0); i < 100; i++ {
-			batch := seqtest.GenerateBatch(
-				&batchCounter, hlc.New(hlcTime, 0),
-				parents, children,
-				parentInfo.Name(), childInfo.Name())
-			expectedMutations += batch.Count()
-		retry:
-			if err := acc.AcceptMultiBatch(ctx, batch, &types.AcceptOptions{}); err != nil {
-				if errors.Is(err, chaos.ErrChaos) {
-					goto retry
-				}
-				return err
-			}
-
-			// Incrementally advance the bounds. Since the max value is
-			// exclusive, we need to add 1.
-			bounds.Set(hlc.Range{hlc.Zero(), hlc.New(hlcTime, 1)})
-			hlcTime++
-		}
-		return nil
-	}
-	// Wait until all tables have advanced to the "current" HLC time.
-	waitForCatchUp := func(r *require.Assertions) {
-		for {
-			expected := hlc.New(hlcTime-1, 1) // The hlcTime is ++'ed at the end of sendBatches()
-			nextStat, changed := stat.Get()
-			caughtUp := hlc.Compare(sequencer.CommonMin(nextStat), expected) >= 0
-			if !caughtUp {
-				select {
-				case <-changed:
-					continue
-				case <-ctx.Done():
-					r.NoError(ctx.Err())
-				}
-			}
-
-			// Verify that all staged mutations are marked as applied.
-			for _, info := range []interface{ Name() ident.Table }{parentInfo, childInfo} {
-				muts, err := fixture.PeekStaged(ctx, info.Name(), hlc.Zero(), expected)
-				r.NoError(err, info.Name().Raw())
-				r.Empty(muts, info.Name().Raw())
-			}
-
-			// Ensure that the diagnostic data is sane.
-			var diag strings.Builder
-			r.NoError(fixture.Diagnostics.Write(ctx, &diag, true))
-			return
-		}
-	}
-
-	// Test toggling modes having waited for the previous to finish.
-	t.Run("basic-transitions", func(t *testing.T) {
-		r := require.New(t)
-
-		for i := 0; i < 5; i++ {
+func TestSwitcher(t *testing.T) {
+	seqtest.CheckSequencer(t,
+		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
+			ctx := fixture.Context
+			mode := &notify.Var[switcher.Mode]{}
 			mode.Set(switcher.ModeBestEffort)
-			r.NoError(sendBatches())
-			waitForCatchUp(r)
-			if addChaos {
-				r.GreaterOrEqual(rec.Count(), expectedMutations)
-			} else {
-				r.Equal(expectedMutations, rec.Count())
-			}
-
-			mode.Set(switcher.ModeSerial)
-			r.NoError(sendBatches())
-			waitForCatchUp(r)
-			if addChaos {
-				r.GreaterOrEqual(rec.Count(), expectedMutations)
-			} else {
-				r.Equal(expectedMutations, rec.Count())
-			}
-
-			mode.Set(switcher.ModeShingle)
-			r.NoError(sendBatches())
-			waitForCatchUp(r)
-			if addChaos {
-				r.GreaterOrEqual(rec.Count(), expectedMutations)
-			} else {
-				r.Equal(expectedMutations, rec.Count())
-			}
-		}
-	})
-
-	// This will allow each mode to perform some work and then
-	// immediately toggle to the next mode.
-	t.Run("jagged-transitions", func(t *testing.T) {
-		r := require.New(t)
-
-		_, progressMade := stat.Get()
-
-		for i := 0; i < 5; i++ {
-			for _, next := range []switcher.Mode{
-				switcher.ModeBestEffort,
-				switcher.ModeSerial,
-				switcher.ModeShingle,
-			} {
-				mode.Set(next)
-				r.NoError(sendBatches())
-				select {
-				case <-progressMade:
-					_, progressMade = stat.Get()
-				case <-ctx.Done():
-					r.NoError(ctx.Err())
+			fixture.Context.Go(func() error {
+				for {
+					select {
+					case <-time.After(100 * time.Millisecond):
+						_, _, _ = mode.Update(func(mode switcher.Mode) (switcher.Mode, error) {
+							switch mode {
+							case switcher.ModeBestEffort:
+								return switcher.ModeShingle, nil
+							case switcher.ModeShingle:
+								return switcher.ModeBestEffort, nil
+							default:
+								panic(fmt.Sprintf("unexpected state %s", mode))
+							}
+						})
+					case <-ctx.Stopping():
+						return nil
+					}
 				}
-			}
-		}
-
-		waitForCatchUp(r)
-		if addChaos {
-			r.GreaterOrEqual(rec.Count(), expectedMutations)
-		} else {
-			r.Equal(expectedMutations, rec.Count())
-		}
-	})
+			})
+			return seqFixture.Switcher.WithMode(mode)
+		},
+		func(t *testing.T, check *seqtest.Check) {})
 }

--- a/internal/source/cdc/server/wire_gen.go
+++ b/internal/source/cdc/server/wire_gen.go
@@ -9,7 +9,6 @@ package server
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
@@ -99,14 +98,11 @@ func NewServer(ctx *stopper.Context, config *Config) (*stdserver.Server, error) 
 		return nil, err
 	}
 	bestEffort := besteffort.ProvideBestEffort(sequencerConfig, typesLeases, stagingPool, stagers, targetPool, watchers)
-	chaosChaos := &chaos.Chaos{
-		Config: sequencerConfig,
-	}
 	immediateImmediate := &immediate.Immediate{}
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
-	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	shingleShingle := shingle.ProvideShingle(sequencerConfig, stagers, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	targets, err := cdc.ProvideTargets(ctx, acceptor, cdcConfig, checkpoints, retireRetire, stagingPool, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err
@@ -185,9 +181,6 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 		return nil, nil, err
 	}
 	bestEffort := besteffort.ProvideBestEffort(sequencerConfig, typesLeases, stagingPool, stagers, targetPool, watchers)
-	chaosChaos := &chaos.Chaos{
-		Config: sequencerConfig,
-	}
 	immediateImmediate := &immediate.Immediate{}
 	scriptConfig := cdc.ProvideScriptConfig(cdcConfig)
 	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
@@ -196,8 +189,8 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 	}
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
-	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	shingleShingle := shingle.ProvideShingle(sequencerConfig, stagers, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	targets, err := cdc.ProvideTargets(context, acceptor, cdcConfig, checkpoints, retireRetire, stagingPool, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, nil, err

--- a/internal/source/cdc/targets.go
+++ b/internal/source/cdc/targets.go
@@ -109,15 +109,13 @@ func (t *Targets) getTarget(schema ident.Schema) (*targetInfo, error) {
 	// Set the mode before starting the switcher.
 	t.modeSelector(ret)
 
-	ret.acceptor, ret.stat, err = t.switcher.Start(
+	ret.acceptor, ret.stat, err = t.switcher.WithMode(&ret.mode).Start(
 		t.stopper,
 		&sequencer.StartOptions{
 			Bounds:   &ret.resolvingRange,
 			Delegate: types.OrderedAcceptorFrom(t.tableAcceptor, t.watchers),
 			Group:    tableGroup,
-		},
-		&ret.mode,
-	)
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -9,7 +9,6 @@ package cdc
 import (
 	"github.com/cockroachdb/cdc-sink/internal/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
@@ -60,9 +59,6 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 		return nil, err
 	}
 	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
-	chaosChaos := &chaos.Chaos{
-		Config: sequencerConfig,
-	}
 	immediateImmediate := &immediate.Immediate{}
 	scriptConfig := ProvideScriptConfig(config)
 	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
@@ -71,8 +67,8 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	}
 	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	serialSerial := serial.ProvideSerial(sequencerConfig, typesLeases, stagers, stagingPool, targetPool)
-	shingleShingle := shingle.ProvideShingle(sequencerConfig, targetPool)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, chaosChaos, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
+	shingleShingle := shingle.ProvideShingle(sequencerConfig, stagers, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, diagnostics, immediateImmediate, sequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	targets, err := ProvideTargets(context, acceptor, config, checkpoints, retireRetire, stagingPool, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err

--- a/internal/util/hlc/hlc.go
+++ b/internal/util/hlc/hlc.go
@@ -22,6 +22,7 @@ package hlc
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -79,6 +80,15 @@ func Parse(timestamp string) (Time, error) {
 // Zero returns a zero-valued Time.
 func Zero() Time {
 	return Time{}
+}
+
+// Before returns the time minus one logical tick. If the time has a
+// zero logical component, the previous nanosecond will be returned.
+func (t Time) Before() Time {
+	if t.logical > 0 {
+		return Time{t.nanos, t.logical - 1}
+	}
+	return Time{t.nanos - 1, math.MaxInt}
 }
 
 // Logical returns the logical counter.

--- a/internal/util/hlc/hlc_test.go
+++ b/internal/util/hlc/hlc_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBefore(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal(Time{1, 0}, Time{1, 1}.Before())
+	a.Equal(Time{1, math.MaxInt}, Time{2, 0}.Before())
+}
+
 func TestCompare(t *testing.T) {
 	a := assert.New(t)
 
@@ -43,11 +50,36 @@ func TestNext(t *testing.T) {
 	a.Equal(New(1, 1), New(1, 0).Next())
 }
 
-func TestRange(t *testing.T) {
+func TestEmpty(t *testing.T) {
 	a := assert.New(t)
 
-	a.True(Range{Time{1, 0}, Time{1, 0}}.Empty())
-	a.False(Range{Time{1, 0}, Time{1, 1}}.Empty())
+	a.True(RangeEmpty().Empty())
+	a.True(RangeEmptyAt(Time{1, 0}).Empty())
+
+	a.False(RangeIncluding(Time{1, 0}, Time{1, 0}).Empty())
+	a.False(RangeIncluding(Time{1, 0}, Time{1, 1}).Empty())
+}
+
+func TestWithMin(t *testing.T) {
+	a := assert.New(t)
+
+	five := New(5, 0)
+	ten := New(10, 0)
+	twenty := New(20, 0)
+	thirty := New(30, 0)
+
+	rng := RangeIncluding(ten, twenty)
+
+	// Move minimum to lower value.
+	a.Equal(RangeIncluding(five, twenty), rng.WithMin(five))
+	// Move minimum forward within range.
+	a.Equal(RangeIncluding(ten.Next(), twenty), rng.WithMin(ten.Next()))
+	// Set min to max, should create an empty range.
+	a.Equal(RangeEmptyAt(twenty), rng.WithMin(twenty))
+	// Set min to just beyond max, should create an empty range.
+	a.Equal(RangeEmptyAt(twenty.Next()), rng.WithMin(twenty.Next()))
+	// Set min to much larger value, should create an empty range.
+	a.Equal(RangeEmptyAt(thirty), rng.WithMin(thirty))
 }
 
 func TestParse(t *testing.T) {

--- a/internal/util/hlc/range.go
+++ b/internal/util/hlc/range.go
@@ -19,8 +19,27 @@ package hlc
 import "fmt"
 
 // Range represents a half-open range of HLC values, inclusive of Min
-// and exclusive of Max.
+// and exclusive of Max. For code readability, prefer using [RangeEmpty]
+// or [RangeIncluding] to construct ranges instead of directly creating
+// a [Range].
 type Range [2]Time
+
+// RangeEmpty returns an empty range.
+func RangeEmpty() Range {
+	return Range{}
+}
+
+// RangeEmptyAt returns a Range that starts at the given time, but for
+// which [Range.Empty] will return true.
+func RangeEmptyAt(ts Time) Range {
+	return Range{ts, ts}
+}
+
+// RangeIncluding returns the smallest range that includes both the
+// start and end times.
+func RangeIncluding(start, end Time) Range {
+	return Range{start, end.Next()}
+}
 
 // Empty returns true if the Min time is greater than or equal to the
 // Max value.
@@ -32,6 +51,20 @@ func (r Range) Min() Time { return r[0] }
 // Max returns the exclusive, maximum value.
 func (r Range) Max() Time { return r[1] }
 
+// MaxInclusive returns the maximum value that is within the range. That
+// is, it returns one tick before the exclusive end bound.
+func (r Range) MaxInclusive() Time { return r[1].Before() }
+
 func (r Range) String() string {
 	return fmt.Sprintf("[ %s -> %s )", r[0], r[1])
+}
+
+// WithMin returns a new range that includes the minimum. If the new
+// minimum is equal to or beyond the end of the range, this is
+// equivalent to calling [RangeEmptyAt].
+func (r Range) WithMin(min Time) Range {
+	if Compare(min, r.Max().Before()) >= 0 {
+		return RangeEmptyAt(min)
+	}
+	return Range{min, r[1]}
 }


### PR DESCRIPTION
This PR consists of two commits.

The first commit improves the testing of the sequencer package by creating a reusable Sequencer API test case that provides more comprehensive scenario coverage. It also fixes a few bugs that were uncovered with the extra testing. The bugs are called out in the commit message.

The second commit fell out of chasing down an occasional timing/fencepost error in BestEffort when the updated progress is being calculated. The way `hlc.Range` was constructed made it difficult to reason about (hence the fencepost bug), so this change takes the previous idioms, plus-one's, etc. and puts them behind an API whose method names should be easier for the reader (and maybe even the author) to understand.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/725)
<!-- Reviewable:end -->
