### PR TITLE
workflow: Make CodeCov upload optional

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -213,6 +213,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        continue-on-error: true # Sometimes CodeCov has a bad day.
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.COVER_OUT }}


### PR DESCRIPTION
This change sets the `continue-on-error` flag on the job step that uploads code coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/786)
<!-- Reviewable:end -->
