### PR TITLE
kafka: finding proper offset to start replay, given a min timestamp

### DIFF
--- a/internal/source/kafka/conn_test.go
+++ b/internal/source/kafka/conn_test.go
@@ -126,14 +126,15 @@ func TestConn(t *testing.T) {
 
 	addr := mb.Addr()
 	config := &Config{
-		BatchSize:     1,
-		Brokers:       []string{addr},
-		Group:         "my-group",
-		Strategy:      "sticky",
-		Topics:        []string{"my-topic"},
-		saslMechanism: sarama.SASLTypePlaintext,
-		saslUser:      "user",
-		saslPassword:  "test",
+		BatchSize:        1,
+		Brokers:          []string{addr},
+		Group:            "my-group",
+		ResolvedInterval: time.Second,
+		Strategy:         "sticky",
+		Topics:           []string{"my-topic"},
+		saslMechanism:    sarama.SASLTypePlaintext,
+		saslUser:         "user",
+		saslPassword:     "test",
 	}
 	err := config.preflight(ctx)
 	a.NoError(err)

--- a/internal/source/kafka/integration_test.go
+++ b/internal/source/kafka/integration_test.go
@@ -184,11 +184,12 @@ func getConfig(fixture *base.Fixture, fc *fixtureConfig, tgt ident.Table) (*Conf
 		},
 		TargetSchema: dbName,
 
-		BatchSize: 100,
-		Brokers:   []string{broker},
-		Group:     dbName.Raw(),
-		Strategy:  "sticky",
-		Topics:    []string{tgt.Raw()},
+		BatchSize:        100,
+		Brokers:          []string{broker},
+		Group:            dbName.Raw(),
+		ResolvedInterval: time.Second,
+		Strategy:         "sticky",
+		Topics:           []string{tgt.Raw()},
 	}
 	if fc.chaos {
 		config.Sequencer.Chaos = 0.0005

--- a/internal/source/kafka/metrics.go
+++ b/internal/source/kafka/metrics.go
@@ -1,0 +1,43 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// TODO (silvano) Provide a grafana dashboard for kafka connector.
+// https://github.com/cockroachdb/cdc-sink/issues/829
+var (
+	mutationsErrorCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "kafka_mutations_error_count",
+		Help: "the total number of mutations that encountered an error during processing",
+	}, []string{"topic", "partition"})
+	mutationsReceivedCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "kafka_mutations_received_count",
+		Help: "the total number of mutations received from the source",
+	}, []string{"topic", "partition"})
+	mutationsSuccessCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "kafka_mutations_success_count",
+		Help: "the total number of mutations that were successfully processed",
+	}, []string{"topic", "partition"})
+	seekMessagesCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "kafka_seeks_count",
+		Help: "the total of messages read seeking a minimum resolved timestamp",
+	}, []string{"topic", "partition"})
+)

