### PR TITLE
sequencer/script: Fix possible nil dereference

### DIFF
--- a/internal/sequencer/script/acceptor.go
+++ b/internal/sequencer/script/acceptor.go
@@ -148,7 +148,12 @@ func (a *acceptor) doMap(
 	ctx context.Context, batch *types.TableBatch, opts *types.AcceptOptions,
 ) error {
 	target, ok := a.userScript.Targets.Get(batch.Table)
-	if ok && target.Map != nil {
+	if !ok {
+		// No target configuration.
+		return a.delegate.AcceptTableBatch(ctx, batch, opts)
+	}
+
+	if target.Map != nil {
 		mapped := batch.Empty()
 		mapped.Data = make([]types.Mutation, 0, len(batch.Data))
 		for _, mut := range batch.Data {


### PR DESCRIPTION
This updates the doMap method to exit early if no target is configured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/803)
<!-- Reviewable:end -->
