### PR TITLE
dashboard: removing hardcoded datasource uid from filters.

### DIFF
--- a/scripts/dashboard/cdc-sink.json
+++ b/scripts/dashboard/cdc-sink.json
@@ -3662,7 +3662,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "d10d997e-936c-4bfb-97ba-067687459fee"
+          "uid": "${DS_PROMETHEUS}"
         },
         "filters": [],
         "hide": 0,


### PR DESCRIPTION
This change fixes the grafana replicator dashboard ad-hoc filtering by using the DS_PROMETHEUS variable in place of the hardcoded uid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/808)
<!-- Reviewable:end -->
