### PR TITLE
workflow: Revise matrix testing

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -24,54 +24,71 @@
 # as the values passed to sinktest.IntegrationMain.
 version: "3.9"
 services:
-  # These define the tested source databases. The network_mode is host
-  # so that outgoing changefeed network requests can connect to the test
-  # server.
-  cockroachdb-v20.2:
+  # These are older versions of CRDB that we want to support as sources,
+  # but not as staging or as a target. The network_mode is host so that
+  # outgoing changefeed network requests can connect to the test server.
+  source-cockroachdb-v20.1:
+    image: cockroachdb/cockroach:latest-v20.1
+    network_mode: host
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  source-cockroachdb-v20.2:
     image: cockroachdb/cockroach:latest-v20.2
     network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-  cockroachdb-v21.1:
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  source-cockroachdb-v21.1:
     image: cockroachdb/cockroach:latest-v21.1
     network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-  cockroachdb-v21.2:
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  source-cockroachdb-v21.2:
     image: cockroachdb/cockroach:latest-v21.2
     network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-  cockroachdb-v22.1:
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  source-cockroachdb-v22.1:
     image: cockroachdb/cockroach:latest-v22.1
     network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-  cockroachdb-v22.2:
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  source-cockroachdb-v22.2:
     image: cockroachdb/cockroach:latest-v22.2
     network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-  cockroachdb-v23.1:
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
+  source-cockroachdb-v23.1:
     image: cockroachdb/cockroach:latest-v23.1
     network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-  cockroachdb-v23.2:
-    image: cockroachdb/cockroach:latest-v23.2
-    network_mode: host
-    command: start-single-node --insecure --store type=mem,size=2G
-
-  # These two services are used for testing split-mode operations. We
-  # need to bypass the usual entry-point script because it has a check
-  # to ensure that the process only listens on localhost and on the
-  # default port.
-  #
-  # https://github.com/cockroachdb/cockroach/issues/84166
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
   source-cockroachdb-v23.2:
     image: cockroachdb/cockroach:latest-v23.2
     network_mode: host
     entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5400 --http-addr :8081
-  target-cockroachdb-v23.2:
+
+  # These versions of CRDB are supported for staging and target operations.
+  cockroachdb-v23.1:
+    image: cockroachdb/cockroach:latest-v23.1
+    network_mode: host
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G
+
+  cockroachdb-v23.2:
     image: cockroachdb/cockroach:latest-v23.2
     network_mode: host
     entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G
+
+  # This target exists to verify split-mode operation, where staging is separate from the target.
+  target-cockroachdb-v23.2:
+    image: cockroachdb/cockroach:latest-v23.2
+    entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G --listen-addr :5401 --http-addr :8082
+    ports:
+      - "5401:5401"
+      - "8082:8082"
 
   mysql-v5.7:
     image: mysql:5.7

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -73,7 +73,7 @@ jobs:
   tests:
     name: Integration Tests
     runs-on: ${{ matrix.runs-on || 'ubuntu-latest-8-core' }}
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       # Refer to the CRDB support policy when determining how many
@@ -83,13 +83,40 @@ jobs:
       # This matrix is explicit, since we have a few axes (target vs
       # integration) that can't be expressed with the automatic
       # cross-product behavior provided by the matrix operator.
+      #
+      # It doesn't appear that substitution variables may be used in the
+      # matrix. If this changes, having a COCKROACH_CURRENT and
+      # COCKROACH_PREV would be nice-to-haves.
       matrix:
         include:
-          - cockroachdb: v21.1
-          - cockroachdb: v21.2
-          - cockroachdb: v22.1
-          - cockroachdb: v22.2
+          # These are our primary supported versions.
+          - cockroachdb: v23.2
           - cockroachdb: v23.1
+
+          # Run a test with a separate CockroachDB source and target
+          # instance to ensure there are no accidental dependencies
+          # between the source, staging, and target schemas.
+          - cockroachdb: v23.2
+            source: source-cockroachdb-v23.2
+            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
+            target: target-cockroachdb-v23.2
+            targetConn: "postgresql://root@127.0.0.1:5401/defaultdb?sslmode=disable"
+
+          # Tests for older CockroachDB versions as a source.
+          - cockroachdb: v23.2
+            source: source-cockroachdb-v20.1
+            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
+          - cockroachdb: v23.2
+            source: source-cockroachdb-v20.2
+            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
+          - cockroachdb: v23.2
+            source: source-cockroachdb-v21.1
+            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
+          - cockroachdb: v23.2
+            source: source-cockroachdb-v21.2
+            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
+
+          # Tests for non-CRDB sources.
           - cockroachdb: v23.2
             integration: mysql-v8
           - cockroachdb: v23.2
