### PR TITLE
apply, stage: Add support for CockroachDB NO_FULL_SCAN hint

### DIFF
--- a/internal/staging/checkpoint/checkpoint.go
+++ b/internal/staging/checkpoint/checkpoint.go
@@ -61,9 +61,11 @@ func (r *Checkpoints) Start(
 	ret.metrics.proposedTime = proposedTime.With(labels)
 	ret.metrics.refreshDuration = refreshDuration.With(labels)
 
+	// This query may indeed require a full table scan.
 	ret.sql.refresh = fmt.Sprintf(refreshTemplate, r.metaTable)
-	ret.sql.mark = fmt.Sprintf(advanceTemplate, r.metaTable)
-	ret.sql.record = fmt.Sprintf(applyTemplate, r.metaTable)
+	hinted := r.pool.HintNoFTS(r.metaTable)
+	ret.sql.mark = fmt.Sprintf(advanceTemplate, hinted)
+	ret.sql.record = fmt.Sprintf(applyTemplate, hinted)
 
 	// Populate data immediately.
 	if err := ret.refreshBounds(ctx); err != nil {

--- a/internal/target/apply/column_mapping.go
+++ b/internal/target/apply/column_mapping.go
@@ -49,7 +49,7 @@ type columnMapping struct {
 	PK                   []types.ColData              // The names of the PK columns.
 	PKDelete             []types.ColData              // The names of the PK columns to delete.
 	Renames              *ident.Map[ident.Ident]      // External (source) names to target names.
-	TableName            ident.Table                  // The target table.
+	TableName            *ident.Hinted[ident.Table]   // The target table.
 	UpsertParameterCount int                          // The number of SQL arguments.
 }
 
@@ -63,7 +63,10 @@ type positionalColumn struct {
 }
 
 func newColumnMapping(
-	cfg *applycfg.Config, cols []types.ColData, product types.Product, table ident.Table,
+	cfg *applycfg.Config,
+	cols []types.ColData,
+	product types.Product,
+	table *ident.Hinted[ident.Table],
 ) (*columnMapping, error) {
 	ret := &columnMapping{
 		Conditions:   make([]types.ColData, len(cfg.CASColumns)),

--- a/internal/target/apply/provider.go
+++ b/internal/target/apply/provider.go
@@ -44,7 +44,7 @@ func ProvideAcceptor(
 		cache:    cache,
 		configs:  configs,
 		dlqs:     dlqs,
-		product:  target.Product,
+		poolInfo: target.Info(),
 		stop:     ctx,
 		watchers: watchers,
 	}

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -77,6 +77,8 @@ var (
 			switch t := prefix.(type) {
 			case string:
 				id = t
+			case *ident.Hinted[ident.Table]:
+				id = t.Base.Table().String() + t.Hint
 			case ident.Ident:
 				id = t.String()
 			case ident.Table:

--- a/internal/target/apply/templates_test.go
+++ b/internal/target/apply/templates_test.go
@@ -473,7 +473,12 @@ func checkTemplate(t *testing.T, global *templateGlobal, tc *templateTestCase) {
 		cfg.Patch(tc.cfg)
 	}
 
-	mapping, err := newColumnMapping(cfg, global.cols, global.product, global.tableID)
+	var hint string
+	if global.product == types.ProductCockroachDB {
+		hint = "@{NO_FULL_SCAN}"
+	}
+
+	mapping, err := newColumnMapping(cfg, global.cols, global.product, ident.WithHint(global.tableID, hint))
 	r.NoError(err)
 
 	tmpls, err := newTemplates(mapping)

--- a/internal/target/apply/testdata/crdb/base.delete.sql
+++ b/internal/target/apply/testdata/crdb/base.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
 ($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/base.toasted.sql
+++ b/internal/target/apply/testdata/crdb/base.toasted.sql
@@ -19,10 +19,10 @@ SELECT
  data."enum",
  data."has_default"
 FROM data
-LEFT JOIN  "database"."schema"."table" as current
+LEFT JOIN  "database"."schema"."table"@{NO_FULL_SCAN} as current
 USING ("pk0","pk1"))
 
-UPSERT INTO "database"."schema"."table" (
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} (
 "pk0","pk1","val0","val1","geom","geog","enum","has_default"
 )
 SELECT "pk0","pk1","val0","val1","geom","geog","enum","has_default"  FROM action

--- a/internal/target/apply/testdata/crdb/base.upsert.sql
+++ b/internal/target/apply/testdata/crdb/base.upsert.sql
@@ -1,4 +1,4 @@
-UPSERT INTO "database"."schema"."table" (
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} (
 "pk0","pk1","val0","val1","geom","geog","enum","has_default"
 ) VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),

--- a/internal/target/apply/testdata/crdb/cas.delete.sql
+++ b/internal/target/apply/testdata/crdb/cas.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
 ($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/cas.upsert.sql
+++ b/internal/target/apply/testdata/crdb/cas.upsert.sql
@@ -4,8 +4,8 @@ VALUES
 ($10::STRING,$11::INT8,$12::STRING,$13::STRING,st_geomfromgeojson($14::JSONB),st_geogfromgeojson($15::JSONB),$16::"database"."schema"."MyEnum",CASE WHEN $17::BOOLEAN THEN $18::INT8 ELSE expr() END)),
 data AS (SELECT (row_number() OVER () - 1) __idx__, * FROM raw_data),
 current AS (
-SELECT "pk0","pk1", "table"."val1","table"."val0"
-FROM "database"."schema"."table"
+SELECT "pk0","pk1", "table"@{NO_FULL_SCAN}."val1","table"@{NO_FULL_SCAN}."val0"
+FROM "database"."schema"."table"@{NO_FULL_SCAN}
 JOIN data
 USING ("pk0","pk1")),
 action AS (
@@ -15,10 +15,10 @@ USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
 (data."val1",data."val0") > (current."val1",current."val0")),
 upserted AS (
-UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
 SELECT "pk0","pk1","val0","val1","geom","geog","enum","has_default" FROM action
 RETURNING "pk0","pk1")
-SELECT data.__idx__, t."pk0",t."pk1",t."val0",t."val1",t."geom",t."geog",t."enum",t."has_default" FROM "database"."schema"."table" t
+SELECT data.__idx__, t."pk0",t."pk1",t."val0",t."val1",t."geom",t."geog",t."enum",t."has_default" FROM "database"."schema"."table"@{NO_FULL_SCAN} t
 JOIN data USING ("pk0","pk1")
 LEFT JOIN upserted USING ("pk0","pk1")
 WHERE upserted."pk0" IS NULL

--- a/internal/target/apply/testdata/crdb/casDeadline.delete.sql
+++ b/internal/target/apply/testdata/crdb/casDeadline.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
 ($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/deadline.delete.sql
+++ b/internal/target/apply/testdata/crdb/deadline.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
 ($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/deadline.upsert.sql
+++ b/internal/target/apply/testdata/crdb/deadline.upsert.sql
@@ -5,10 +5,10 @@ VALUES
 data AS (SELECT (row_number() OVER () - 1) __idx__, * FROM raw_data),
 deadlined AS (SELECT * FROM data WHERE("val0">now()-'1h0m0s'::INTERVAL)AND("val1">now()-'1s'::INTERVAL)),
 upserted AS (
-UPSERT INTO "database"."schema"."table" ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} ("pk0","pk1","val0","val1","geom","geog","enum","has_default")
 SELECT "pk0","pk1","val0","val1","geom","geog","enum","has_default" FROM deadlined
 RETURNING "pk0","pk1")
-SELECT data.__idx__, t."pk0",t."pk1",t."val0",t."val1",t."geom",t."geog",t."enum",t."has_default" FROM "database"."schema"."table" t
+SELECT data.__idx__, t."pk0",t."pk1",t."val0",t."val1",t."geom",t."geog",t."enum",t."has_default" FROM "database"."schema"."table"@{NO_FULL_SCAN} t
 JOIN data USING ("pk0","pk1")
 LEFT JOIN upserted USING ("pk0","pk1")
 WHERE upserted."pk0" IS NULL

--- a/internal/target/apply/testdata/crdb/expr.delete.sql
+++ b/internal/target/apply/testdata/crdb/expr.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,($2+$2)::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,($2+$2)::INT8,$3::STRING),
 ($4::STRING,($5+$5)::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/expr.upsert.sql
+++ b/internal/target/apply/testdata/crdb/expr.upsert.sql
@@ -1,4 +1,4 @@
-UPSERT INTO "database"."schema"."table" (
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} (
 "pk0","pk1","val0","val1","enum","has_default"
 ) VALUES
 ($1::STRING,($2+$2)::INT8,('fixed')::STRING,($3||'foobar')::STRING,$4::"database"."schema"."MyEnum",CASE WHEN $5::BOOLEAN THEN $6::INT8 ELSE expr() END),

--- a/internal/target/apply/testdata/crdb/ignore.delete.sql
+++ b/internal/target/apply/testdata/crdb/ignore.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
 ($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/ignore.upsert.sql
+++ b/internal/target/apply/testdata/crdb/ignore.upsert.sql
@@ -1,4 +1,4 @@
-UPSERT INTO "database"."schema"."table" (
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} (
 "pk0","pk1","val0","val1","enum","has_default"
 ) VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,$5::"database"."schema"."MyEnum",CASE WHEN $6::BOOLEAN THEN $7::INT8 ELSE expr() END),

--- a/internal/target/apply/testdata/crdb/source_names.delete.sql
+++ b/internal/target/apply/testdata/crdb/source_names.delete.sql
@@ -1,2 +1,2 @@
-DELETE FROM "database"."schema"."table" WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
+DELETE FROM "database"."schema"."table"@{NO_FULL_SCAN} WHERE ("pk0","pk1","ignored_pk")IN(($1::STRING,$2::INT8,$3::STRING),
 ($4::STRING,$5::INT8,$6::STRING))

--- a/internal/target/apply/testdata/crdb/source_names.upsert.sql
+++ b/internal/target/apply/testdata/crdb/source_names.upsert.sql
@@ -1,4 +1,4 @@
-UPSERT INTO "database"."schema"."table" (
+UPSERT INTO "database"."schema"."table"@{NO_FULL_SCAN} (
 "pk0","pk1","val0","val1","geom","geog","enum","has_default"
 ) VALUES
 ($1::STRING,$2::INT8,$3::STRING,$4::STRING,st_geomfromgeojson($5::JSONB),st_geogfromgeojson($6::JSONB),$7::"database"."schema"."MyEnum",CASE WHEN $8::BOOLEAN THEN $9::INT8 ELSE expr() END),

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -390,6 +390,15 @@ type PoolInfo struct {
 	// ErrCode returns a database error code, if err is of the pool's
 	// underlying driver error type.
 	ErrCode func(err error) (string, bool) `json:"-"`
+	// HintNoFTS decorates the table name to prevent CockroachDB from
+	// generating an UPSERT (or other) plan that may involve a full
+	// table scan. For other databases or versions of CockroachDB that
+	// do not support this hint, this function returns an unhinted table
+	// name.
+	//
+	// https://www.cockroachlabs.com/docs/stable/table-expressions#prevent-full-scan
+	// https://github.com/cockroachdb/cockroach/issues/98211
+	HintNoFTS func(table ident.Table) *ident.Hinted[ident.Table] `json:"-"`
 	// IsDeferrable returns true if the error might clear if the work is
 	// tried at a future point in time (e.g.: foreign key dependencies).
 	IsDeferrable func(err error) bool `json:"-"`

--- a/internal/util/ident/hint.go
+++ b/internal/util/ident/hint.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ident
+
+// Hinted decorates the raw and sql-safe string representations of an
+// Identifier with an extra, target-specific hint string.
+type Hinted[I Identifier] struct {
+	Base I
+	Hint string
+}
+
+// WithHint wraps the identifier with a target-specific hint. An empty
+// hint string is valid.
+func WithHint[I Identifier](id I, hint string) *Hinted[I] {
+	return &Hinted[I]{id, hint}
+}
+
+// Raw implements [Identifier] and concatenates the underlying raw
+// representation with the hint.
+func (h *Hinted[I]) Raw() string {
+	return h.Base.Raw() + h.Hint
+}
+
+// String implements [Identifier] and concatenates the underlying
+// sql-safe representation with the hint.
+func (h *Hinted[I]) String() string {
+	return h.Base.String() + h.Hint
+}

--- a/internal/util/ident/hint_test.go
+++ b/internal/util/ident/hint_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ident
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHint(t *testing.T) {
+	r := require.New(t)
+
+	tbl := NewTable(MustSchema(New("my_db"), Public), New("tbl"))
+	h := WithHint(tbl, "@{HINT}")
+
+	r.Equal(`my_db.public.tbl@{HINT}`, h.Raw())
+	r.Equal(`"my_db"."public"."tbl"@{HINT}`, h.String())
+}

--- a/internal/util/stdpool/crdb_hints.go
+++ b/internal/util/stdpool/crdb_hints.go
@@ -1,0 +1,104 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stdpool
+
+import (
+	"regexp"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
+)
+
+// For example:
+//
+//	CockroachDB CCL v23.1.17 (aarch64-apple-darwin21.2, ....)
+var roachVerPattern = regexp.MustCompile(`^CockroachDB.* (v\d+\.\d+.\d+) `)
+
+// CockroachSemver extracts the semantic version string from a cluster's
+// reported version.
+func CockroachSemver(version string) (string, bool) {
+	found := roachVerPattern.FindStringSubmatch(version)
+	if found == nil {
+		return "", false
+	}
+	return found[1], true
+}
+
+// CockroachMinVersion returns true if the CockroachDB version string is
+// at least the specified minimum.
+func CockroachMinVersion(version string, minVersion string) (bool, error) {
+	found, ok := CockroachSemver(version)
+	if !ok {
+		return false, errors.Errorf("could not extract semver from %q", version)
+	}
+	if !semver.IsValid(found) {
+		return false, errors.Errorf("not a semver: %q", found)
+	}
+	if !semver.IsValid(minVersion) {
+		return false, errors.Errorf("not a semver: %q", minVersion)
+	}
+	return semver.Compare(found, minVersion) >= 0, nil
+}
+
+// cockroachSupportsNoFullScanHint returns true for CRDB >= v23.1.17 or
+// CRDB >= v23.2.3.
+//
+// https://github.com/cockroachdb/cockroach/pull/119104
+func cockroachSupportsNoFullScanHint(version string) (bool, error) {
+	if ok, err := CockroachMinVersion(version, "v23.2.3"); err != nil {
+		return false, err
+	} else if ok {
+		return true, nil
+	}
+	if isV232, err := CockroachMinVersion(version, "v23.2.0"); err != nil {
+		return false, err
+	} else if isV232 {
+		return false, nil
+	}
+	return CockroachMinVersion(version, "v23.1.17")
+}
+
+func emptyHint(table ident.Table) *ident.Hinted[ident.Table] {
+	return ident.WithHint(table, "")
+}
+
+func noFullScanHint(table ident.Table) *ident.Hinted[ident.Table] {
+	return ident.WithHint(table, "@{NO_FULL_SCAN}")
+}
+
+// setTableHint will populate the [types.PoolInfo.HintNoFTS] field.
+func setTableHint(info *types.PoolInfo) error {
+	if info.Version == "" {
+		return errors.New("set PoolInfo.Version first")
+	}
+	if info.Product != types.ProductCockroachDB {
+		info.HintNoFTS = emptyHint
+		return nil
+	}
+	ok, err := cockroachSupportsNoFullScanHint(info.Version)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		info.HintNoFTS = emptyHint
+		return nil
+	}
+	info.HintNoFTS = noFullScanHint
+	return nil
+}

--- a/internal/util/stdpool/crdb_hints_test.go
+++ b/internal/util/stdpool/crdb_hints_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stdpool
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFTSHintSupported(t *testing.T) {
+	tcs := []struct {
+		version string
+		hinted  bool
+	}{
+		{"v23.1.16", false},
+		{"v23.1.17", true},
+		{"v23.1.18", true},
+		{"v23.2.0", false},
+		{"v23.2.1", false},
+		{"v23.2.2", false},
+		{"v23.2.3", true},
+		{"v23.2.4", true},
+		{"v24.1.0", true},
+	}
+
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			r := require.New(t)
+			tc.version = fmt.Sprintf("CockroachDB CCL %s (platform)", tc.version)
+			support, err := cockroachSupportsNoFullScanHint(tc.version)
+			r.NoError(err)
+			r.Equal(tc.hinted, support)
+		})
+	}
+}
+
+func TestFTSPoolInfo(t *testing.T) {
+	tcs := []struct {
+		version string
+		hinted  bool
+	}{
+		{"v23.1.16", false},
+		{"v23.1.17", true},
+	}
+	for idx, tc := range tcs {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			r := require.New(t)
+			pi := &types.PoolInfo{
+				Product: types.ProductCockroachDB,
+				Version: fmt.Sprintf("CockroachDB CCL %s (platform)", tc.version),
+			}
+			r.NoError(setTableHint(pi))
+			r.NotNil(pi.HintNoFTS)
+
+			hint := pi.HintNoFTS(ident.Table{}).Hint
+			if tc.hinted {
+				r.Equal("@{NO_FULL_SCAN}", hint)
+			} else {
+				r.Empty(hint)
+			}
+		})
+	}
+	t.Run("non-crdb", func(t *testing.T) {
+		r := require.New(t)
+		pi := &types.PoolInfo{
+			Product: types.ProductPostgreSQL,
+			Version: "ignored",
+		}
+		r.NoError(setTableHint(pi))
+		r.NotNil(pi.HintNoFTS)
+		r.Empty(pi.HintNoFTS(ident.Table{}).Hint)
+	})
+}

--- a/internal/util/stdpool/my.go
+++ b/internal/util/stdpool/my.go
@@ -151,6 +151,9 @@ func OpenMySQLAsTarget(
 		if strings.Contains(ret.Version, "MariaDB") {
 			ret.PoolInfo.Product = types.ProductMariaDB
 		}
+		if err := setTableHint(ret.Info()); err != nil {
+			return nil, err
+		}
 		// If debug is enabled we print sql mode and ssl info.
 		if log.IsLevelEnabled(log.DebugLevel) {
 			var mode string

--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -129,7 +129,9 @@ ping:
 	if err := ret.QueryRow("SELECT banner FROM V$VERSION").Scan(&ret.Version); err != nil {
 		return nil, errors.Wrap(err, "could not query version")
 	}
-
+	if err := setTableHint(ret.Info()); err != nil {
+		return nil, err
+	}
 	if err := attachOptions(ctx, ret.DB, options); err != nil {
 		return nil, err
 	}

--- a/internal/util/stdpool/pgx.go
+++ b/internal/util/stdpool/pgx.go
@@ -119,7 +119,9 @@ func OpenPgxAsStaging(
 	if !strings.HasPrefix(ret.Version, "CockroachDB") {
 		return nil, errors.Errorf("only CockroachDB is supported as a staging server; saw %q", ret.Version)
 	}
-
+	if err := setTableHint(ret.Info()); err != nil {
+		return nil, err
+	}
 	if err := attachOptions(ctx, &ret.PoolInfo, options); err != nil {
 		return nil, err
 	}
@@ -156,6 +158,9 @@ func OpenPgxAsTarget(
 		return ret.QueryRowContext(ctx, "SELECT version()").Scan(&ret.Version)
 	}); err != nil {
 		return nil, errors.Wrap(err, "could not determine cluster version")
+	}
+	if err := setTableHint(ret.Info()); err != nil {
+		return nil, err
 	}
 
 	switch {


### PR DESCRIPTION
This change adds an explicit hint for hot-path UPSERT statements in the apply and stage packages. We see cases where stale or missing table statistics in CockroachDB cause an UPSERT to execute with a full table scan, leading to performance decay. By adding an `@{NO_FULL_SCAN}` hint, we can force the optimizer to issue a lookup join.

The `ident.Hinted` wrapper associates an identifier with an arbitrary suffix that contains a table or index hint. This design is generalized to support other potential target database use cases that would benefit from hints.

In the specific case of CockroachDB, support for this hint is added in v23.1.17 and v23.2.3, so we need to conditionally inject the hinting behavior. This is accomplished by adding another helper function to PoolInfo that will decorate a table name if appropriate.

While it would be possible to set the CockroachDB `disallow_full_table_scans` session variable by way of the pgx connection parameters, there are some bootstrap and metrics cases that do require full scans. The number of performance-critical queries that require this hint is relatively small, hence the choice to selectively hint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/812)
<!-- Reviewable:end -->
