### PR TITLE
types: Add CopyInto methods to mutation batch types

### DIFF
--- a/internal/sequencer/scheduler/scheduler.go
+++ b/internal/sequencer/scheduler/scheduler.go
@@ -98,15 +98,10 @@ func keyForBatch(batch *types.MultiBatch) []string {
 	// The keys will be deduplicated and ordered by
 	// lockset.Set.Schedule, so we don't need to worry about that here.
 	var ret []string
-	for _, sub := range batch.Data {
-		// Ignoring error because callback only returns nil.
-		_ = sub.Data.Range(func(tbl ident.Table, tblData *types.TableBatch) error {
-			for _, mut := range tblData.Data {
-				ret = append(ret, keyForSingleton(tbl, mut)...)
-			}
-			return nil
-		})
-	}
+	_ = batch.CopyInto(types.AccumulatorFunc(func(table ident.Table, mut types.Mutation) error {
+		ret = append(ret, keyForSingleton(table, mut)...)
+		return nil
+	}))
 	return ret
 }
 

--- a/internal/types/batches_test.go
+++ b/internal/types/batches_test.go
@@ -17,7 +17,9 @@
 package types_test
 
 import (
+	"bytes"
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cdc-sink/internal/sinktest/mutations"
@@ -53,22 +55,42 @@ func testBatchInterface[B types.Batch[B]](t *testing.T, batch B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	now := hlc.New(100, 100)
 	r.Equal(0, batch.Count())
 
 	const mutCount = 100
-	for mut := range mutations.Generator(ctx, 1024 /* distinct ids */, 0.1) {
-		mut.Time = now
-		r.NoError(batch.Accumulate(fakeTable, mut))
-		if batch.Count() == mutCount {
-			break
+	data := mutations.Generator(ctx, 1024 /* distinct ids */, 0.1)
+	expected := make([]types.Mutation, mutCount)
+	for i := 0; i < mutCount; i++ {
+		mut := <-data
+		// We want the multi-batch sorted by time.
+		if _, isMulti := any(batch).(*types.MultiBatch); isMulti {
+			mut.Time = hlc.New(int64(i+1), i+1)
+		} else {
+			mut.Time = fakeTime
 		}
+		expected[i] = mut
+		r.NoError(batch.Accumulate(fakeTable, mut))
 	}
 	r.Equal(mutCount, batch.Count())
+
+	// These types wind up being sorted by key.
+	switch any(batch).(type) {
+	case *types.TableBatch, *types.TemporalBatch:
+		sort.Slice(expected, func(i, j int) bool {
+			return bytes.Compare(expected[i].Key, expected[j].Key) < 0
+		})
+	}
 
 	cpy := batch.Copy()
 	r.NotSame(batch, cpy)
 	r.Equal(batch.Count(), cpy.Count())
 
 	r.Zero(batch.Empty().Count())
+
+	acc := &types.MultiBatch{}
+	r.NoError(batch.CopyInto(acc))
+	r.Equal(batch.Count(), acc.Count())
+
+	flattened := types.Flatten[B](batch)
+	r.Equal(expected, flattened)
 }


### PR DESCRIPTION
This change adds a general-pupose, ordered, traversal mechanism to the batch types. This supports an upcoming commit and a few existing batch traversals are update to use CopyInto.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/775)
<!-- Reviewable:end -->
