### PR TITLE
stage: Make unapplied metrics count AOST

### DIFF
--- a/internal/staging/stage/stage.go
+++ b/internal/staging/stage/stage.go
@@ -71,11 +71,12 @@ type stage struct {
 
 	// Compute SQL fragments exactly once on startup.
 	sql struct {
-		markApplied string // Mark mutations as having been applied.
-		retire      string // Delete a batch of staged mutations.
-		stage       string // General-purpose upsert into staging table.
-		stageExists string // Stage a mutation if one already exists.
-		unapplied   string // Count stale, unapplied mutations.
+		markApplied   string // Mark mutations as having been applied.
+		retire        string // Delete a batch of staged mutations.
+		stage         string // General-purpose upsert into staging table.
+		stageExists   string // Stage a mutation if one already exists.
+		unapplied     string // Count stale, unapplied mutations.
+		unappliedAOST string // Count stale, unapplied mutations.
 	}
 }
 
@@ -160,7 +161,9 @@ CREATE INDEX IF NOT EXISTS %[1]s ON %[2]s (key) STORING (applied)
 	s.sql.retire = fmt.Sprintf(retireTemplate, table)
 	s.sql.stage = fmt.Sprintf(stageTemplate, table)
 	s.sql.stageExists = fmt.Sprintf(stageIfExistsTemplate, table)
-	s.sql.unapplied = fmt.Sprintf(countTemplate, table)
+	s.sql.unapplied = fmt.Sprintf(countTemplate, table, "")
+	s.sql.unappliedAOST = fmt.Sprintf(countTemplate, table,
+		"AS OF SYSTEM TIME follower_read_timestamp()")
 
 	// Report unapplied mutations on a periodic basis.
 	ctx.Go(func() error {
@@ -172,7 +175,7 @@ CREATE INDEX IF NOT EXISTS %[1]s ON %[2]s (key) STORING (applied)
 			// since this value may be updated at a high rate on the
 			// instance of cdc-sink that holds the resolver lease.
 			from, _ := s.retireFrom.Get()
-			ct, err := s.CountUnapplied(ctx, db, from)
+			ct, err := s.CountUnapplied(ctx, db, from, true /* AOST */)
 			if err != nil {
 				log.WithError(err).Warnf("could not count unapplied mutations for target: %s", target)
 			} else {
@@ -194,20 +197,27 @@ CREATE INDEX IF NOT EXISTS %[1]s ON %[2]s (key) STORING (applied)
 }
 
 const countTemplate = `
-SELECT count(*) FROM %s
+SELECT count(*) FROM %s %s
 WHERE (nanos, logical) < ($1, $2) AND NOT applied
 `
 
 // CountUnapplied returns the number of dangling mutations that likely
 // indicate an error condition.
 func (s *stage) CountUnapplied(
-	ctx context.Context, db types.StagingQuerier, before hlc.Time,
+	ctx context.Context, db types.StagingQuerier, before hlc.Time, aost bool,
 ) (int, error) {
+	var q string
+	if aost {
+		q = s.sql.unappliedAOST
+	} else {
+		q = s.sql.unapplied
+	}
+
 	var ret int
 	err := retry.Retry(ctx, func(ctx context.Context) error {
-		return db.QueryRow(ctx, s.sql.unapplied, before.Nanos(), before.Logical()).Scan(&ret)
+		return db.QueryRow(ctx, q, before.Nanos(), before.Logical()).Scan(&ret)
 	})
-	return ret, errors.Wrap(err, s.sql.unapplied)
+	return ret, errors.Wrap(err, q)
 }
 
 // GetTable returns the table that the stage is storing into.

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -63,7 +63,9 @@ func TestPutAndDrain(t *testing.T) {
 
 	// Not part of public API, but we want to test the metrics function.
 	ctr := s.(interface {
-		CountUnapplied(ctx context.Context, db types.StagingQuerier, before hlc.Time) (int, error)
+		CountUnapplied(
+			ctx context.Context, db types.StagingQuerier, before hlc.Time, aost bool,
+		) (int, error)
 	})
 
 	jumbledStager, err := fixture.Stagers.Get(ctx, sinktest.JumbleTable(dummyTarget))
@@ -104,8 +106,9 @@ func TestPutAndDrain(t *testing.T) {
 	r.NoError(err)
 	a.Equal(total, count)
 
-	// Verify metrics query.
-	count, err = ctr.CountUnapplied(ctx, pool, hlc.New(math.MaxInt64, 0))
+	// Verify metrics query. We can't test AOST=true since the schema
+	// change will not have taken place yet.
+	count, err = ctr.CountUnapplied(ctx, pool, hlc.New(math.MaxInt64, 0), false)
 	r.NoError(err)
 	a.Equal(total, count)
 
@@ -131,7 +134,7 @@ func TestPutAndDrain(t *testing.T) {
 	a.Equal(muts, readBack)
 
 	// Verify metrics query.
-	count, err = ctr.CountUnapplied(ctx, pool, hlc.New(math.MaxInt64, 0))
+	count, err = ctr.CountUnapplied(ctx, pool, hlc.New(math.MaxInt64, 0), false)
 	r.NoError(err)
 	a.Zero(count)
 


### PR DESCRIPTION
The monitoring query to count the number of unapplied mutations should be moved to follower reads. Otherwise, it can create contention on the staging indexes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/729)
<!-- Reviewable:end -->
