### PR TITLE
script: Use a queuing, not blocking, Promise concurrency limit

### DIFF
--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -101,7 +101,7 @@ CREATE TABLE %s.skewed_merge_times(
 	r.NoError(fixture.Watcher.Refresh(ctx, fixture.TargetPool))
 	var opts mapOptions
 
-	loader, err := ProvideLoader(fixture.Configs, &Config{
+	loader, err := ProvideLoader(ctx, fixture.Configs, &Config{
 		FS:       testData,
 		MainPath: "/testdata/main.ts",
 		Options:  &opts,

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -43,7 +43,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 	serialSerial := serial.ProvideSerial(config, leases, stagers, stagingPool, targetPool)
 	configs := fixture.Configs
 	diagnostics := fixture.Diagnostics
-	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
+	loader, err := script.ProvideLoader(context, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/cdc/server/wire_gen.go
+++ b/internal/source/cdc/server/wire_gen.go
@@ -45,7 +45,7 @@ func NewServer(ctx *stopper.Context, config *Config) (*stdserver.Server, error) 
 	}
 	cdcConfig := &config.CDC
 	scriptConfig := cdc.ProvideScriptConfig(cdcConfig)
-	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
+	loader, err := script.ProvideLoader(ctx, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 	bestEffort := besteffort.ProvideBestEffort(sequencerConfig, typesLeases, stagingPool, stagers, targetPool, watchers)
 	immediateImmediate := &immediate.Immediate{}
 	scriptConfig := cdc.ProvideScriptConfig(cdcConfig)
-	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
+	loader, err := script.ProvideLoader(context, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -61,7 +61,7 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
 	immediateImmediate := &immediate.Immediate{}
 	scriptConfig := ProvideScriptConfig(config)
-	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
+	loader, err := script.ProvideLoader(context, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -32,7 +32,7 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 		return nil, err
 	}
 	scriptConfig := &config.Script
-	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
+	loader, err := script.ProvideLoader(ctx, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -32,7 +32,7 @@ func Start(context *stopper.Context, config *Config) (*PGLogical, error) {
 		return nil, err
 	}
 	scriptConfig := &config.Script
-	loader, err := script.ProvideLoader(configs, scriptConfig, diagnostics)
+	loader, err := script.ProvideLoader(context, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/stdlogical/stdlogical.go
+++ b/internal/util/stdlogical/stdlogical.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // Register pprof handlers.
+	"runtime"
 	"runtime/debug"
 	"time"
 
@@ -39,6 +40,14 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
+
+// Since we're installing the pprof handlers, we also want to enable
+// profiling for blocking calls and mutex locking. This is a reasonable
+// rate that's also used by CockroachDB proper.
+func init() {
+	runtime.SetBlockProfileRate(1000)
+	runtime.SetMutexProfileFraction(1000)
+}
 
 // MetricsAddrFlag is a global flag that will start an HTTP server.
 const MetricsAddrFlag = "metricsAddr"

--- a/internal/util/workgroup/workgroup.go
+++ b/internal/util/workgroup/workgroup.go
@@ -1,0 +1,165 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package workgroup contains a concurrency-control utility.
+package workgroup
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const idleNanos = int64(time.Second)
+
+type callback func(context.Context)
+
+// Group is a basic concurrency-control mechanism that has a
+// variable-sized pool of worker goroutines executing callbacks from a
+// queue. Unlike an [errgroup.Group], this types does not allow awaiting
+// on outcomes of callbacks.
+//
+// A Group is safe to call from multiple goroutines. A Group should not
+// be copied once created.
+type Group struct {
+	ctx        context.Context
+	handoff    chan callback // Synchronous channel for immediate dispatch.
+	maxWorkers int
+	queue      chan callback // Buffered channel for work backlog.
+
+	mu struct {
+		sync.Mutex
+		numWorkers int
+	}
+}
+
+// WithSize returns a [Group] that will execute with up to the
+// requested number of goroutines and queue up to the requested number
+// of work elements.
+func WithSize(ctx context.Context, maxWorkers int, maxQueueDepth int) *Group {
+	return &Group{
+		ctx:        ctx,
+		handoff:    make(chan callback),
+		maxWorkers: maxWorkers,
+		queue:      make(chan callback, maxQueueDepth),
+	}
+}
+
+// Go executes the callback in a worker goroutine. If all workers have
+// been created and the queue is full, an error will be returned.
+func (g *Group) Go(fn func(ctx context.Context)) error {
+	if err := g.ctx.Err(); err != nil {
+		return err
+	}
+
+	// Synchronous handoff to a waiting worker.
+	select {
+	case g.handoff <- fn:
+		return nil
+	default:
+	}
+
+	// Warm-up case where we start a worker to handle the work unit.
+	if g.maybeStart(fn) {
+		return nil
+	}
+
+	select {
+	case g.queue <- fn:
+		// This represents an exceedingly unlikely case where all
+		// workers simultaneously selected on their idle channel and
+		// exited instead of consuming a work unit.
+		g.maybeStart(nil)
+		return nil
+	default:
+		return errors.Errorf("queue depth %d exceeded", cap(g.queue))
+	}
+}
+
+// Len returns the number of queued work items.
+func (g *Group) Len() int {
+	return len(g.queue)
+}
+
+// maybeStart will return true if started a worker goroutine that is
+// guaranteed to execute the callback.
+func (g *Group) maybeStart(fn callback) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.mu.numWorkers >= g.maxWorkers {
+		return false
+	}
+	g.mu.numWorkers++
+
+	// If we start a worker, we want to know that the initiating
+	// callback will be executed by the worker. This lends
+	// predictability to the number of times Go can be called before
+	// it will start returning errors.
+	go g.worker(g.ctx, fn)
+	return true
+}
+
+func (g *Group) worker(ctx context.Context, initial callback) {
+	defer func() {
+		g.mu.Lock()
+		g.mu.numWorkers--
+		g.mu.Unlock()
+
+		// When a worker exits, we want to ensure that a replacement
+		// worker will be available to pick up any leftover work that
+		// this worker could have picked up.
+		if len(g.queue) > 0 && ctx.Err() == nil {
+			g.maybeStart(nil)
+		}
+	}()
+
+	if initial != nil {
+		initial(ctx)
+		initial = nil
+	}
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		// Reset timer and smear timeout behaviors.
+		if !timer.Stop() {
+			<-timer.C
+		}
+		timer.Reset(time.Duration(idleNanos + rand.Int63n(idleNanos)))
+
+		select {
+		case next := <-g.handoff:
+			// Execute the next work unit from a synchronous handoff.
+			next(ctx)
+
+		case next := <-g.queue:
+			// Execute the next work unit out of the backlog.
+			next(ctx)
+
+		case <-timer.C:
+			// If we've been idle for a while, shed goroutines.
+			return
+
+		case <-ctx.Done():
+			// Time to shut down.
+			return
+		}
+	}
+}

--- a/internal/util/workgroup/workgroup_test.go
+++ b/internal/util/workgroup/workgroup_test.go
@@ -1,0 +1,135 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workgroup
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkGroup(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	block := make(chan struct{})
+
+	const workers = 16
+	const depth = 32
+
+	var calls notify.Var[int]
+	wg := WithSize(ctx, workers, depth)
+
+	// Ensure we can start the expected number of workers and add
+	// additional elements to the queue.
+	for i := 0; i < workers+depth; i++ {
+		r.NoError(wg.Go(func(ctx context.Context) {
+			select {
+			case <-block:
+				_, _, _ = calls.Update(func(old int) (int, error) {
+					return old + 1, nil
+				})
+			case <-ctx.Done():
+			}
+		}))
+	}
+
+	// Ensure all workers were started.
+	wg.mu.Lock()
+	count := wg.mu.numWorkers
+	wg.mu.Unlock()
+	r.Equal(workers, count)
+
+	// Ensure queue is full.
+	r.Equal(depth, wg.Len())
+
+	// Check we can't add any more work.
+	r.ErrorContains(wg.Go(func(ctx context.Context) {}),
+		fmt.Sprintf("queue depth %d exceeded", depth))
+
+	// Allow workers to drain.
+	close(block)
+
+	// Wait for backlog to be processed.
+	for {
+		count, changed := calls.Get()
+		if count == workers+depth {
+			break
+		}
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			r.NoError(ctx.Err())
+		}
+	}
+
+	// Test synchronous handoff to the now-warmed-up worker pool.
+	for i := 0; i < workers; i++ {
+		r.NoError(wg.Go(func(ctx context.Context) {
+			select {
+			case <-block:
+				_, _, _ = calls.Update(func(old int) (int, error) {
+					return old + 1, nil
+				})
+			case <-ctx.Done():
+			}
+		}))
+	}
+
+	// Wait for backlog to be processed.
+	for {
+		count, changed := calls.Get()
+		if count == 2*workers+depth {
+			break
+		}
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			r.NoError(ctx.Err())
+		}
+	}
+
+	// Crash all workers.
+	for i := 0; i < workers; i++ {
+		r.NoError(wg.Go(func(ctx context.Context) {
+			runtime.Goexit()
+		}))
+	}
+
+	// Ensure we can recover from worker-pool failure.
+	restored := make(chan struct{})
+	r.NoError(wg.Go(func(ctx context.Context) {
+		close(restored)
+	}))
+
+	select {
+	case <-restored:
+	// Success.
+	case <-ctx.Done():
+		r.NoError(ctx.Err())
+	}
+
+	// Verify cancellation behavior.
+	cancel()
+	r.ErrorIs(wg.Go(nil), context.Canceled)
+}


### PR DESCRIPTION
The userscript limits the number of concurrently-executing promise goroutines
to prevent accidental resource exhaustion. The current implementation uses an
`errgroup.Group` with a limit. However, this can create a deadlock situation
where `execTrackedPromise` blocks on the call to `Go()`. Since promises are
being constructed while already in `execTrackedJS()`, we can wind up with a
deadlock situation where other promise resolutions are waiting to enter the
userscript mutex.

This change adds a simple workerpool implementation which provides an upper
bound on the number of worker goroutines and the maximum number of pending
tasks.

The stdlogical package, which installs the global pprof handlers, now also
sets a reasonable default for block and mutex profiling.

Fixes #730

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/731)
<!-- Reviewable:end -->