--- a/internal/source/kafka/mocks/client.go
+++ b/internal/source/kafka/mocks/client.go
@@ -1,0 +1,200 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mocks implements a simple Kafka client and consumer for testing purposes.
+// The main use case is to test a consumer that has a predefined set of messages.
+// Note: only the methods that are actively used for testing are implemented.
+package mocks
+
+import (
+	"time"
+
+	"github.com/IBM/sarama"
+	log "github.com/sirupsen/logrus"
+)
+
+// MockClient implements sarama.Client interface for testing purposes.
+type MockClient struct {
+	closed   bool
+	config   *sarama.Config
+	consumer *MockConsumer
+	offsets  map[string]map[int32][]time.Time
+}
+
+var _ sarama.Client = &MockClient{}
+
+// NewMockClient instantiate a new client that always returns the given Consumer
+func NewMockClient(config *sarama.Config, consumer *MockConsumer) *MockClient {
+	offsets := make(map[string]map[int32][]time.Time)
+	for topic, partitions := range consumer.messages {
+		offsets[topic] = make(map[int32][]time.Time)
+		for partition, messages := range partitions {
+			offsets[topic][partition] = make([]time.Time, len(messages))
+			for offset, message := range messages {
+				offsets[topic][partition][offset] = message.Timestamp
+			}
+		}
+	}
+	return &MockClient{
+		config:   config,
+		consumer: consumer,
+		offsets:  offsets,
+	}
+}
+
+// Consumer returns the underlying sarama.Consumer.
+func (m *MockClient) Consumer() sarama.Consumer {
+	return m.consumer
+}
+
+// Broker implements sarama.Client.
+func (m *MockClient) Broker(brokerID int32) (*sarama.Broker, error) {
+	panic("unimplemented")
+}
+
+// Brokers implements sarama.Client.
+func (m *MockClient) Brokers() []*sarama.Broker {
+	panic("unimplemented")
+}
+
+// Close implements sarama.Client.
+func (m *MockClient) Close() error {
+	m.closed = true
+	return m.consumer.Close()
+}
+
+// Closed implements sarama.Client.
+func (m *MockClient) Closed() bool {
+	return m.closed
+}
+
+// Config implements sarama.Client.
+func (m *MockClient) Config() *sarama.Config {
+	return m.config
+}
+
+// Controller implements sarama.Client.
+func (m *MockClient) Controller() (*sarama.Broker, error) {
+	panic("unimplemented")
+}
+
+// Coordinator implements sarama.Client.
+func (m *MockClient) Coordinator(consumerGroup string) (*sarama.Broker, error) {
+	panic("unimplemented")
+}
+
+// GetOffset implements sarama.Client.
+func (m *MockClient) GetOffset(topic string, partitionID int32, time int64) (int64, error) {
+	offsets := m.offsets[topic][partitionID]
+	if time == sarama.OffsetNewest {
+		return int64(len(offsets)) + m.consumer.oldestOffset, nil
+	}
+	if time == sarama.OffsetOldest {
+		return m.consumer.oldestOffset, nil
+	}
+	res := sarama.OffsetOldest
+	for i, o := range offsets {
+		log.Tracef("Comparing %d %d\n", o.UnixMilli(), time)
+		if o.UnixMilli() > time {
+			log.Debugf("Found %d %d\n", o.UnixMilli(), res)
+			return res, nil
+		}
+		res = int64(i) + m.consumer.oldestOffset
+	}
+	return sarama.OffsetNewest, nil
+}
+
+// InSyncReplicas implements sarama.Client.
+func (m *MockClient) InSyncReplicas(topic string, partitionID int32) ([]int32, error) {
+	panic("unimplemented")
+}
+
+// InitProducerID implements sarama.Client.
+func (m *MockClient) InitProducerID() (*sarama.InitProducerIDResponse, error) {
+	panic("unimplemented")
+}
+
+// Leader implements sarama.Client.
+func (m *MockClient) Leader(topic string, partitionID int32) (*sarama.Broker, error) {
+	panic("unimplemented")
+}
+
+// LeaderAndEpoch implements sarama.Client.
+func (m *MockClient) LeaderAndEpoch(
+	topic string, partitionID int32,
+) (*sarama.Broker, int32, error) {
+	panic("unimplemented")
+}
+
+// LeastLoadedBroker implements sarama.Client.
+func (m *MockClient) LeastLoadedBroker() *sarama.Broker {
+	panic("unimplemented")
+}
+
+// OfflineReplicas implements sarama.Client.
+func (m *MockClient) OfflineReplicas(topic string, partitionID int32) ([]int32, error) {
+	panic("unimplemented")
+}
+
+// Partitions implements sarama.Client.
+func (m *MockClient) Partitions(topic string) ([]int32, error) {
+	return m.consumer.Partitions(topic)
+}
+
+// RefreshBrokers implements sarama.Client.
+func (m *MockClient) RefreshBrokers(addrs []string) error {
+	panic("unimplemented")
+}
+
+// RefreshController implements sarama.Client.
+func (m *MockClient) RefreshController() (*sarama.Broker, error) {
+	panic("unimplemented")
+}
+
+// RefreshCoordinator implements sarama.Client.
+func (m *MockClient) RefreshCoordinator(consumerGroup string) error {
+	panic("unimplemented")
+}
+
+// RefreshMetadata implements sarama.Client.
+func (m *MockClient) RefreshMetadata(topics ...string) error {
+	panic("unimplemented")
+}
+
+// RefreshTransactionCoordinator implements sarama.Client.
+func (m *MockClient) RefreshTransactionCoordinator(transactionID string) error {
+	panic("unimplemented")
+}
+
+// Replicas implements sarama.Client.
+func (m *MockClient) Replicas(topic string, partitionID int32) ([]int32, error) {
+	panic("unimplemented")
+}
+
+// Topics implements sarama.Client.
+func (m *MockClient) Topics() ([]string, error) {
+	panic("unimplemented")
+}
+
+// TransactionCoordinator implements sarama.Client.
+func (m *MockClient) TransactionCoordinator(transactionID string) (*sarama.Broker, error) {
+	panic("unimplemented")
+}
+
+// WritablePartitions implements sarama.Client.
+func (m *MockClient) WritablePartitions(topic string) ([]int32, error) {
+	panic("unimplemented")
+}

