### PR TITLE
sequencer: Use a common lockset for concurrent sequencers

### DIFF
--- a/internal/cmd/preflight/preflight.go
+++ b/internal/cmd/preflight/preflight.go
@@ -77,7 +77,7 @@ func testTargetConnection(ctx *stopper.Context, connString string) error {
 	pool, err := stdpool.OpenTarget(
 		ctx,
 		connString,
-		stdpool.WithConnectionLifetime(5*time.Minute),
+		stdpool.WithConnectionLifetime(5*time.Minute, time.Minute, 15*time.Second),
 		stdpool.WithTransactionTimeout(time.Minute),
 	)
 	if err != nil {
@@ -133,7 +133,7 @@ func testStagingConnection(ctx *stopper.Context, connString string) error {
 	pool, err := stdpool.OpenPgxAsStaging(
 		ctx,
 		connString,
-		stdpool.WithConnectionLifetime(5*time.Minute),
+		stdpool.WithConnectionLifetime(5*time.Minute, time.Minute, 15*time.Second),
 		stdpool.WithTransactionTimeout(time.Minute),
 	)
 	if err != nil {

--- a/internal/sequencer/besteffort/besteffort_test.go
+++ b/internal/sequencer/besteffort/besteffort_test.go
@@ -43,13 +43,13 @@ func TestStepByStep(t *testing.T) {
 	r.NoError(err)
 	ctx := fixture.Context
 
+	seqCfg := &sequencer.Config{
+		Parallelism:     16,
+		QuiescentPeriod: 100 * time.Millisecond,
+	}
+	r.NoError(seqCfg.Preflight())
 	seqFixture, err := seqtest.NewSequencerFixture(fixture,
-		&sequencer.Config{
-			Parallelism:     2,
-			QuiescentPeriod: 100 * time.Millisecond,
-			TimestampLimit:  sequencer.DefaultTimestampLimit,
-			SweepLimit:      1000,
-		},
+		seqCfg,
 		&script.Config{})
 	r.NoError(err)
 

--- a/internal/sequencer/besteffort/provider.go
+++ b/internal/sequencer/besteffort/provider.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/scheduler"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
 	"github.com/google/wire"
@@ -34,6 +35,7 @@ var Set = wire.NewSet(
 func ProvideBestEffort(
 	cfg *sequencer.Config,
 	leases types.Leases,
+	scheduler *scheduler.Scheduler,
 	stagingPool *types.StagingPool,
 	stagers types.Stagers,
 	targetPool *types.TargetPool,
@@ -42,6 +44,7 @@ func ProvideBestEffort(
 	return &BestEffort{
 		cfg:         cfg,
 		leases:      leases,
+		scheduler:   scheduler,
 		stagingPool: stagingPool,
 		stagers:     stagers,
 		targetPool:  targetPool,

--- a/internal/sequencer/scheduler/metrics.go
+++ b/internal/sequencer/scheduler/metrics.go
@@ -14,31 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package shingle
+package scheduler
 
 import (
-	"github.com/cockroachdb/cdc-sink/internal/sequencer"
-	"github.com/cockroachdb/cdc-sink/internal/sequencer/scheduler"
-	"github.com/cockroachdb/cdc-sink/internal/types"
-	"github.com/google/wire"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// Set is used by Wire.
-var Set = wire.NewSet(ProvideShingle)
-
-// ProvideShingle is called by Wire.
-func ProvideShingle(
-	cfg *sequencer.Config,
-	scheduler *scheduler.Scheduler,
-	stagers types.Stagers,
-	staging *types.StagingPool,
-	target *types.TargetPool,
-) *Shingle {
-	return &Shingle{
-		cfg:       cfg,
-		scheduler: scheduler,
-		stagers:   stagers,
-		staging:   staging,
-		target:    target,
-	}
-}
+var (
+	executedCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "sequencer_scheduler_executed_tasks_count",
+		Help: "the number of scheduled tasks that were executed",
+	})
+	executingCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "sequencer_scheduler_executing_tasks_count",
+		Help: "the number of scheduled tasks currently executing",
+	})
+)

--- a/internal/sequencer/scheduler/scheduler.go
+++ b/internal/sequencer/scheduler/scheduler.go
@@ -1,0 +1,90 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package scheduler contains Sequencer-specific utilities for ensuring
+// ordered access to rows.
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/lockset"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+)
+
+// A Scheduler is shared across Sequencer implementations to limit
+// overall parallelism and to ensure ordered access to target rows.
+type Scheduler struct {
+	set lockset.Set[string]
+}
+
+// Batch executes the callback when it has clear access to apply
+// all mutations in the given batch.
+func (s *Scheduler) Batch(batch *types.MultiBatch, fn func() error) *notify.Var[*lockset.Status] {
+	ret, _ := s.set.Schedule(
+		keyForBatch(batch),
+		func([]string) error {
+			executingCount.Inc()
+			defer executingCount.Dec()
+			defer executedCount.Inc()
+			return fn()
+		},
+	)
+	return ret
+}
+
+// Singleton executes the callback executed when it has clear access to
+// apply the mutation in the given table.
+func (s *Scheduler) Singleton(
+	table ident.Table, mut types.Mutation, fn func() error,
+) *notify.Var[*lockset.Status] {
+	ret, _ := s.set.Schedule(
+		keyForSingleton(table, mut),
+		func([]string) error {
+			executingCount.Inc()
+			defer executingCount.Dec()
+			defer executedCount.Inc()
+			return fn()
+		},
+	)
+	return ret
+}
+
+// keyForSingleton prevents collisions if the same key is operated on multiple
+// times within a single sweep.
+func keyForSingleton(table ident.Table, mut types.Mutation) []string {
+	return []string{fmt.Sprintf("%s:%s", table, string(mut.Key))}
+}
+
+// keyForBatch creates a locking set for all rows within the batch.
+func keyForBatch(batch *types.MultiBatch) []string {
+	// The keys will be deduplicated and ordered by
+	// lockset.Set.Schedule, so we don't need to worry about that here.
+	var ret []string
+	for _, sub := range batch.Data {
+		// Ignoring error because callback only returns nil.
+		_ = sub.Data.Range(func(tbl ident.Table, tblData *types.TableBatch) error {
+			for _, mut := range tblData.Data {
+				ret = append(ret, keyForSingleton(tbl, mut)...)
+			}
+			return nil
+		})
+	}
+	return ret
+
+}

--- a/internal/sequencer/scheduler/scheduler_test.go
+++ b/internal/sequencer/scheduler/scheduler_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/mutations"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/lockset"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/stretchr/testify/require"
+)
+
+// This really just tests the key generation. See lockset tests for
+// more in-depth testing of ordering guarantees.
+func TestScheduler(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	muts := mutations.Generator(ctx, 1024, 0)
+	table := ident.NewTable(ident.MustSchema(ident.New("schema")), ident.New("table"))
+
+	batch := &types.MultiBatch{}
+	var lastMut types.Mutation
+	for i := 0; i < 100; i++ {
+		lastMut = <-muts
+		r.NoError(batch.Accumulate(table, lastMut))
+	}
+
+	block := make(chan struct{})
+	var seen []string
+	var s Scheduler
+
+	// This single task should block the batch.
+	singleStatus := s.Singleton(table, lastMut, func() error {
+		seen = append(seen, "single")
+		<-block
+		return nil
+	})
+	batchStatus := s.Batch(batch, func() error {
+		seen = append(seen, "batch")
+		return nil
+	})
+
+	// Allow singleton to complete.
+	close(block)
+
+	// Await outcome.
+	r.NoError(lockset.Wait(ctx, []*notify.Var[*lockset.Status]{singleStatus, batchStatus}))
+
+	// Verify execution order.
+	r.Equal([]string{"single", "batch"}, seen)
+}

--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -111,13 +111,13 @@ api.configureTable("t_2", {
 });
 `)}}}
 
+	seqCfg := &sequencer.Config{
+		Parallelism:     2,
+		QuiescentPeriod: 100 * time.Millisecond,
+	}
+	r.NoError(seqCfg.Preflight())
 	seqFixture, err := seqtest.NewSequencerFixture(fixture,
-		&sequencer.Config{
-			Parallelism:     2,
-			QuiescentPeriod: time.Second,
-			SweepLimit:      sequencer.DefaultSweepLimit,
-			TimestampLimit:  sequencer.DefaultTimestampLimit,
-		},
+		seqCfg,
 		scriptCfg)
 	r.NoError(err)
 

--- a/internal/sequencer/seqtest/check.go
+++ b/internal/sequencer/seqtest/check.go
@@ -52,6 +52,7 @@ func CheckSequencer(
 
 		// Create sequencer test fixture.
 		cfg := &sequencer.Config{
+			FlushSize:       batches/10 + 1,
 			Parallelism:     8,
 			QuiescentPeriod: 100 * time.Millisecond,
 			TimestampLimit:  batches/10 + 1,

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/retire"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/scheduler"
 	script2 "github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/shingle"
@@ -31,10 +32,14 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 	if err != nil {
 		return nil, err
 	}
+	schedulerScheduler, err := scheduler.ProvideScheduler(context, config)
+	if err != nil {
+		return nil, err
+	}
 	stagers := fixture.Stagers
 	targetPool := baseFixture.TargetPool
 	watchers := fixture.Watchers
-	bestEffort := besteffort.ProvideBestEffort(config, leases, stagingPool, stagers, targetPool, watchers)
+	bestEffort := besteffort.ProvideBestEffort(config, leases, schedulerScheduler, stagingPool, stagers, targetPool, watchers)
 	chaosChaos := &chaos.Chaos{
 		Config: config,
 	}
@@ -48,7 +53,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 		return nil, err
 	}
 	scriptSequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	shingleShingle := shingle.ProvideShingle(config, stagers, stagingPool, targetPool)
+	shingleShingle := shingle.ProvideShingle(config, schedulerScheduler, stagers, stagingPool, targetPool)
 	switcherSwitcher := switcher.ProvideSequencer(bestEffort, diagnostics, immediateImmediate, scriptSequencer, serialSerial, shingleShingle, stagingPool, targetPool)
 	seqtestFixture := &Fixture{
 		Fixture:    fixture,

--- a/internal/sequencer/serial/serial_test.go
+++ b/internal/sequencer/serial/serial_test.go
@@ -40,13 +40,12 @@ func TestStepByStep(t *testing.T) {
 	r.NoError(err)
 	ctx := fixture.Context
 
+	seqCfg := &sequencer.Config{
+		QuiescentPeriod: 100 * time.Millisecond,
+	}
+	r.NoError(seqCfg.Preflight())
 	seqFixture, err := seqtest.NewSequencerFixture(fixture,
-		&sequencer.Config{
-			Parallelism:     2, // Has no particular effect on serial.
-			QuiescentPeriod: time.Second,
-			SweepLimit:      sequencer.DefaultSweepLimit,
-			TimestampLimit:  sequencer.DefaultTimestampLimit,
-		},
+		seqCfg,
 		&script.Config{})
 	r.NoError(err)
 	serial := seqFixture.Serial

--- a/internal/sequencer/shingle/segment.go
+++ b/internal/sequencer/shingle/segment.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shingle
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+)
+
+// segmentMultiBatch will split the batch into one or more batches whose
+// mutation count is approximately idealSize. Excessively large
+// [types.TemporalBatch] instances will not be split, but will instead
+// be returned as singleton MultiBatches.
+func segmentMultiBatch(batch *types.MultiBatch, idealSize int) []*types.MultiBatch {
+	count := batch.Count()
+	if count <= idealSize {
+		return []*types.MultiBatch{batch}
+	}
+
+	var segment *types.MultiBatch
+	ret := make([]*types.MultiBatch, 0, count/idealSize+1) // Guess at capacity
+	var total int
+
+	for _, sub := range batch.Data {
+		nextCount := sub.Count()
+		if segment == nil || total+nextCount > idealSize {
+			// Create a new segment if one does not exist or if adding
+			// the next batch would exceed the ideal size.
+			segment = &types.MultiBatch{
+				Data:   []*types.TemporalBatch{sub},
+				ByTime: map[hlc.Time]*types.TemporalBatch{sub.Time: sub},
+			}
+			ret = append(ret, segment)
+			total = nextCount
+		} else {
+			// Otherwise, append to the current segment.
+			segment.ByTime[sub.Time] = sub
+			segment.Data = append(segment.Data, sub)
+			total += nextCount
+		}
+	}
+
+	return ret
+}

--- a/internal/sequencer/shingle/segment_test.go
+++ b/internal/sequencer/shingle/segment_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shingle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/mutations"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSegmentMultiBatch(t *testing.T) {
+	const count = 1000
+	const ideal = 99
+	r := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	table := ident.NewTable(
+		ident.MustSchema(ident.New("foo")),
+		ident.New("bar"))
+
+	// Generate a large batch of data.
+	big := &types.MultiBatch{}
+	mutCh := mutations.Generator(ctx, 1024, 0)
+	for i := 0; i < count; i++ {
+		r.NoError(big.Accumulate(table, <-mutCh))
+	}
+	r.Equal(count, big.Count())
+
+	// Verify number of generated segments.
+	segments := segmentMultiBatch(big, ideal)
+	r.Len(segments, count/ideal+1)
+
+	// Ensure we haven't dropped any mutations.
+	total := 0
+	for _, segment := range segments {
+		total += segment.Count()
+	}
+	r.Equal(count, total)
+
+	// Verify small-segment pass-through.
+	moreSegments := segmentMultiBatch(segments[0], ideal)
+	r.Len(moreSegments, 1)
+	r.Same(segments[0], moreSegments[0])
+}

--- a/internal/sequencer/shingle/shingle.go
+++ b/internal/sequencer/shingle/shingle.go
@@ -20,6 +20,7 @@ package shingle
 
 import (
 	"github.com/cockroachdb/cdc-sink/internal/sequencer"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/scheduler"
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/notify"
 	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
@@ -29,10 +30,11 @@ import (
 // target transaction to be applied concurrently, with ordering enforced
 // on a per-key basis.
 type Shingle struct {
-	cfg     *sequencer.Config
-	stagers types.Stagers
-	staging *types.StagingPool
-	target  *types.TargetPool
+	cfg       *sequencer.Config
+	scheduler *scheduler.Scheduler
+	stagers   types.Stagers
+	staging   *types.StagingPool
+	target    *types.TargetPool
 }
 
 var _ sequencer.Shim = (*Shingle)(nil)

--- a/internal/sequencer/switcher/provider.go
+++ b/internal/sequencer/switcher/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/besteffort"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/chaos"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/immediate"
+	"github.com/cockroachdb/cdc-sink/internal/sequencer/scheduler"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/script"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/serial"
 	"github.com/cockroachdb/cdc-sink/internal/sequencer/shingle"
@@ -31,10 +32,11 @@ import (
 // Set is used by Wire.
 var Set = wire.NewSet(
 	besteffort.Set,
-	immediate.Set,
 	chaos.Set,
+	immediate.Set,
 	script.Set,
 	serial.Set,
+	scheduler.Set,
 	shingle.Set,
 
 	ProvideSequencer,

--- a/internal/sinkprod/common.go
+++ b/internal/sinkprod/common.go
@@ -1,0 +1,73 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sinkprod
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+// CommonConfig defines settings that are shared by [StagingConfig] and
+// [TargetConfig].
+type CommonConfig struct {
+	// Connection string for the database.
+	Conn string
+	// The maximum lifetime of an idle connection.
+	IdleTime time.Duration
+	// The length of time to jitter disconnections over.
+	JitterTime time.Duration
+	// The maximum lifetime for a database connection; improves
+	// loadbalancer compatibility.
+	MaxLifetime time.Duration
+	// The number of connections to the target database. If zero, a
+	// default value will be used.
+	MaxPoolSize int
+}
+
+func (c *CommonConfig) bind(f *pflag.FlagSet, prefix string) {
+	f.StringVar(&c.Conn, prefix+"Conn", "",
+		fmt.Sprintf("the %s database's connection string", prefix))
+	f.DurationVar(&c.IdleTime, prefix+"IdleTime", defaultIdleTime,
+		"maximum lifetime of an idle connection")
+	f.DurationVar(&c.JitterTime, prefix+"JitterTime", defaultJitterTime,
+		"the time over which to jitter database pool disconnections")
+	f.DurationVar(&c.MaxLifetime, prefix+"MaxLifetime", defaultMaxLifetime,
+		"the maximum lifetime of a database connection")
+	f.IntVar(&c.MaxPoolSize, prefix+"MaxPoolSize", defaultMaxPoolSize,
+		fmt.Sprintf("the maximum number of %s database connections", prefix))
+}
+
+func (c *CommonConfig) preflight(prefix string, requireConn bool) error {
+	if requireConn {
+		if c.Conn == "" {
+			return errors.Errorf("%sConn must be set", prefix)
+		}
+	}
+	if c.IdleTime == 0 {
+		c.IdleTime = defaultIdleTime
+	}
+	if c.JitterTime == 0 {
+		c.JitterTime = defaultJitterTime
+	}
+	if c.MaxPoolSize == 0 {
+		c.MaxPoolSize = defaultMaxPoolSize
+	}
+	return nil
+}

--- a/internal/sinkprod/sinkprod.go
+++ b/internal/sinkprod/sinkprod.go
@@ -34,7 +34,9 @@ var Set = wire.NewSet(
 
 const (
 	defaultApplyTimeout = 30 * time.Second
-	defaultLifetime     = 10 * time.Minute
 	defaultCacheSize    = 128
-	defaultPoolSize     = 128
+	defaultJitterTime   = 15 * time.Second
+	defaultIdleTime     = 1 * time.Minute
+	defaultMaxLifetime  = 5 * time.Minute
+	defaultMaxPoolSize  = 128
 )

--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -231,6 +231,7 @@ func ProvideStagingPool(ctx *stopper.Context) (*types.StagingPool, error) {
 			WaitForStartup: true,
 		}),
 		stdpool.WithPoolSize(32),
+		stdpool.WithTransactionTimeout(2*time.Minute), // Aligns with test case timeout.
 	)
 	if err != nil {
 		return nil, err
@@ -255,6 +256,7 @@ func ProvideTargetPool(
 			WaitForStartup: true,
 		}),
 		stdpool.WithPoolSize(32),
+		stdpool.WithTransactionTimeout(2*time.Minute), // Aligns with test case timeout.
 	)
 	if err != nil {
 		return nil, err

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -110,6 +110,7 @@ func createFixture(
 			MainPath: "/testdata/logical_test.ts",
 		}
 	}
+	r.NoError(cfg.Preflight())
 	fixture, err := newTestFixture(baseFixture, cfg)
 	r.NoError(err)
 
@@ -753,6 +754,7 @@ func testMassBackfillWithForeignKeys(
 	for idx := range fixtures {
 		cfg := &Config{
 			SequencerConfig: sequencer.Config{
+				FlushSize:       rowCount / 4,
 				Parallelism:     2,
 				QuiescentPeriod: 100 * time.Millisecond,
 				RetireOffset:    time.Hour,

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -760,6 +760,7 @@ func testMassBackfillWithForeignKeys(
 				SweepLimit:      rowCount / 3, // Read the same timestamp more than once.
 			},
 		}
+		r.NoError(cfg.Preflight())
 		for _, fn := range fns {
 			fn(cfg)
 		}

--- a/internal/source/cdc/server/integration_test.go
+++ b/internal/source/cdc/server/integration_test.go
@@ -170,13 +170,17 @@ func testIntegration(t *testing.T, cfg testConfig) {
 			GenerateSelfSigned: cfg.webhook && supportsWebhook, // Webhook implies self-signed TLS is ok.
 		},
 		Staging: stagingProd.StagingConfig{
-			Conn:     destFixture.StagingPool.ConnectionString,
-			Schema:   destFixture.StagingDB.Schema(),
-			PoolSize: 16,
+			CommonConfig: stagingProd.CommonConfig{
+				Conn:        destFixture.StagingPool.ConnectionString,
+				MaxPoolSize: 16,
+			},
+			Schema: destFixture.StagingDB.Schema(),
 		},
 		Target: stagingProd.TargetConfig{
-			Conn:     targetPool.ConnectionString,
-			PoolSize: 16,
+			CommonConfig: stagingProd.CommonConfig{
+				Conn:        targetPool.ConnectionString,
+				MaxPoolSize: 16,
+			},
 		},
 	}
 	if cfg.shingle {

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -488,8 +488,10 @@ func getConfig(fixture *all.Fixture, fc *fixtureConfig, tgt ident.Table) (*Confi
 			Schema: fixture.StagingDB.Schema(),
 		},
 		Target: sinkprod.TargetConfig{
+			CommonConfig: sinkprod.CommonConfig{
+				Conn: crdbPool.ConnectionString,
+			},
 			ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
-			Conn:         crdbPool.ConnectionString,
 		},
 		SourceConn:   defaultSourceConn,
 		ProcessID:    123456,

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -190,8 +190,10 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 			Schema: fixture.StagingDB.Schema(),
 		},
 		Target: sinkprod.TargetConfig{
+			CommonConfig: sinkprod.CommonConfig{
+				Conn: crdbPool.ConnectionString,
+			},
 			ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
-			Conn:         crdbPool.ConnectionString,
 		},
 		Publication:    pubNameRaw,
 		Slot:           pubNameRaw,
@@ -432,8 +434,10 @@ func TestDataTypes(t *testing.T) {
 			Schema: fixture.StagingDB.Schema(),
 		},
 		Target: sinkprod.TargetConfig{
+			CommonConfig: sinkprod.CommonConfig{
+				Conn: crdbPool.ConnectionString,
+			},
 			ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
-			Conn:         crdbPool.ConnectionString,
 		},
 		Publication:    pubNameRaw,
 		Slot:           pubNameRaw,
@@ -544,8 +548,10 @@ func TestEmptyTransactions(t *testing.T) {
 			Schema: fixture.StagingDB.Schema(),
 		},
 		Target: sinkprod.TargetConfig{
+			CommonConfig: sinkprod.CommonConfig{
+				Conn: crdbPool.ConnectionString,
+			},
 			ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
-			Conn:         crdbPool.ConnectionString,
 		},
 		Publication:    pubNameRaw,
 		Slot:           pubNameRaw,
@@ -675,8 +681,10 @@ func TestToast(t *testing.T) {
 			Schema: fixture.StagingDB.Schema(),
 		},
 		Target: sinkprod.TargetConfig{
+			CommonConfig: sinkprod.CommonConfig{
+				Conn: crdbPool.ConnectionString,
+			},
 			ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
-			Conn:         crdbPool.ConnectionString,
 		},
 		Publication:    pubNameRaw,
 		Slot:           pubNameRaw,


### PR DESCRIPTION
This PR consists of three commits to optimize throughput and improve correctness.

---

This change revises the staging and target pool sizes and timeouts to better
align with operational best practices. Additional points of configuration have
been added to set the maximum idle lifetime and jitter.

---

This change allows invocation of the callback functions to be delegated to
another type, instead of using the go keyword. This will allow, for example,
the use of a workgroup to limit overall concurrency.

----

This change adds a new `sequencer/scheduler` package that provides a
centralized way for BestEffort and Shingle to ensure that their various
goroutines preserve the order of updates on individual keys. This scheduler is
built around the existing `lockset.Set`, configured with a `workgroup.Group`
that enforces the Parallelism configuration option.

This commit fixes an occasional race condition in BestEffort when a mutation
contains multiple updates for the same key. It was possible for the mutations
to be applied in an out-of-order sequence. This was causing occasional test
failures and could be reproduced locally by adding a random delay while
processing batches.

The shingle implementation was creating an excessive number of tasks, so it now
operates on larger segments. This segmentation code is driven by a new
configuration field, `FlushSize`.

The serial sequencer does not use the scheduler since it operates on a single
goroutine.

There were a few tests that were not calling the configuration Preflight
method. This has been corrected.

Fixes #726

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/740)
<!-- Reviewable:end -->