@@ -108,22 +135,6 @@ jobs:
             integration: postgresql-v14
           - cockroachdb: v23.2
             integration: postgresql-v15
-          # Run a test with a separate CockroachDB source and target
-          # instance to ensure there are no accidental dependencies
-          # between the source, staging, and target schemas.
-          - cockroachdb: v23.2
-            source: source-cockroachdb-v23.2
-            sourceConn: "postgresql://root@127.0.0.1:5400/defaultdb?sslmode=disable"
-            target: target-cockroachdb-v23.2
-            targetConn: "postgresql://root@127.0.0.1:5401/defaultdb?sslmode=disable"
-            # The Oracle 18 image doesn't come with a pre-built database, we need to do more work
-            # to allow this image to boot up fast enough for use in tests.
-#          - cockroachdb: v23.2
-#            target: oracle-v18.4
-#            targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
-          - cockroachdb: v23.2
-            target: oracle-v21.3
-            targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
 
           # Test CRDB -> PostgreSQL for migration backfill use cases.
           - cockroachdb: v23.2
@@ -141,14 +152,21 @@ jobs:
           - cockroachdb: v23.2
             target: postgresql-v15
             targetConn: "postgres://postgres:SoupOrSecret@127.0.0.1:5432"
+
           # Test CRDB -> MySQL for migration backfill use cases.
           - cockroachdb: v23.2
             target: mysql-v8
             targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql?sslmode=require"
+
           # Test CRDB -> MariaDB for migration backfill use cases.
           - cockroachdb: v23.2
             target: mysql-mariadb-v10
             targetConn: "mysql://root:SoupOrSecret@127.0.0.1:3306/mysql"
+
+          # Test CRDB -> OracleDB for migration backfill use case.
+          - cockroachdb: v23.2
+            target: oracle-v21.3
+            targetConn: "oracle://system:SoupOrSecret@127.0.0.1:1521/XEPDB1"
 
     env:
       COVER_OUT: coverage-${{ strategy.job-index }}.out

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230522175609-2e198f4a06a1 // indirect
-	golang.org/x/mod v0.16.0 // indirect
+	golang.org/x/mod v0.16.0
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto v0.0.0-20240102182953-50ed04b92917 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,21 +277,14 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
-github.com/jackc/pglogrepl v0.0.0-20230428004623-0c5b98f52784 h1:qk5+0FP+HrGuqOcrQB2ISaLduvBaPnXBUoJ2FsQE9wg=
-github.com/jackc/pglogrepl v0.0.0-20230428004623-0c5b98f52784/go.mod h1:P5+MSYwllwjij1PDNGA4NF6hpomKWs0CmuagKUW9s0c=
 github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9 h1:86CQbMauoZdLS0HDLcEHYo6rErjiCBjVvcxGsioIn7s=
 github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9/go.mod h1:SO15KF4QqfUM5UhsG9roXre5qeAQLC1rm8a8Gjpgg5k=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
-github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
-github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.0.3/go.mod h1:JBbvW3Hdw77jKl9uJrEDATUZIFM2VFPzRq4RWIhkF4o=
 github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
 github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
-github.com/jackc/puddle/v2 v2.0.0/go.mod h1:itE7ZJY8xnoo0JqJEpSMprN0f+NQkMCuEV/N9j8h0oc=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -359,7 +352,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qq
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -439,7 +432,6 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
@@ -525,7 +517,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=


### PR DESCRIPTION
This change updates the build matrix to require cdc-sink to be able to use the
CockroachDB versions that are within the maintenance window as staging and
target databases. Older versions of CockroachDB are tested only as changefeed
sources.

The server integration test is cleaned up a bit to use the semver comparison
function from the go mod tool.

Support for v20.1 as a source is re-enabled.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/781)
<!-- Reviewable:end -->