--- a/internal/source/kafka/mocks/consumer.go
+++ b/internal/source/kafka/mocks/consumer.go
@@ -1,0 +1,101 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import "github.com/IBM/sarama"
+
+// MockConsumer is a consumer for a fixed set of messages.
+type MockConsumer struct {
+	oldestOffset int64
+	messages     map[string]map[int32][]*Message
+}
+
+var _ sarama.Consumer = &MockConsumer{}
+
+// NewMockConsumer creates a consumer for the given set of messages
+func NewMockConsumer(messages map[string]map[int32][]*Message, oldestOffset int64) *MockConsumer {
+	return &MockConsumer{
+		messages:     messages,
+		oldestOffset: oldestOffset,
+	}
+}
+
+// Close implements sarama.Consumer.
+func (m *MockConsumer) Close() error {
+	return nil
+}
+
+// ConsumePartition implements sarama.Consumer.
+func (m *MockConsumer) ConsumePartition(
+	topic string, partition int32, offset int64,
+) (sarama.PartitionConsumer, error) {
+	return NewMockPartitionConsumer(topic, partition, m.messages[topic][partition], offset, m.oldestOffset), nil
+}
+
+// HighWaterMarks implements sarama.Consumer.
+func (m *MockConsumer) HighWaterMarks() map[string]map[int32]int64 {
+	res := make(map[string]map[int32]int64)
+	for topic, topicMessages := range m.messages {
+		res[topic] = make(map[int32]int64)
+		for part, partMessages := range topicMessages {
+			res[topic][part] = int64(len(partMessages)) + m.oldestOffset
+		}
+	}
+	return res
+}
+
+// Partitions implements sarama.Consumer.
+func (m *MockConsumer) Partitions(topic string) ([]int32, error) {
+	res := make([]int32, len(m.messages[topic]))
+	i := 0
+	for part := range m.messages[topic] {
+		res[i] = part
+		i++
+	}
+	return res, nil
+}
+
+// Pause implements sarama.Consumer.
+func (m *MockConsumer) Pause(topicPartitions map[string][]int32) {
+	panic("unimplemented")
+}
+
+// PauseAll implements sarama.Consumer.
+func (m *MockConsumer) PauseAll() {
+	panic("unimplemented")
+}
+
+// Resume implements sarama.Consumer.
+func (m *MockConsumer) Resume(topicPartitions map[string][]int32) {
+	panic("unimplemented")
+}
+
+// ResumeAll implements sarama.Consumer.
+func (m *MockConsumer) ResumeAll() {
+	panic("unimplemented")
+}
+
+// Topics implements sarama.Consumer.
+func (m *MockConsumer) Topics() ([]string, error) {
+	res := make([]string, len(m.messages))
+	i := 0
+	for topic := range m.messages {
+		res[i] = topic
+		i++
+	}
+	return res, nil
+}

