### PR TITLE
cdc: Add discard mode for throughput tuning

### DIFF
--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -22,6 +22,7 @@ package cdc
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 
@@ -77,6 +78,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.WithField(
 		"path", sanitizer.Replace(r.URL.Path),
 	).Trace("request")
+
+	if h.Config.Discard {
+		_, err := io.Copy(io.Discard, r.Body)
+		sendErr(err)
+		return
+	}
 
 	req, err := h.newRequest(r)
 	if err != nil {

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -43,6 +43,7 @@ import (
 )
 
 type fixtureConfig struct {
+	discard   bool
 	immediate bool
 	script    bool
 }
@@ -88,6 +89,7 @@ func createFixture(
 
 	cfg := &Config{
 		BestEffortWindow: math.MaxInt64,
+		Discard:          htc.discard,
 		Immediate:        htc.immediate,
 		SequencerConfig: sequencer.Config{
 			RetireOffset:    time.Hour, // Enable post-hoc inspection.
@@ -489,6 +491,18 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 			body:   strings.NewReader(""),
 		}))
 	})
+}
+
+func TestDiscard(t *testing.T) {
+	a := assert.New(t)
+	fixture, _ := createFixture(t, &fixtureConfig{discard: true})
+	h := fixture.Handler
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/anything", strings.NewReader("Ignored world"))
+	h.ServeHTTP(rec, req)
+
+	a.Equal(200, rec.Code)
 }
 
 func TestRejectedAuth(t *testing.T) {


### PR DESCRIPTION
This change adds a --discard flag which will cause the CDC HTTP handler to read and ignore all incoming payloads. The intended use is to determine the maximum theoretical changefeed throughput for a given deployment. Operators can set this flag as part of load testing to find any bottlenecks in message delivery to cdc-sink.