### PR TITLE
workflows: Fix docker push setup

### DIFF
--- a/.github/workflows/go-docker.yaml
+++ b/.github/workflows/go-docker.yaml
@@ -45,10 +45,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: linux/amd64
-          - platform: linux/amd64
+          - platforms: linux/amd64,linux/arm64
+          - platforms: linux/amd64
             target: "oracle"
-          - platform: linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,7 +79,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platforms }}
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Docker image pushes are not additive. This builds and pushes the AMD and Arm builds in a single stage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/826)
<!-- Reviewable:end -->