--- a/internal/source/kafka/mocks/partition.go
+++ b/internal/source/kafka/mocks/partition.go
@@ -1,0 +1,126 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import (
+	"time"
+
+	"github.com/IBM/sarama"
+	log "github.com/sirupsen/logrus"
+)
+
+// Message is used to abstract a Kafka message for testing purposes.
+type Message struct {
+	Timestamp  time.Time
+	Key, Value []byte
+}
+
+// MockPartitionConsumer implements sarama.PartitionConsumer interface for testing purposes.
+type MockPartitionConsumer struct {
+	done         chan struct{}
+	errChan      chan *sarama.ConsumerError
+	oldestOffset int64
+	messages     []*Message
+	msgChan      chan *sarama.ConsumerMessage
+	offset       int64
+	partition    int32
+	topic        string
+}
+
+var _ sarama.PartitionConsumer = &MockPartitionConsumer{}
+
+// NewMockPartitionConsumer sets the messages that the partition will return to the consumer.
+func NewMockPartitionConsumer(
+	topic string, partition int32, messages []*Message, offset int64, oldestOffset int64,
+) *MockPartitionConsumer {
+	part := &MockPartitionConsumer{
+		done:         make(chan struct{}),
+		errChan:      make(chan *sarama.ConsumerError),
+		messages:     messages,
+		oldestOffset: oldestOffset,
+		msgChan:      make(chan *sarama.ConsumerMessage),
+		offset:       offset - oldestOffset,
+		partition:    partition,
+		topic:        topic,
+	}
+	go part.start()
+	return part
+}
+
+func (m *MockPartitionConsumer) start() {
+outer:
+	for m.offset < int64(len(m.messages)) {
+		msg := &sarama.ConsumerMessage{
+			Key:       m.messages[m.offset].Key,
+			Offset:    m.offset + m.oldestOffset,
+			Timestamp: m.messages[m.offset].Timestamp,
+			Topic:     m.topic,
+			Value:     m.messages[m.offset].Value,
+		}
+		select {
+		case <-m.done:
+			break outer
+		case m.msgChan <- msg:
+			m.offset++
+		}
+	}
+	log.Debug("MockPartitionConsumer is done")
+	close(m.msgChan)
+	close(m.errChan)
+}
+
+// AsyncClose implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) AsyncClose() {
+	log.Debug("MockPartitionConsumer.AsyncClose")
+	m.done <- struct{}{}
+}
+
+// Close implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) Close() error {
+	m.AsyncClose()
+	return nil
+}
+
+// Errors implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	return m.errChan
+}
+
+// HighWaterMarkOffset implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) HighWaterMarkOffset() int64 {
+	return int64(len(m.messages))
+}
+
+// IsPaused implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) IsPaused() bool {
+	panic("unimplemented")
+}
+
+// Messages implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return m.msgChan
+}
+
+// Pause implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) Pause() {
+	panic("unimplemented")
+}
+
+// Resume implements sarama.PartitionConsumer.
+func (m *MockPartitionConsumer) Resume() {
+	panic("unimplemented")
+}

