### PR TITLE
script: Add metrics showing time in the userscript VM

### DIFF
--- a/internal/script/metrics.go
+++ b/internal/script/metrics.go
@@ -1,0 +1,36 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"github.com/cockroachdb/cdc-sink/internal/util/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	scriptEntryWait = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "script_entry_wait_seconds",
+		Help:    "the length of time spent waiting to enter the JS runtime",
+		Buckets: metrics.LatencyBuckets,
+	})
+	scriptExecTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "script_exec_time_seconds",
+		Help:    "the length of time spent executing JS code",
+		Buckets: metrics.LatencyBuckets,
+	})
+)

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -722,12 +722,15 @@ type asyncTracker interface {
 func (s *UserScript) execTrackedJS(
 	tracker asyncTracker, fn func(rt *goja.Runtime) error,
 ) (err error) {
+	start := time.Now()
 	s.rtMu.Lock()
+	scriptEntryWait.Observe(time.Since(start).Seconds())
 	s.rt.ClearInterrupt()
 	defer func() {
 		s.rt.Interrupt(errUseExec)
 		s.rtMu.Unlock()
 		s.rtExit.Notify()
+		scriptExecTime.Observe(time.Since(start).Seconds())
 	}()
 
 	if tracker != nil {


### PR DESCRIPTION
This change adds two histograms showing the time spent waiting to enter the VM and the time spent executing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/802)
<!-- Reviewable:end -->
