### PR TITLE
Correctly merge time.Time or other complex types

### DIFF
--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
+	"github.com/cockroachdb/cdc-sink/internal/util/crep"
 	"github.com/cockroachdb/cdc-sink/internal/util/diag"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
@@ -44,7 +45,7 @@ import (
 //
 // [ pk0, pk1, ..., pkN ] => [ pk0, pkN, ... ]
 type deleteKeyJS func(
-	key []any,
+	key []crep.Value,
 	meta map[string]any,
 ) ([]any, error)
 
@@ -54,7 +55,7 @@ type deleteKeyJS func(
 //
 //	{ doc } => { "target" : [ { doc }, ... ], "otherTarget" : [ { doc }, ... ], ... }
 type dispatchJS func(
-	doc map[string]any,
+	doc map[string]crep.Value,
 	meta map[string]any,
 ) (map[string][]map[string]any, error)
 
@@ -62,7 +63,7 @@ type dispatchJS func(
 //
 //	{ doc } => { doc }
 type mapJS func(
-	doc map[string]any,
+	doc map[string]crep.Value,
 	meta map[string]any,
 ) (map[string]any, error)
 

--- a/internal/script/safe_value.go
+++ b/internal/script/safe_value.go
@@ -17,13 +17,8 @@
 package script
 
 import (
-	"bytes"
-	"encoding/json"
-	"strconv"
-	"time"
-
+	"github.com/cockroachdb/cdc-sink/internal/util/crep"
 	"github.com/dop251/goja"
-	"github.com/pkg/errors"
 )
 
 // The maximum safe numeric value in JavaScript.
@@ -40,140 +35,12 @@ const maxInt = 1 << 53
 // Goja does not, yet, have builtin support for BigInt. If and when this
 // happens, we should revisit this code to emit the numbers as such.
 func safeValue(rt *goja.Runtime, value any) (goja.Value, error) {
-	// This should cover the 80% use case of values returned from a
-	// database query.
-	var buf []byte
-	switch t := value.(type) {
-	case goja.Value:
-		return t, nil
-
-	case nil:
-		return goja.Null(), nil
-
-	case bool, string:
-		return rt.ToValue(t), nil
-
-	case int:
-		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
-	case int8:
-		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
-	case int16:
-		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
-	case int32:
-		return rt.ToValue(strconv.FormatInt(int64(t), 10)), nil
-	case int64:
-		return rt.ToValue(strconv.FormatInt(t, 10)), nil
-
-	case uint:
-		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
-	case uint8:
-		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
-	case uint16:
-		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
-	case uint32:
-		return rt.ToValue(strconv.FormatUint(uint64(t), 10)), nil
-	case uint64:
-		return rt.ToValue(strconv.FormatUint(t, 10)), nil
-
-	case float32:
-		return rt.ToValue(strconv.FormatFloat(float64(t), 'f', -1, 32)), nil
-	case float64:
-		return rt.ToValue(strconv.FormatFloat(t, 'f', -1, 64)), nil
-
-	case time.Time:
-		// Very common case and we can encode to our desired format.
-		return rt.ToValue(t.UTC().Format(time.RFC3339Nano)), nil
-
-	case json.RawMessage:
-		// Parse raw message as-is.
-		buf = t
-
-	case []byte:
-		// Parse raw message as-is.
-		buf = t
-
-	default:
-		// Marshal other random types.
-		var err error
-		buf, err = json.Marshal(value)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
+	if jsVal, ok := value.(goja.Value); ok {
+		return jsVal, nil
 	}
-
-	// Use our number-preserving unmarshal function.
-top:
-	switch buf[0] {
-	case 0x20, 0x0D, 0x0A, 0x09:
-		// Whitespace constants per JSON spec.
-		buf = buf[1:]
-		if len(buf) == 0 {
-			return nil, errors.New("only whitespace in input")
-		}
-		goto top
-
-	case '{':
-		m := make(map[string]any)
-		if err := unmarshal(buf, &m); err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return rt.ToValue(m), nil
-
-	case '[':
-		var arr []any
-		if err := unmarshal(buf, &arr); err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return rt.ToValue(arr), nil
-
-	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
-		var n json.Number
-		if err := unmarshal(buf, &n); err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return rt.ToValue(n.String()), nil
-
-	case 'f':
-		return rt.ToValue(false), nil
-
-	case 't':
-		return rt.ToValue(true), nil
-
-	case 'n':
-		return goja.Null(), nil
-
-	default:
-		// We're going to call the JSON.parse function within the
-		// runtime. This seems to be the least-worst way to re-parse
-		// strings and any quoted characters therein.
-		var ret goja.Value
-		if err := rt.Try(func() {
-			jsonObj := rt.GlobalObject().Get("JSON").(*goja.Object)
-			parse := jsonObj.Get("parse").Export().(func(call goja.FunctionCall) goja.Value)
-			ret = parse(goja.FunctionCall{
-				Arguments: []goja.Value{
-					rt.ToValue(string(buf)),
-				},
-			})
-		}); err != nil {
-			return nil, err
-		}
-		return ret, nil
-	}
-}
-
-// unmarshal should be used instead of [json.Unmarshal] to ensure that
-// numeric types are decoded with minimum loss of precision.
-func unmarshal(data []byte, v any) error {
-	reader := bytes.NewReader(data)
-	dec := json.NewDecoder(reader)
-	dec.UseNumber()
-	err := dec.Decode(v)
+	canon, err := crep.Canonical(value)
 	if err != nil {
-		return errors.WithStack(err)
+		return nil, err
 	}
-	if dec.More() {
-		return errors.New("invalid JSON input")
-	}
-	return nil
+	return rt.ToValue(canon), nil
 }

--- a/internal/script/safe_value_test.go
+++ b/internal/script/safe_value_test.go
@@ -131,7 +131,7 @@ func TestSafeValue(t *testing.T) {
 		},
 		{
 			input:      []any{now, now},
-			exportType: "[]interface {}",
+			exportType: "[]crep.Value",
 			jsString:   "2024-02-23T23:39:22.135Z,2024-02-23T23:39:22.135Z",
 		},
 		{
@@ -175,7 +175,7 @@ func TestSafeValue(t *testing.T) {
 		},
 		{
 			input:      json.RawMessage(`{"BigInt":9007199254740995}`),
-			exportType: "map[string]interface {}",
+			exportType: "map[string]crep.Value",
 			jsString:   "[object Object]",
 			test: func(a *assert.Assertions, value goja.Value) {
 				obj := value.(*goja.Object)
@@ -184,7 +184,7 @@ func TestSafeValue(t *testing.T) {
 		},
 		{
 			input:      json.RawMessage(`[9007199254740995]`),
-			exportType: "[]interface {}",
+			exportType: "[]crep.Value",
 			jsString:   "9007199254740995",
 			test: func(a *assert.Assertions, value goja.Value) {
 				obj := value.(*goja.Object)

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -221,7 +221,7 @@ CREATE TABLE %s.skewed_merge_times(
 			mut, keep, err := filter(context.Background(), types.Mutation{Key: []byte(`[ 1, 2 ]`)})
 			a.NoError(err)
 			a.True(keep)
-			a.Equal(json.RawMessage(`[2,1]`), mut.Key)
+			a.Equal(json.RawMessage(`["2","1"]`), mut.Key)
 		}
 	}
 

--- a/internal/util/crep/crep.go
+++ b/internal/util/crep/crep.go
@@ -1,0 +1,276 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package crep ("see-rep") contains a utility for producing a Canonical
+// REPresentation of a value type.
+package crep
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// A Value is one of:
+//   - nil
+//   - string
+//   - bool
+//   - []Value
+//   - map[string]Value
+type Value any
+
+// Canonical returns a canonical, JSON-esque representation of an input
+// value. The values returned by this function will, in general, agree
+// with the changefeed encoding for that value type. Furthermore,
+// numbers will be converted to a string representation, so that they
+// may be presented to the script runtime without loss of precision.
+func Canonical(value any) (Value, error) {
+	// This should cover the 80% use case of values returned from a
+	// database query.
+	var buf []byte
+	switch t := value.(type) {
+
+	case nil:
+		return nil, nil
+
+	case bool, string:
+		return t, nil
+
+	case int:
+		return strconv.FormatInt(int64(t), 10), nil
+	case int8:
+		return strconv.FormatInt(int64(t), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(t), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(t), 10), nil
+	case int64:
+		return strconv.FormatInt(t, 10), nil
+
+	case uint:
+		return strconv.FormatUint(uint64(t), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(t), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(t), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(t), 10), nil
+	case uint64:
+		return strconv.FormatUint(t, 10), nil
+
+	case float32:
+		return strconv.FormatFloat(float64(t), 'f', -1, 32), nil
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), nil
+
+	case time.Time:
+		// Very common case and we can encode to our desired format.
+		return t.UTC().Format(time.RFC3339Nano), nil
+
+	case json.RawMessage:
+		// Parse raw message as-is.
+		buf = t
+
+	case []byte:
+		// Parse raw message as-is.
+		buf = t
+
+	default:
+		// Marshal other random types.
+		var err error
+		buf, err = json.Marshal(t)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
+	return Unmarshal(buf)
+}
+
+// Unmarshal should be used instead of [json.Unmarshal] to ensure that
+// numeric types are decoded with minimum loss of precision.
+func Unmarshal(data []byte) (Value, error) {
+	reader := bytes.NewReader(data)
+	dec := json.NewDecoder(reader)
+	dec.UseNumber()
+
+	ret, err := (&decoder{source: dec}).Decode()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if dec.More() {
+		return nil, errors.New("invalid JSON input")
+	}
+	return ret, nil
+}
+
+// decoder interprets a JSON token stream, replacing any [json.Number]
+// values that we encounter with a string.
+type decoder struct {
+	source *json.Decoder
+
+	arrStack []*[]any
+	objStack []*map[string]any
+	valStack []any
+}
+
+// Decode returns a reified form of the next value in the JSON token
+// stream.
+func (d *decoder) Decode() (any, error) {
+	for {
+		token, err := d.source.Token()
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("unexpected EOF")
+		} else if err != nil {
+			return nil, errors.Wrapf(err, "offset %d", d.source.InputOffset())
+		}
+
+		// Simple values are pushed directly onto the value stack.
+		switch t := token.(type) {
+		case nil:
+			d.valStack = append(d.valStack, nil)
+		case bool:
+			d.valStack = append(d.valStack, t)
+		case string:
+			d.valStack = append(d.valStack, t)
+		case json.Number:
+			d.valStack = append(d.valStack, t.String())
+		case float64:
+			return nil, errors.Errorf("call UseNumber() on underlying decoder")
+
+		case json.Delim:
+			// Token will have already handled delimiter matching, so
+			// we're guaranteed to get structurally sound JSON input.
+			switch t {
+			case '[':
+				// When we see an opening delimiter, we'll push a
+				// pointer to the enclosing accumulator (a map or a
+				// slice) onto both the value stack and a separate
+				// accumulator-specific stack.
+				var arr []any
+				ptr := &arr
+				d.arrStack = append(d.arrStack, ptr)
+				d.valStack = append(d.valStack, ptr)
+				continue
+
+			case '{':
+				// As above. While a map is a pointer type, it is not a
+				// comparable type, so we still need a pointer to know
+				// when we're done popping values.
+				obj := make(map[string]any)
+				ptr := &obj
+				d.objStack = append(d.objStack, ptr)
+				d.valStack = append(d.valStack, ptr)
+				continue
+
+			case ']':
+				// When we see a closing delimiter, we'll pop the
+				// relevant pointer from the type-specific accumulator
+				// stack. We'll consume elements from the value stack
+				// until encountering the accumulator on the value
+				// stack. Once we see the accumulator on the value
+				// stack, we know we can stop consuming values.
+				accumulator := d.popArrPtr()
+			accumulateArr:
+				for {
+					if ptr, ok := d.topValMayBePointer().(*[]any); ok && accumulator == ptr {
+						// We're accumulating the values in a LIFO
+						// order, so we need to reverse the slice. We'll
+						// do this by walking from both ends until the
+						// two indexes meet in the middle. This also
+						// handles the empty or singleton case since j
+						// will either be -1 or 0, respectively, which
+						// is not greater than i=0.
+						for i, j := 0, len(*accumulator)-1; i < j; i, j = i+1, j-1 {
+							(*accumulator)[i], (*accumulator)[j] =
+								(*accumulator)[j], (*accumulator)[i]
+						}
+						break accumulateArr
+					}
+					*accumulator = append(*accumulator, d.popValActual())
+				}
+
+			case '}':
+				// As above, although we don't need to worry about the
+				// order of keys in a map.
+				accumulator := d.popObjPtr()
+			accumulateObj:
+				for {
+					if m, ok := d.topValMayBePointer().(*map[string]any); ok && accumulator == m {
+						break accumulateObj
+					}
+					val := d.popValActual()
+					key := d.popValActual().(string)
+					(*accumulator)[key] = val
+				}
+
+			default:
+				return nil, errors.Errorf("unexpected delimiter: %s", string(t))
+			}
+
+		default:
+			return nil, errors.Errorf("unexpected token type %T", t)
+		}
+
+		if len(d.valStack) == 1 {
+			return d.popValActual(), nil
+		}
+	}
+}
+
+// popArrPtr pops the top array accumulator pointer from the stack.
+func (d *decoder) popArrPtr() *[]any {
+	idx := len(d.arrStack) - 1
+	ret := d.arrStack[idx]
+	d.arrStack = d.arrStack[:idx]
+	return ret
+}
+
+// popObjPtr pops the top object accumulator pointer from the stack.
+func (d *decoder) popObjPtr() *map[string]any {
+	idx := len(d.objStack) - 1
+	ret := d.objStack[idx]
+	d.objStack = d.objStack[:idx]
+	return ret
+}
+
+// popValActual pops the top value from the value stack. If the top
+// value is a pointer to an accumulator (slice or map), we'll
+// dereference the pointer and return the underlying accumulator.
+func (d *decoder) popValActual() any {
+	idx := len(d.valStack) - 1
+	ret := d.valStack[idx]
+	d.valStack = d.valStack[:idx]
+	switch t := ret.(type) {
+	case *[]any:
+		return *t
+	case *map[string]any:
+		return *t
+	default:
+		return t
+	}
+}
+
+// topValMayBePointer returns the top-most value in the value stack.
+// This might be a pointer to an accumulator, so the value is not useful
+// other than to see if we're about to exit a collection type.
+func (d *decoder) topValMayBePointer() any {
+	return d.valStack[len(d.valStack)-1]
+}

--- a/internal/util/crep/crep_test.go
+++ b/internal/util/crep/crep_test.go
@@ -134,8 +134,8 @@ func TestCanonical(t *testing.T) {
 		},
 		{
 			input:      []any{now, now},
-			exportType: "[]interface {}",
-			expected:   []any{"2024-02-23T23:39:22.135Z", "2024-02-23T23:39:22.135Z"},
+			exportType: "[]crep.Value",
+			expected:   []Value{"2024-02-23T23:39:22.135Z", "2024-02-23T23:39:22.135Z"},
 		},
 		{
 			input:      float32(3.141592),
@@ -188,14 +188,14 @@ func TestCanonical(t *testing.T) {
   "Null": null
 }
 }`),
-			exportType: "map[string]interface {}",
-			expected: map[string]any{
+			exportType: "map[string]crep.Value",
+			expected: map[string]Value{
 				"BigFloat": "9007199254740995.98765",
 				"BigInt":   "9007199254740995",
-				"Embedded": map[string]any{
-					"Baz":      []any{"1", "2", "3"},
-					"EmptyArr": []any(nil),
-					"EmptyObj": map[string]any{},
+				"Embedded": map[string]Value{
+					"Baz":      []Value{"1", "2", "3"},
+					"EmptyArr": []Value(nil),
+					"EmptyObj": map[string]Value{},
 					"Foo":      "Bar",
 					"Null":     nil,
 				},
@@ -203,8 +203,8 @@ func TestCanonical(t *testing.T) {
 		},
 		{
 			input:      json.RawMessage(`[9007199254740995]`),
-			exportType: "[]interface {}",
-			expected:   []any{"9007199254740995"},
+			exportType: "[]crep.Value",
+			expected:   []Value{"9007199254740995"},
 		},
 		{
 			input: json.RawMessage(`     `),
@@ -222,7 +222,7 @@ func TestCanonical(t *testing.T) {
 		{
 			// Test mismatched delimiter.
 			input: json.RawMessage(`[1,2, { "foo": "bar" ] ]`),
-			err:   "invalid character ']' after object key:value pair",
+			err:   "offset 21: invalid character ']' after object key:value pair",
 		},
 	}
 

--- a/internal/util/crep/equal.go
+++ b/internal/util/crep/equal.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package crep
+
+import "github.com/pkg/errors"
+
+// Equal returns true if the two values are canonically equal. Two
+// values are equal if their Canonical representations are equal.
+func Equal(a, b any) (bool, error) {
+	// Equal is almost always going to be called on  a leaf value like a
+	// string-ish or an object. For leaf values, the Canonical function
+	// will have a type-switching fast-path; we'll get a comparable in
+	// short order. For objects, however, we have to accumulate all,
+	// unordered, key-value pairs in order to be able to make a
+	// comparison, or at least decompose one of the objects. At that
+	// point, we may as well just implement a walker over the
+	// fully-cooked, canonical values.
+	aVal, err := Canonical(a)
+	if err != nil {
+		return false, err
+	}
+	bVal, err := Canonical(b)
+	if err != nil {
+		return false, err
+	}
+	return equal(aVal, bVal), nil
+}
+
+func equal(aVal, bVal Value) bool {
+	switch ta := aVal.(type) {
+	case nil:
+		return bVal == nil
+
+	case bool:
+		tb, ok := bVal.(bool)
+		return ok && ta == tb
+
+	case string:
+		tb, ok := bVal.(string)
+		return ok && ta == tb
+
+	case []Value:
+		tb, ok := bVal.([]Value)
+		if !ok || len(ta) != len(tb) {
+			return false
+		}
+		for i := range ta {
+			if !equal(ta[i], tb[i]) {
+				return false
+			}
+		}
+		return true
+
+	case map[string]Value:
+		tb, ok := bVal.(map[string]Value)
+		if !ok || len(ta) != len(tb) {
+			return false
+		}
+		for key, aElt := range ta {
+			bElt, ok := tb[key]
+			if !ok {
+				return false
+			}
+			if !equal(aElt, bElt) {
+				return false
+			}
+		}
+		return true
+
+	default:
+		// This would only get hit if Canonical starts returning
+		// additional value types.
+		panic(errors.Errorf("unexpected Value type: %T", ta))
+	}
+}

--- a/internal/util/crep/equal_test.go
+++ b/internal/util/crep/equal_test.go
@@ -1,0 +1,185 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package crep
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqual(t *testing.T) {
+	tcs := []struct {
+		a, b  any
+		equal bool
+		err   string
+	}{
+		{
+			a:     nil,
+			b:     nil,
+			equal: true,
+		},
+		{
+			a:     true,
+			b:     true,
+			equal: true,
+		},
+		{
+			a:     false,
+			b:     true,
+			equal: false,
+		},
+		{
+			a:     "hello",
+			b:     "hello",
+			equal: true,
+		},
+		{
+			// Bool and string are separate types.
+			a:     true,
+			b:     "true",
+			equal: false,
+		},
+		{
+			// Numbers canonicalize to strings.
+			a:     1,
+			b:     "1",
+			equal: true,
+		},
+		{
+			a:     1,
+			b:     "01",
+			equal: false,
+		},
+		{
+			// Time canonicalize to strings.
+			a:     "2024-02-23T23:39:22.135Z",
+			b:     time.UnixMilli(1708731562135).UTC(),
+			equal: true,
+		},
+		{
+			// Key order does not matter.
+			a: json.RawMessage(`{
+"Foo": 1,
+"Bar": 2
+}`),
+			b: json.RawMessage(`{
+"Bar": 2,
+"Foo": 1
+}`),
+			equal: true,
+		},
+		{
+			// Differing value
+			a: json.RawMessage(`{
+"Foo": 1
+}`),
+			b: json.RawMessage(`{
+"Foo": 2
+}`),
+			equal: false,
+		},
+		{
+			// Mismatch in keys
+			a: json.RawMessage(`{
+"Foo": 1
+}`),
+			b: json.RawMessage(`{
+"Bar": 1
+}`),
+			equal: false,
+		},
+		{
+			// Mismatch in number of keys.
+			a: json.RawMessage(`{
+"Foo": 1,
+"Bar": 2
+}`),
+			b: json.RawMessage(`{
+"Bar": 2,
+"Foo": 1,
+"Quux": false
+}`),
+			equal: false,
+		},
+		{
+			// Simple array case.
+			a:     json.RawMessage(`[ 1 , 2 , 3 ]`),
+			b:     json.RawMessage(`[ 1 , 2 , 3 ]`),
+			equal: true,
+		},
+		{
+			// Element mismatch.
+			a:     json.RawMessage(`[ 3 , 2 , 1 ]`),
+			b:     json.RawMessage(`[ 1 , 2 , 3 ]`),
+			equal: false,
+		},
+		{
+			// Length mismatch.
+			a:     json.RawMessage(`[ 1 , 2 ]`),
+			b:     json.RawMessage(`[ 1 , 2 , 3 ]`),
+			equal: false,
+		},
+		{
+			// Bad parse in A.
+			a:   json.RawMessage(`[ 1 , 2 `),
+			b:   json.RawMessage(`[ 1 , 2 , 3 ]`),
+			err: "unexpected EOF",
+		},
+		{
+			// Bad parse in B.
+			a:   json.RawMessage(`[ 1 , 2 ]`),
+			b:   json.RawMessage(`[ 1 , 2 , 3 `),
+			err: "unexpected EOF",
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			a := assert.New(t)
+
+			if tc.err != "" {
+				_, err := Equal(tc.a, tc.b)
+				a.ErrorContains(err, tc.err)
+				return
+			}
+
+			// Base case.
+			if eq, err := Equal(tc.a, tc.b); a.NoError(err) {
+				a.Equal(tc.equal, eq)
+			}
+
+			// Symmetry case.
+			if eq, err := Equal(tc.b, tc.a); a.NoError(err) {
+				a.Equal(tc.equal, eq)
+			}
+
+			// Reflexive A case.
+			if eq, err := Equal(tc.a, tc.a); a.NoError(err) {
+				a.True(eq)
+			}
+
+			// Reflexive B case.
+			if eq, err := Equal(tc.b, tc.b); a.NoError(err) {
+				a.True(eq)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR contains three commits. The first extracts the value-canonicalization code from the script package into a new package. The second expands upon the first by adding an equality comparison and updating the standard merge function. The third commit is the test that was written first to prove out the other commits.

See #732 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/735)
<!-- Reviewable:end -->
