### PR TITLE
stdpool: Extract prerelease version strings correctly

### DIFF
--- a/internal/util/stdpool/crdb_hints.go
+++ b/internal/util/stdpool/crdb_hints.go
@@ -28,7 +28,8 @@ import (
 // For example:
 //
 //	CockroachDB CCL v23.1.17 (aarch64-apple-darwin21.2, ....)
-var roachVerPattern = regexp.MustCompile(`^CockroachDB.* (v\d+\.\d+.\d+) `)
+//	CockroachDB CCL v24.1.0-alpha.5-dev-d45a65e08d45383aade2bcffdcdbe72a0cc279b1 (....)
+var roachVerPattern = regexp.MustCompile(`^CockroachDB.* (v\d+\.\d+.\d+(-[^ ]+)?) `)
 
 // CockroachSemver extracts the semantic version string from a cluster's
 // reported version.

--- a/internal/util/stdpool/crdb_hints_test.go
+++ b/internal/util/stdpool/crdb_hints_test.go
@@ -38,6 +38,7 @@ func TestFTSHintSupported(t *testing.T) {
 		{"v23.2.2", false},
 		{"v23.2.3", true},
 		{"v23.2.4", true},
+		{"v24.1.0-alpha.5-dev-d45a65e08d45383aade2bcffdcdbe72a0cc279b1", true},
 		{"v24.1.0", true},
 	}
 


### PR DESCRIPTION
The regex used in crdb_hints.go did not consider prerelease versions. The pattern has been extended to consume the extra prerelease values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/818)
<!-- Reviewable:end -->
