### PR TITLE
cdc: Add configurable discard delay

### DIFF
--- a/internal/source/cdc/config.go
+++ b/internal/source/cdc/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	// changefeed throughput without considering cdc-sink performance.
 	Discard bool
 
+	// If non-zero, wait half before and after consuming the payload.
+	DiscardDelay time.Duration
+
 	// Write directly to staging tables. May limit compatibility with
 	// schemas that contain foreign keys.
 	Immediate bool
@@ -78,6 +81,8 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 		"eventually-consistent mode; useful for high throughput, skew-tolerant schemas with FKs")
 	f.BoolVar(&c.Discard, "discard", false,
 		"(dangerous) discard all incoming HTTP requests; useful for changefeed throughput testing")
+	f.DurationVar(&c.DiscardDelay, "discardDelay", 0,
+		"adds additional delay in discard mode; useful for gauging the impact of changefeed RTT")
 	f.BoolVar(&c.Immediate, "immediate", false,
 		"bypass staging tables and write directly to target; "+
 			"recommended only for KV-style workloads with no FKs")

--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/httpauth"
@@ -80,7 +81,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	).Trace("request")
 
 	if h.Config.Discard {
+		time.Sleep(h.Config.DiscardDelay / 2)
 		_, err := io.Copy(io.Discard, r.Body)
+		time.Sleep(h.Config.DiscardDelay / 2)
 		sendErr(err)
 		return
 	}


### PR DESCRIPTION
This adds an additional flag to the CDC configuration to add an arbitrary amount of delay when discarding input.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/800)
<!-- Reviewable:end -->
