### PR TITLE
stdpool: Restore sql.DB maximum idle connection count

### DIFF
--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -230,6 +230,7 @@ func ProvideStagingPool(ctx *stopper.Context) (*types.StagingPool, error) {
 		stdpool.WithTestControls(stdpool.TestControls{
 			WaitForStartup: true,
 		}),
+		stdpool.WithConnectionLifetime(time.Minute, 15*time.Second, 5*time.Second),
 		stdpool.WithPoolSize(32),
 		stdpool.WithTransactionTimeout(2*time.Minute), // Aligns with test case timeout.
 	)
@@ -255,6 +256,7 @@ func ProvideTargetPool(
 		stdpool.WithTestControls(stdpool.TestControls{
 			WaitForStartup: true,
 		}),
+		stdpool.WithConnectionLifetime(time.Minute, 15*time.Second, 5*time.Second),
 		stdpool.WithPoolSize(32),
 		stdpool.WithTransactionTimeout(2*time.Minute), // Aligns with test case timeout.
 	)

--- a/internal/util/stdpool/size.go
+++ b/internal/util/stdpool/size.go
@@ -42,11 +42,8 @@ func (o *withPoolSize) pgxPoolConfig(_ context.Context, cfg *pgxpool.Config) err
 	return nil
 }
 func (o *withPoolSize) sqlDB(_ context.Context, impl *sql.DB) error {
-	// This code patch is only used for non-pgx targets. They typically
-	// don't want to leave idle connections lying around. Setting this
-	// value higher also seems to trigger test failures due to
-	// https://github.com/sijms/go-ora/issues/513
-	impl.SetMaxIdleConns(2)
+	// Allow idle connections to fall out based on lifetime settings.
+	impl.SetMaxIdleConns(o.size)
 	impl.SetMaxOpenConns(o.size)
 	return nil
 }


### PR DESCRIPTION
This commit undoes the change to the maximum idle connection count for the
sql.DB pool from PR https://github.com/cockroachdb/cdc-sink/pull/740. Having a low setting caused an excessive amount of
connection pool thrash at high parallelism settings. We do keep the pgx
MinConns setting so we, generally, open connections on demand and then allow
them to age out.

The testing pools are configured with an explicit idle lifetime. We see issues
with go-ora where allowing idle connections to remain open, seems to cause all
connections in the pool to be canceled at once. This setting is also consistent
with the production pool setup code.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/753)
<!-- Reviewable:end -->
