### PR TITLE
workflow: Test CockroachDB v23.2

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     image: cockroachdb/cockroach:latest-v23.1
     network_mode: host
     command: start-single-node --insecure --store type=mem,size=2G
+  cockroachdb-v23.2:
+    image: cockroachdb/cockroach:latest-v23.2
+    network_mode: host
+    command: start-single-node --insecure --store type=mem,size=2G
 
   # These two services are used for testing split-mode operations. We
   # need to bypass the usual entry-point script because it has a check
@@ -58,13 +62,13 @@ services:
   # default port.
   #
   # https://github.com/cockroachdb/cockroach/issues/84166
-  source-cockroachdb-v23.1:
-    image: cockroachdb/cockroach:latest-v23.1
+  source-cockroachdb-v23.2:
+    image: cockroachdb/cockroach:latest-v23.2
     network_mode: host
     entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
-  target-cockroachdb-v23.1:
-    image: cockroachdb/cockroach:latest-v23.1
+  target-cockroachdb-v23.2:
+    image: cockroachdb/cockroach:latest-v23.2
     network_mode: host
     entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5401 --http-addr :8082

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -90,62 +90,63 @@ jobs:
           - cockroachdb: v22.1
           - cockroachdb: v22.2
           - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: mysql-v8
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: mysql-v5.6
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: mysql-v5.7
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: mysql-mariadb-v10
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: postgresql-v11
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: postgresql-v12
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: postgresql-v13
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: postgresql-v14
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             integration: postgresql-v15
           # Run a test with a separate CockroachDB source and target
           # instance to ensure there are no accidental dependencies
           # between the source, staging, and target schemas.
-          - cockroachdb: v23.1
-            source: source-cockroachdb-v23.1
+          - cockroachdb: v23.2
+            source: source-cockroachdb-v23.2
             sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
-            target: target-cockroachdb-v23.1
+            target: target-cockroachdb-v23.2
             targetConn: "postgresql://root@127.0.0.1:5401/defaultdb?sslmode=disable"
             # The Oracle 18 image doesn't come with a pre-built database, we need to do more work
             # to allow this image to boot up fast enough for use in tests.
-#          - cockroachdb: v23.1
+#          - cockroachdb: v23.2
 #            target: oracle-v18.4
 #            targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: oracle-v21.3
             targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
 
           # Test CRDB -> PostgreSQL for migration backfill use cases.
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: postgresql-v11
             targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: postgresql-v12
             targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: postgresql-v13
             targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: postgresql-v14
             targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: postgresql-v15
             targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
           # Test CRDB -> MySQL for migration backfill use cases.
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: mysql-v8
             targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql?sslmode=require"
           # Test CRDB -> MariaDB for migration backfill use cases.
-          - cockroachdb: v23.1
+          - cockroachdb: v23.2
             target: mysql-mariadb-v10
             targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql"
 


### PR DESCRIPTION
This promotes v23.2 to be the primary version tested. A v23.1-only test is added to ensure ongoing compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/739)
<!-- Reviewable:end -->
