### PR TITLE
stage: Add metric to track number of duplicate mutations

### DIFF
--- a/internal/staging/stage/metrics.go
+++ b/internal/staging/stage/metrics.go
@@ -78,6 +78,10 @@ var (
 		Name: "stage_mutations_total",
 		Help: "the number of mutations staged for this table",
 	}, metrics.TableLabels)
+	stageDuplicateCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "stage_duplicate_mutations_total",
+		Help: "the number of duplicate mutations received",
+	}, metrics.TableLabels)
 	stageDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "stage_duration_seconds",
 		Help:    "the length of time it took to successfully stage mutations",


### PR DESCRIPTION
This change adds a new metric to count the number of duplicate mutations that have been received. The staging query is changed from an `UPSERT` to an `IOCDN` since the upsert always returns the number of rows in its input, regardless of whether any change took place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/791)
<!-- Reviewable:end -->