--- a/internal/source/kafka/offset.go
+++ b/internal/source/kafka/offset.go
@@ -1,0 +1,206 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// OffsetSeeker finds offsets within Kafka topics.
+type OffsetSeeker interface {
+	// GetOffsets finds the most recent offsets for resolved timestamp messages
+	// that are before the given time, and in the given topics.
+	GetOffsets([]string, hlc.Time) ([]*partitionState, error)
+	// Close shuts down the connection with the Kafka broker.
+	Close() error
+}
+
+// offsetSeeker implements the OffsetSeeker interface.
+type offsetSeeker struct {
+	client                 sarama.Client
+	consumer               sarama.Consumer
+	resolvedIntervalMillis int64
+}
+
+// NewOffsetSeeker instantiates an offsetManager.
+func NewOffsetSeeker(config *Config) (OffsetSeeker, error) {
+	cl, err := sarama.NewClient(config.Brokers, config.saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+	consumer, err := sarama.NewConsumerFromClient(cl)
+	if err != nil {
+		return nil, err
+	}
+	return &offsetSeeker{
+		client:                 cl,
+		consumer:               consumer,
+		resolvedIntervalMillis: config.ResolvedInterval.Milliseconds(),
+	}, nil
+}
+
+var _ OffsetSeeker = &offsetSeeker{}
+
+// GetOffsets implements OffsetSeeker.
+func (o *offsetSeeker) GetOffsets(topics []string, min hlc.Time) ([]*partitionState, error) {
+	res := make([]*partitionState, 0)
+	// TODO (silvano): make this parallel https://github.com/cockroachdb/cdc-sink/issues/830
+	for _, topic := range topics {
+		partitions, err := o.client.Partitions(topic)
+		if err != nil {
+			return nil, err
+		}
+		for _, partition := range partitions {
+			offset, err := o.getPartitionOffset(min, topic, partition)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, &partitionState{
+				topic:     topic,
+				partition: partition,
+				offset:    offset,
+			})
+		}
+	}
+	return res, nil
+}
+
+// Close implements OffsetSeeker
+func (o *offsetSeeker) Close() error {
+	if err := o.consumer.Close(); err != nil {
+		return err
+	}
+	return o.client.Close()
+}
+
+// getPartitionOffset get the most recent offsets at the given time
+// for a specific topic and partition.
+func (o *offsetSeeker) getPartitionOffset(
+	min hlc.Time, topic string, partition int32,
+) (int64, error) {
+	minMillis := min.Nanos() / int64(time.Millisecond)
+	// Get the offset at log head.
+	loghead, err := o.client.GetOffset(topic, partition, sarama.OffsetNewest)
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	log.Debugf("loghead for %s@%d = %d", topic, partition, loghead)
+	last := loghead
+	var offset int64
+	// Looking for an offset that is reasonably just before the given min
+	// resolved timestamp.
+	// We want to limit as much as possible applying messages that are before
+	// the given min timestamp, but we want to make sure we don't miss any
+	// mutation after it.
+	for {
+		// Get the most recent available offset at the given time.
+		offset, err = o.client.GetOffset(topic, partition, minMillis)
+		if err != nil {
+			return 0, errors.WithStack(err)
+		}
+		// We are all caught up
+		if offset == sarama.OffsetNewest {
+			return sarama.OffsetNewest, nil
+		}
+		// If the topic has low traffic, we make sure we go back at least
+		// one message since the last message we saw.
+		if offset >= last {
+			offset = last - 1
+		}
+		if offset < 0 {
+			// There are no messages in the channel older than the
+			// min timestamp.
+			offset = sarama.OffsetOldest
+			break
+		}
+		max := last
+		last = offset
+		// Verify that we see the min timestamp right after the offset.
+		offset, err = o.seekResolved(min, topic, partition,
+			offsetRange{offset, max})
+		if err != nil {
+			return 0, errors.WithStack(err)
+		}
+		// seekResolved returns sarama.OffsetOldest if in the given range
+		// we have not found a resolved message that is less than the min timestamp.
+		if offset != sarama.OffsetOldest {
+			// We found a suitable offset.
+			break
+		}
+		// If we get sarama.OffsetOldest, we try to see if can do better by
+		// going back resolvedIntervalMillis.
+		minMillis = minMillis - o.resolvedIntervalMillis
+	}
+	log.Infof("topic:%s partition:%d offset:%d latest:%d", topic, partition, offset, loghead)
+	return offset, nil
+}
+
+// seekResolved finds the most recent resolved timestamp message within the
+// specified offset range that is before the given time.
+// It returns sarama.OffsetOldest if we don't find it.
+func (o *offsetSeeker) seekResolved(
+	min hlc.Time, topic string, partition int32, offsets offsetRange,
+) (int64, error) {
+	log.Debugf("seekResolved: finding a message earlier than %s within [%d - %d]", min, offsets.min, offsets.max)
+	partConsumer, err := o.consumer.ConsumePartition(topic, partition, offsets.min)
+	if err != nil {
+		return 0, err
+	}
+	defer partConsumer.Close()
+	found := sarama.OffsetOldest
+	for {
+		select {
+		case msg, ok := <-partConsumer.Messages():
+			seekMessagesCount.WithLabelValues(topic, strconv.Itoa(int(partition))).Inc()
+			if !ok {
+				return 0, errors.Errorf("consumer for %s closed", topic)
+			}
+			if msg.Offset > offsets.max {
+				// we reached the end of the offset range without finding the resolved timestamp.
+				return sarama.OffsetOldest, nil
+			}
+			payload, err := asPayload(msg)
+			if err != nil {
+				return 0, err
+			}
+			if payload.Resolved != "" {
+				timestamp, err := hlc.Parse(payload.Resolved)
+				if err != nil {
+					return 0, err
+				}
+				log.Debugf("seekResolved: checking message @%d %d", msg.Offset, timestamp.Nanos())
+				if hlc.Compare(min, timestamp) <= 0 {
+					if found >= 0 {
+						log.Debugf("seekResolved: found message @%d", found)
+					}
+					// we are seeing a resolved message after the min timestamp
+					// the previous found value is what we are looking for.
+					return found, nil
+				}
+				found = msg.Offset
+			}
+		case err := <-partConsumer.Errors():
+			return 0, err
+		}
+	}
+}

