### PR TITLE
script: Ensure script.Config.Preflight is called.

### DIFF
--- a/internal/script/config.go
+++ b/internal/script/config.go
@@ -30,7 +30,9 @@ type Config struct {
 	MainPath string  // A path, relative to FS that holds the entrypoint.
 	Options  Options // The target for calls to api.setOptions().
 
-	userscript string // An external filesystem path.
+	// An external filesystem path. This will be cleared after Preflight
+	// has been called. This symbol is exported for testing.
+	UserScriptPath string
 }
 
 // Bind adds flags to the set.
@@ -38,14 +40,14 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	if c.Options == nil {
 		c.Options = &FlagOptions{f}
 	}
-	f.StringVar(&c.userscript, "userscript", "",
+	f.StringVar(&c.UserScriptPath, "userscript", "",
 		"the path to a configuration script, see userscript subcommand")
 }
 
-// Preflight validates the configuration.
+// Preflight will set FS and MainPath, if UserScriptPath is set.
 func (c *Config) Preflight() error {
-	if c.userscript != "" {
-		path, err := filepath.Abs(c.userscript)
+	if c.UserScriptPath != "" {
+		path, err := filepath.Abs(c.UserScriptPath)
 		if err != nil {
 			return err
 		}
@@ -53,7 +55,7 @@ func (c *Config) Preflight() error {
 		dir, path := filepath.Split(path)
 		c.FS = os.DirFS(dir)
 		c.MainPath = "/" + path
-		c.userscript = ""
+		c.UserScriptPath = ""
 	}
 
 	return nil

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -41,6 +41,12 @@ var Set = wire.NewSet(
 func ProvideLoader(
 	ctx context.Context, applyConfigs *applycfg.Configs, cfg *Config, diags *diag.Diagnostics,
 ) (*Loader, error) {
+	// We depend on preflight to expand the file path. Ensure that it
+	// has been called at least once.
+	if err := cfg.Preflight(); err != nil {
+		return nil, err
+	}
+
 	// Return an empty version if unconfigured.
 	if cfg.FS == nil {
 		return &Loader{}, nil

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -18,7 +18,6 @@ package script
 
 import (
 	"context"
-	"embed"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -35,9 +34,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-//go:embed testdata/*
-var testData embed.FS
 
 type mapOptions struct {
 	data map[string]string
@@ -101,11 +97,11 @@ CREATE TABLE %s.skewed_merge_times(
 	r.NoError(fixture.Watcher.Refresh(ctx, fixture.TargetPool))
 	var opts mapOptions
 
-	loader, err := ProvideLoader(ctx, fixture.Configs, &Config{
-		FS:       testData,
-		MainPath: "/testdata/main.ts",
-		Options:  &opts,
-	}, fixture.Diagnostics)
+	cfg := &Config{
+		Options:        &opts,
+		UserScriptPath: "./testdata/main.ts",
+	}
+	loader, err := ProvideLoader(ctx, fixture.Configs, cfg, fixture.Diagnostics)
 	r.NoError(err)
 
 	s, err := loader.Bind(ctx, fixture.TargetSchema, fixture.ApplyAcceptor, fixture.Watchers)


### PR DESCRIPTION
This is a follow-up from #738. The call to `script.Config.Preflight` is necessary to populate the FS field. The script test no longer uses an embedded FS so that this code may be exercised.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/746)
<!-- Reviewable:end -->
