### PR TITLE
source: Defer configuration preflight until script has loaded

### DIFF
--- a/internal/source/cdc/server/injector_test.go
+++ b/internal/source/cdc/server/injector_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"fmt"
+	"testing"
+	"testing/fstest"
+
+	"github.com/cockroachdb/cdc-sink/internal/script"
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
+	"github.com/cockroachdb/cdc-sink/internal/source/cdc"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// This test ensures that the database pools can be configured via
+// the script API.
+func TestScriptConfigureTarget(t *testing.T) {
+	r := require.New(t)
+
+	fixture, err := base.NewFixture(t)
+	r.NoError(err)
+
+	tsFile := fmt.Sprintf(`
+import * as api from "cdc-sink@v1";
+api.setOptions({
+  "bindAddr": "127.0.0.1:0",
+  "stagingSchema": %q,
+  "targetConn": %q
+});
+`,
+		// We'll use the staging schema since it's always CRDB.
+		fixture.StagingDB.Idents(nil)[0].Raw(),
+		fixture.StagingPool.ConnectionString,
+	)
+
+	cfg := &Config{
+		CDC: cdc.Config{
+			ScriptConfig: script.Config{
+				MainPath: "/main.ts",
+				FS:       fstest.MapFS{"main.ts": &fstest.MapFile{Data: []byte(tsFile)}},
+			},
+		},
+	}
+	cfg.Bind(pflag.NewFlagSet("testing", pflag.ContinueOnError))
+
+	_, err = NewServer(fixture.Context, cfg)
+	r.NoError(err)
+}

--- a/internal/source/cdc/server/provider.go
+++ b/internal/source/cdc/server/provider.go
@@ -57,9 +57,9 @@ func ProvideAuthenticator(
 }
 
 // ProvideEagerConfig makes the configuration objects depend upon the
-// script loader.
-func ProvideEagerConfig(cfg *Config, _ *script.Loader) *EagerConfig {
-	return (*EagerConfig)(cfg)
+// script loader and preflights the configuration.
+func ProvideEagerConfig(cfg *Config, _ *script.Loader) (*EagerConfig, error) {
+	return (*EagerConfig)(cfg), cfg.Preflight()
 }
 
 // ProvideListener is called by Wire to construct the incoming network

--- a/internal/source/cdc/server/wire_gen.go
+++ b/internal/source/cdc/server/wire_gen.go
@@ -49,7 +49,10 @@ func NewServer(ctx *stopper.Context, config *Config) (*stdserver.Server, error) 
 	if err != nil {
 		return nil, err
 	}
-	eagerConfig := ProvideEagerConfig(config, loader)
+	eagerConfig, err := ProvideEagerConfig(config, loader)
+	if err != nil {
+		return nil, err
+	}
 	stagingConfig := &eagerConfig.Staging
 	targetConfig := &eagerConfig.Target
 	stagingPool, err := sinkprod.ProvideStagingPool(ctx, stagingConfig, diagnostics, targetConfig)

--- a/internal/source/mylogical/provider.go
+++ b/internal/source/mylogical/provider.go
@@ -111,7 +111,7 @@ func ProvideConn(
 
 // ProvideEagerConfig is a hack to move up the evaluation of the user
 // script so that the options callbacks can set any non-script-related
-// CLI flags.
-func ProvideEagerConfig(cfg *Config, _ *script.Loader) *EagerConfig {
-	return (*EagerConfig)(cfg)
+// CLI flags. The configuration will be preflighted.
+func ProvideEagerConfig(cfg *Config, _ *script.Loader) (*EagerConfig, error) {
+	return (*EagerConfig)(cfg), cfg.Preflight()
 }

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -36,7 +36,10 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 	if err != nil {
 		return nil, err
 	}
-	eagerConfig := ProvideEagerConfig(config, loader)
+	eagerConfig, err := ProvideEagerConfig(config, loader)
+	if err != nil {
+		return nil, err
+	}
 	targetConfig := &eagerConfig.Target
 	targetPool, err := sinkprod.ProvideTargetPool(ctx, targetConfig, diagnostics)
 	if err != nil {

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -142,7 +142,7 @@ func ProvideConn(
 
 // ProvideEagerConfig is a hack to move up the evaluation of the user
 // script so that the options callbacks can set any non-script-related
-// CLI flags.
-func ProvideEagerConfig(cfg *Config, _ *scriptRT.Loader) *EagerConfig {
-	return (*EagerConfig)(cfg)
+// CLI flags. The configuration will be preflighted.
+func ProvideEagerConfig(cfg *Config, _ *scriptRT.Loader) (*EagerConfig, error) {
+	return (*EagerConfig)(cfg), cfg.Preflight()
 }

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -36,7 +36,10 @@ func Start(context *stopper.Context, config *Config) (*PGLogical, error) {
 	if err != nil {
 		return nil, err
 	}
-	eagerConfig := ProvideEagerConfig(config, loader)
+	eagerConfig, err := ProvideEagerConfig(config, loader)
+	if err != nil {
+		return nil, err
+	}
 	targetConfig := &eagerConfig.Target
 	targetPool, err := sinkprod.ProvideTargetPool(context, targetConfig, diagnostics)
 	if err != nil {

--- a/internal/util/stdlogical/stdlogical.go
+++ b/internal/util/stdlogical/stdlogical.go
@@ -55,7 +55,6 @@ const MetricsAddrFlag = "metricsAddr"
 // Config is our standard protocol for configuration objects.
 type Config interface {
 	Bind(set *pflag.FlagSet)
-	Preflight() error
 }
 
 // HasAuthenticator allows the object to supply a [types.Authenticator].
@@ -107,13 +106,6 @@ func New(t *Template) *cobra.Command {
 					info[s.Key] = s.Value
 				}
 				log.WithFields(info).Info("cdc-sink starting")
-			}
-
-			// Validate configuration.
-			if t.Config != nil {
-				if err := t.Config.Preflight(); err != nil {
-					return err
-				}
 			}
 
 			// Delegate startup. main.go provides a stopper.


### PR DESCRIPTION
This change moves configuration preflighting out of stdlogical and into the Wire injector. This restores the previous behavior of allowing the userscript to drive all CLI options (e.g. `--targetConn`).

Fixes #733

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/738)
<!-- Reviewable:end -->