--- a/internal/source/kafka/offset_test.go
+++ b/internal/source/kafka/offset_test.go
@@ -1,0 +1,346 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/cockroachdb/cdc-sink/internal/source/kafka/mocks"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTime(sec int64) hlc.Time {
+	return hlc.New(sec*int64(time.Second), 0)
+}
+func timestamp(t hlc.Time) time.Time {
+	return time.Unix(0, t.Nanos()+int64(rand.IntN(int(time.Millisecond))))
+}
+func resolved(t hlc.Time) *mocks.Message {
+	return &mocks.Message{
+		Timestamp: timestamp(t),
+		Key:       []byte(""),
+		Value:     []byte(fmt.Sprintf(`{"resolved":"%s"}`, t)),
+	}
+}
+func mut(t hlc.Time, key string) *mocks.Message {
+	return &mocks.Message{
+		Timestamp: timestamp(t),
+		Key:       []byte(key),
+		Value:     []byte(fmt.Sprintf(`{"updated":"%s"}`, t)),
+	}
+}
+
+func TestGetOffsets(t *testing.T) {
+	tests := []struct {
+		name         string
+		topics       []string
+		messages     map[string]map[int32][]*mocks.Message
+		min          hlc.Time
+		oldestOffset int64
+		want         map[string]map[int]int64
+		wantErr      bool
+	}{
+		{
+			name:   "one topic, one empty partition",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {},
+				},
+			},
+			min: newTime(4),
+			want: map[string]map[int]int64{
+				"topic": {
+					0: sarama.OffsetNewest,
+				},
+			},
+		},
+		{
+			name:   "one topic, one partition",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min: newTime(4),
+			want: map[string]map[int]int64{
+				"topic": {
+					0: 3,
+				},
+			},
+		},
+		{
+			name:   "one topic, one partition, oldest offset > 0",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min:          newTime(4),
+			oldestOffset: 100,
+			want: map[string]map[int]int64{
+				"topic": {
+					0: 103,
+				},
+			},
+		},
+		{
+			name:   "one topic, one partition, replay",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min: newTime(4),
+			want: map[string]map[int]int64{
+				"topic": {
+					0: 5,
+				},
+			},
+		},
+		{
+			name:   "one topic, one partition from beginning",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min: newTime(0),
+			want: map[string]map[int]int64{
+				"topic": {
+					0: sarama.OffsetOldest,
+				},
+			},
+		},
+		{
+			name:   "one topic, one partition from beginning, oldest offset > 0",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min:          newTime(0),
+			oldestOffset: 123,
+			want: map[string]map[int]int64{
+				"topic": {
+					0: sarama.OffsetOldest,
+				},
+			},
+		},
+		{
+			name:   "one topic, one partition, no pending messages",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min: newTime(6),
+			want: map[string]map[int]int64{
+				"topic": {
+					0: sarama.OffsetNewest,
+				},
+			},
+		},
+		{
+			name:   "one topic, multiple partitions",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"topic": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+					1: {
+						resolved(newTime(1)),
+						mut(newTime(2), "12"),
+						resolved(newTime(2)),
+						mut(newTime(3), "13"),
+						resolved(newTime(3)),
+						mut(newTime(4), "12"),
+						mut(newTime(4), "13"),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+					2: {
+						resolved(newTime(1)),
+						mut(newTime(2), "20"),
+						mut(newTime(2), "21"),
+						mut(newTime(2), "22"),
+						mut(newTime(2), "23"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						mut(newTime(4), "23"),
+						mut(newTime(4), "22"),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min: newTime(4),
+			want: map[string]map[int]int64{
+				"topic": {
+					0: 3,
+					1: 4,
+					2: 6,
+				},
+			},
+		},
+		{
+			name:   "two topics, multiple partitions",
+			topics: []string{"topic"},
+			messages: map[string]map[int32][]*mocks.Message{
+				"one": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						mut(newTime(3), "2"),
+						resolved(newTime(3)),
+						mut(newTime(4), "3"),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+				"two": {
+					0: {
+						resolved(newTime(1)),
+						mut(newTime(2), "1"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+					1: {
+						resolved(newTime(1)),
+						mut(newTime(2), "12"),
+						resolved(newTime(2)),
+						mut(newTime(3), "13"),
+						resolved(newTime(3)),
+						mut(newTime(4), "12"),
+						mut(newTime(4), "13"),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+					2: {
+						resolved(newTime(1)),
+						mut(newTime(2), "20"),
+						mut(newTime(2), "21"),
+						mut(newTime(2), "22"),
+						mut(newTime(2), "23"),
+						resolved(newTime(2)),
+						resolved(newTime(3)),
+						mut(newTime(4), "23"),
+						mut(newTime(4), "22"),
+						resolved(newTime(4)),
+						resolved(newTime(5)),
+					},
+				},
+			},
+			min: newTime(4),
+			want: map[string]map[int]int64{
+				"one": {
+					0: 4,
+				},
+				"two": {
+					0: 3,
+					1: 4,
+					2: 6,
+				},
+			},
+		},
+	}
+	intervals := []int64{500, 1000, 2000}
+	for _, tt := range tests {
+		for _, interval := range intervals {
+			interval := interval
+			name := fmt.Sprintf("%s_%d", tt.name, interval)
+			t.Run(name, func(t *testing.T) {
+				a := assert.New(t)
+				consumer := mocks.NewMockConsumer(tt.messages, tt.oldestOffset)
+				seeker := &offsetSeeker{
+					client:                 mocks.NewMockClient(&sarama.Config{}, consumer),
+					consumer:               consumer,
+					resolvedIntervalMillis: interval,
+				}
+				got, err := seeker.GetOffsets(tt.topics, tt.min)
+				a.NoError(err)
+				for _, g := range got {
+					a.Equal(tt.want[g.topic][int(g.partition)], g.offset)
+				}
+			})
+		}
+	}
+}

--- a/internal/source/kafka/payload.go
+++ b/internal/source/kafka/payload.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/IBM/sarama"
+	"github.com/pkg/errors"
+)
+
+// payload is the encoding of a mutation in a Kafka message.
+type payload struct {
+	After    json.RawMessage `json:"after"`
+	Before   json.RawMessage `json:"before"`
+	Resolved string          `json:"resolved"`
+	Updated  string          `json:"updated"`
+}
+
+// asPayload extracts the mutation payload from a Kafka consumer message.
+func asPayload(msg *sarama.ConsumerMessage) (*payload, error) {
+	payload := &payload{}
+	dec := json.NewDecoder(bytes.NewReader(msg.Value))
+	dec.UseNumber()
+	if err := dec.Decode(payload); err != nil {
+		// Empty input is a no-op.
+		if errors.Is(err, io.EOF) {
+			return payload, nil
+		}
+		return nil, errors.Wrap(err, "could not decode payload")
+	}
+	return payload, nil
+}

--- a/internal/source/kafka/payload_test.go
+++ b/internal/source/kafka/payload_test.go
@@ -1,0 +1,141 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAsPayload verifies that we can parse a Kafka message to a payload struct.
+func TestAsPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     *sarama.ConsumerMessage
+		want    *payload
+		wantErr string
+	}{
+		{
+			name: "insert",
+			msg: &sarama.ConsumerMessage{
+				Timestamp: time.Now(),
+				Topic:     "table",
+				Partition: 0,
+				Key:       []byte(`[0]`),
+				Value:     []byte(`{"after": {"k":0, "v": "a"}, "updated":"1.0"}`),
+			},
+			want: &payload{
+				After:    []byte(`{"k":0, "v": "a"}`),
+				Before:   nil,
+				Resolved: "",
+				Updated:  "1.0",
+			},
+		},
+		{
+			name: "insert",
+			msg: &sarama.ConsumerMessage{
+				Timestamp: time.Now(),
+				Topic:     "table",
+				Partition: 0,
+				Key:       []byte(`[0]`),
+				Value:     []byte(`{"after": {"k":0, "v": "a"}, "updated":"1.0"}`),
+			},
+			want: &payload{
+				After:    []byte(`{"k":0, "v": "a"}`),
+				Before:   nil,
+				Resolved: "",
+				Updated:  "1.0",
+			},
+		},
+		{
+			name: "update",
+			msg: &sarama.ConsumerMessage{
+				Timestamp: time.Now(),
+				Topic:     "table",
+				Partition: 0,
+				Key:       []byte(`[0]`),
+				Value:     []byte(`{"after": {"k":0, "v": "b"},"before": {"k":0, "v": "a"}, "updated":"2.0"}`),
+			},
+			want: &payload{
+				After:    []byte(`{"k":0, "v": "b"}`),
+				Before:   []byte(`{"k":0, "v": "a"}`),
+				Resolved: "",
+				Updated:  "2.0",
+			},
+		},
+		{
+			name: "delete",
+			msg: &sarama.ConsumerMessage{
+				Timestamp: time.Now(),
+				Topic:     "table",
+				Partition: 0,
+				Key:       []byte(`[0]`),
+				Value:     []byte(`{"before": {"k":0, "v": "a"}, "updated":"5.0"}`),
+			},
+			want: &payload{
+				After:    nil,
+				Before:   []byte(`{"k":0, "v": "a"}`),
+				Resolved: "",
+				Updated:  "5.0",
+			},
+		},
+		{
+			name: "resolved",
+			msg: &sarama.ConsumerMessage{
+				Timestamp: time.Now(),
+				Topic:     "table",
+				Partition: 0,
+				Key:       []byte(`[0]`),
+				Value:     []byte(`{"resolved":"11.0"}`),
+			},
+			want: &payload{
+				After:    nil,
+				Before:   nil,
+				Resolved: "11.0",
+				Updated:  "",
+			},
+		},
+		{
+			name: "invalid",
+			msg: &sarama.ConsumerMessage{
+				Timestamp: time.Now(),
+				Topic:     "table",
+				Partition: 0,
+				Key:       []byte(`[0]`),
+				Value:     []byte(`tt{"resolved":"11.0"}`),
+			},
+			wantErr: "could not decode payload",
+		},
+	}
+	for _, tt := range tests {
+		a := assert.New(t)
+		r := require.New(t)
+		got, err := asPayload(tt.msg)
+		if tt.wantErr != "" {
+			a.Error(err)
+			a.ErrorContains(err, tt.wantErr)
+		} else {
+			r.NoError(err)
+		}
+		a.Equal(tt.want, got)
+	}
+
+}


### PR DESCRIPTION
This change improves the logic to find an adequate offset to start the event replay. We return the offset of the most recent resolved timestamp message that is stricly less than the minimum timestamp provided by the user.

A new set of metrics have been added to track the total number of messages that have been replayed, and the number of messages read to find the resolved timestamp.

A new mock client and consumer have been introduced to facilitate testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/824)
<!-- Reviewable:end -->
