### PR TITLE
apply: Report original value if ColData.Parse fails

### DIFF
--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -745,13 +745,13 @@ func toDBType(colData *types.ColData, value any) (any, error) {
 	}
 	if value != nil && colData.Parse != nil {
 		// Target-driver specific fixups.
-		var err error
-		value, err = colData.Parse(value)
+		next, err := colData.Parse(value)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not parse %v as a %s",
 				value, colData.Type)
 
 		}
+		value = next
 	}
 	return value, nil
 }


### PR DESCRIPTION
The existing code reports a meaningless value if the call to Parse fails. The assignment to the value variable is deferred until after the error check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/784)
<!-- Reviewable:end -->
