### PR TITLE
checkpoint: Support for partitioned checkpoints

### DIFF
--- a/internal/source/cdc/resolved.go
+++ b/internal/source/cdc/resolved.go
@@ -67,5 +67,5 @@ func (h *Handler) resolved(ctx context.Context, req *request) error {
 	if err != nil {
 		return err
 	}
-	return target.checkpoint.Advance(ctx, req.timestamp)
+	return target.checkpoint.Advance(ctx, target.partition, req.timestamp)
 }

--- a/internal/source/cdc/targets.go
+++ b/internal/source/cdc/targets.go
@@ -39,6 +39,7 @@ type targetInfo struct {
 	acceptor       types.MultiAcceptor         // Possibly-async writes to the target.
 	checkpoint     *checkpoint.Group           // Persistence of checkpoint (fka. resolved) timestamps
 	mode           notify.Var[switcher.Mode]   // Switchable strategies.
+	partition      ident.Ident                 // For future configuration.
 	resolvingRange notify.Var[hlc.Range]       // Range of resolved timestamps to be processed.
 	stat           *notify.Var[sequencer.Stat] // Processing status.
 	target         ident.Schema                // Identify for logging.
@@ -96,8 +97,9 @@ func (t *Targets) getTarget(schema ident.Schema) (*targetInfo, error) {
 	}
 
 	ret := &targetInfo{
-		target:  schema,
-		watcher: w,
+		partition: ident.New(schema.Canonical().Raw()),
+		target:    schema,
+		watcher:   w,
 	}
 
 	ret.checkpoint, err = t.checkpoints.Start(t.stopper, tableGroup, &ret.resolvingRange)

--- a/internal/staging/checkpoint/group.go
+++ b/internal/staging/checkpoint/group.go
@@ -18,15 +18,16 @@ package checkpoint
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/notify"
 	"github.com/cockroachdb/cdc-sink/internal/util/retry"
 	"github.com/cockroachdb/cdc-sink/internal/util/stopper"
 	"github.com/cockroachdb/cdc-sink/internal/util/stopvar"
-	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -36,36 +37,35 @@ import (
 // timestamp for a target schema.
 const schema = `
 CREATE TABLE IF NOT EXISTS %[1]s (
-  target_schema     STRING      NOT NULL,
-  source_nanos      INT         NOT NULL,
-  source_logical    INT         NOT NULL,
+  group_name        STRING      NOT NULL,
+  source_hlc        DECIMAL     NOT NULL,
+  partition         STRING      NOT NULL,
   first_seen        TIMESTAMPTZ NOT NULL DEFAULT now(),
   target_applied_at TIMESTAMPTZ,
-  source_wall_time  TIMESTAMPTZ AS (to_timestamp(source_nanos::FLOAT8 / 1e9)) VIRTUAL,
-  PRIMARY KEY (target_schema, source_nanos, source_logical),
-  INDEX (target_schema, source_nanos DESC, source_logical DESC)
-)`
 
-// Used for v21.X and v22.1 that don't support to_timestamp().
-const schemaNoTimestamp = `
-CREATE TABLE IF NOT EXISTS %[1]s (
-  target_schema     STRING      NOT NULL,
-  source_nanos      INT         NOT NULL,
-  source_logical    INT         NOT NULL,
-  first_seen        TIMESTAMPTZ NOT NULL DEFAULT now(),
-  target_applied_at TIMESTAMPTZ,
-  PRIMARY KEY (target_schema, source_nanos, source_logical),
-  INDEX (target_schema, source_nanos DESC, source_logical DESC)
+-- Virtual columns for DBA convenience
+  source_nanos      INT8        AS (floor(source_hlc)::INT8) VIRTUAL,
+  source_logical    INT8        AS (((source_hlc-floor(source_hlc))*1e10)::INT8) VIRTUAL,
+  source_wall_time  TIMESTAMPTZ AS (to_timestamp(floor(source_hlc)::FLOAT8 / 1e9)) VIRTUAL,
+  PRIMARY KEY (group_name, source_hlc, partition),
+  INDEX (group_name, target_applied_at, partition)
 )`
 
 // Group provides durable storage of the checkpoint (FKA resolved)
-// timestamps associated with a [types.TableGroup]. Timestamps to be
-// processed are recorded with [Group.Advance] and their completion is
-// recorded via [Group.Commit]. This Group type will collaborate with
-// other components by driving a [notify.Var] containing an [hlc.Range].
-// This range represents a window of eligible checkpoints that require
-// processing, where the minimum is called "committed" and the maximum
-// is called "proposed".
+// timestamps associated with a [types.TableGroup].
+//
+// Timestamps to be processed are recorded with [Group.Advance] and
+// their completion is recorded via [Group.Commit]. A checkpoint may
+// consist of an arbitrary number of partitions, which may be
+// pre-created with [Group.Ensure].
+//
+//	This Group type will collaborate with other components by driving a
+//	[notify.Var] containing an [hlc.Range]. This range represents a
+//	window of eligible checkpoints that require processing, where the
+//	minimum is called "committed" and the maximum is called "proposed".
+//	The proposed time is the least common maximum value across all
+//	partitions of a checkpoint, whereas the commit time is always common
+//	to all partitions.
 type Group struct {
 	bounds     *notify.Var[hlc.Range]
 	pool       *types.StagingPool
@@ -84,46 +84,47 @@ type Group struct {
 	}
 
 	sql struct {
-		mark    string
-		record  string
+		advance string
+		commit  string
+		ensure  string
 		refresh string
 	}
 }
 
-// This query conditionally inserts a new mark for a target schema if
+// This query conditionally inserts a new mark for a partition if
 // there is no previous mark or if the proposed mark is equal to or
-// after the latest-known mark for the target schema.
+// after the latest-known mark for the target partition.
 //
-// $1 = target_schema
-// $2 = source_nanos
-// $3 = source_logical
+// $1 = group_name
+// $2 = partition
+// $3 = source_hlc
 const advanceTemplate = `
 WITH
 not_before AS (
-  SELECT source_nanos, source_logical FROM %[1]s
-  WHERE target_schema=$1
-  ORDER BY source_nanos desc, source_logical desc
+  SELECT source_hlc FROM %[1]s
+  WHERE group_name=$1 AND partition=$2 
+  ORDER BY source_hlc DESC
   FOR UPDATE
   LIMIT 1),
 to_insert AS (
-  SELECT $1::STRING, $2::INT, $3::INT
+  SELECT $1::STRING, $2::STRING, $3::DECIMAL
   WHERE (SELECT count(*) FROM not_before) = 0
-     OR ($2::INT, $3::INT) >= (SELECT (source_nanos, source_logical) FROM not_before))
-UPSERT INTO %[1]s (target_schema, source_nanos, source_logical)
+     OR ($3::DECIMAL) >= (SELECT source_hlc FROM not_before))
+UPSERT INTO %[1]s (group_name, partition, source_hlc)
 SELECT * FROM to_insert`
 
 // Advance extends the proposed checkpoint timestamp associated with the
-// Group. It is an error if the timestamp does not advance beyond its
-// current point, as this will indicate a violation of changefeed
-// invariants. If successful, this method will asynchronously refresh
-// the Group.
-func (r *Group) Advance(ctx context.Context, ts hlc.Time) error {
+// partition of the Group. It is an error if the timestamp does not
+// advance beyond its current point, as this will indicate a violation
+// of changefeed invariants. If successful, this method will
+// asynchronously refresh the Group.
+func (r *Group) Advance(ctx context.Context, partition ident.Ident, ts hlc.Time) error {
 	start := time.Now()
 	tag, err := r.pool.Exec(ctx,
-		r.sql.mark,
+		r.sql.advance,
 		r.target.Name.Canonical().Raw(),
-		ts.Nanos(),
-		ts.Logical(),
+		partition.Canonical().Raw(),
+		ts,
 	)
 	if err != nil {
 		return errors.WithStack(err)
@@ -131,10 +132,10 @@ func (r *Group) Advance(ctx context.Context, ts hlc.Time) error {
 	if tag.RowsAffected() == 0 {
 		r.metrics.backwards.Inc()
 		return errors.Errorf(
-			"proposed checkpoint timestamp for %s is going backwards %s; "+
+			"proposed checkpoint timestamp for group=%s, partition=%s is going backwards: %s; "+
 				"verify changefeed cursor or remove already-applied "+
 				"checkpoint timestamp entries",
-			r.target, ts)
+			r.target, partition, ts)
 	}
 	r.Refresh()
 
@@ -142,15 +143,21 @@ func (r *Group) Advance(ctx context.Context, ts hlc.Time) error {
 	log.WithFields(log.Fields{
 		"checkpoint": ts,
 		"group":      r.target,
+		"partition":  partition,
 	}).Trace("advanced checkpoint timestamp")
 	return nil
 }
 
-const applyTemplate = `
+// Sets target_applied_at to now().
+//
+// $1 = group_name
+// $2 = hlc_min
+// $3 = hlc_max
+const commitTemplate = `
 UPDATE %s 
 SET target_applied_at = now()
-WHERE target_schema = $1
-AND (source_nanos, source_logical) >= ($2, $3) AND (source_nanos, source_logical) < ($4, $5)
+WHERE group_name = $1
+AND source_hlc >= $2 AND source_hlc < $3
 AND target_applied_at IS NULL
 `
 
@@ -161,12 +168,10 @@ func (r *Group) Commit(ctx context.Context, rng hlc.Range) error {
 	err := retry.Retry(ctx, r.pool, func(ctx context.Context) error {
 		start := time.Now()
 		_, err := r.pool.Exec(ctx,
-			r.sql.record,
+			r.sql.commit,
 			r.target.Name.Canonical().Raw(),
-			rng.Min().Nanos(),
-			rng.Min().Logical(),
-			rng.Max().Nanos(),
-			rng.Max().Logical(),
+			rng.Min(),
+			rng.Max(),
 		)
 		if err == nil {
 			r.metrics.commitDuration.Observe(time.Since(start).Seconds())
@@ -175,6 +180,37 @@ func (r *Group) Commit(ctx context.Context, rng hlc.Range) error {
 	})
 	if err == nil {
 		log.Tracef("recorded checkpoint timestamps for %s: %s", r.target, rng)
+		r.Refresh()
+	}
+	return err
+}
+
+const ensureTemplate = `
+UPSERT INTO %[1]s (group_name, partition, source_hlc, target_applied_at)
+SELECT $1, $2, 1.0000000001, now()
+ WHERE NOT EXISTS (SELECT 1 FROM %[1]s WHERE group_name=$1 AND partition=$2)
+`
+
+// Ensure that a checkpoint exists for all named partitions. If no
+// checkpoint exists for a given partition, an applied, minimum-valued
+// checkpoint will be created. This method can be used to expand the
+// number of partitions associated with a group at any point in time.
+func (r *Group) Ensure(ctx context.Context, partitions []ident.Ident) error {
+	err := retry.Retry(ctx, r.pool, func(ctx context.Context) error {
+		tx, err := r.pool.Begin(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		for _, part := range partitions {
+			if _, err := tx.Exec(ctx, r.sql.ensure, r.target.Name.Raw(), part.Raw()); err != nil {
+				return errors.Wrap(err, r.sql.ensure)
+			}
+		}
+		return errors.WithStack(tx.Commit(ctx))
+	})
+	if err == nil {
 		r.Refresh()
 	}
 	return err
@@ -191,46 +227,73 @@ func (r *Group) TableGroup() *types.TableGroup {
 	return r.target
 }
 
-// This query computes the open checkpoint window. That is, it returns
-// the newest applied and newest unapplied checkpoint times.
+// This query computes the open checkpoint window for the entire group.
+// That is, it returns the newest applied and newest unapplied
+// checkpoint times across all partitions of the group.
 //
 // Params:
-//   - $1: target schema
-//   - $2: last successful checkpoint nanos
-//   - $3: last successful checkpoint logical
+//   - $1: group name
+//   - $2: last successful checkpoint to reduce table scan range
 //
 // CTE components:
-//   - start: The newest applied timestamp
-//   - stop: The newest unapplied timestamp (i.e. the last row)
-//
-// The top-level query uses coalesce+sub-select to provide default
-// values if either one of the CTE elements returns no rows. In the
-// bootstrap or idle case, the ($2, $3) pair will be emitted.
+//   - available_data: A buffer of data after the previous checkpoint.
+//   - partition_max_times: Determines the latest known checkpoint for
+//     each partition within the group.
+//   - visible_data: Restricts available_data by the minimum-maximum
+//     value from p_max_times.
+//   - partition_max_unapplied: Finds the last checkpoint time that
+//     hasn't been processed.
+//   - last_applied: Finds the latest applied timestamp within
+//     visible_data. This is almost always going to be the start point.
+//   - stop: Finds the minimum unapplied timestamp within the visible
+//     data. If there are no unapplied timestamps, this will return the
+//     last-applied time to create an empty range.
+//   - look_back: Handles a degenerate case where there's a gap in the
+//     checkpoint entries and last_applied is actually after the stop
+//     point.
 const refreshTemplate = `
 WITH
-start AS (
-SELECT source_nanos n, source_logical l
+available_data AS (
+SELECT partition, source_hlc, target_applied_at
   FROM %[1]s
- WHERE target_schema = $1
-   AND (source_nanos, source_logical) >= ($2, $3)
-   AND target_applied_at IS NOT NULL
- ORDER BY n DESC, l DESC
- LIMIT 1
+ WHERE group_name = $1
+   AND source_hlc >= $2
+),
+partition_max_times AS (
+SELECT partition, max(source_hlc) AS hlc
+  FROM available_data
+ GROUP BY partition
+),
+visible_data AS (
+SELECT *
+  FROM available_data
+ WHERE source_hlc <= (SELECT min(hlc) FROM partition_max_times)
+),
+partition_max_unapplied AS (
+SELECT partition, max(source_hlc) AS hlc
+  FROM visible_data
+ WHERE target_applied_at IS NULL
+ GROUP BY partition
+),
+last_applied AS (
+SELECT max(source_hlc) AS hlc
+  FROM visible_data
+ WHERE target_applied_at IS NOT NULL
 ),
 stop AS (
-SELECT source_nanos n, source_logical l
-  FROM %[1]s
- WHERE target_schema = $1
-   AND (source_nanos, source_logical) >= ($2, $3)
-   AND target_applied_at IS NULL
- ORDER BY n DESC, l DESC
- LIMIT 1
+SELECT min(COALESCE(partition_max_unapplied.hlc, (SELECT hlc FROM last_applied))) AS hlc
+  FROM (SELECT DISTINCT partition FROM visible_data)
+  LEFT JOIN partition_max_unapplied USING (partition)
+),
+look_back AS (
+SELECT max(source_hlc) AS hlc
+  FROM visible_data
+ WHERE target_applied_at IS NOT NULL
+   AND source_hlc <= (SELECT hlc FROM stop)
 )
-SELECT 
-  COALESCE((SELECT start.n FROM start), $2),
-  COALESCE((SELECT start.l FROM start), $3),
-  COALESCE((SELECT stop.n FROM stop), $2),
-  COALESCE((SELECT stop.l FROM stop), $3)
+SELECT
+  (SELECT hlc FROM look_back),
+  (SELECT hlc FROM stop)
 `
 
 // refreshBounds synchronizes the in-memory bounds with the database.
@@ -238,35 +301,46 @@ func (r *Group) refreshBounds(ctx context.Context) error {
 	return retry.Retry(ctx, r.pool, func(ctx context.Context) error {
 		_, _, err := r.bounds.Update(func(old hlc.Range) (hlc.Range, error) {
 			start := time.Now()
-			var next hlc.Range
-			var minNanos, maxNanos int64
-			var minLogical, maxLogical int
-			if err := r.pool.QueryRow(ctx, r.sql.refresh,
-				r.target.Name.Canonical().Raw(),
-				old.Min().Nanos(),
-				old.Min().Logical(),
-			).Scan(&minNanos, &minLogical, &maxNanos, &maxLogical); err == nil {
-				next = hlc.RangeIncluding(
-					hlc.New(minNanos, minLogical),
-					hlc.New(maxNanos, maxLogical),
-				)
-			} else if errors.Is(err, pgx.ErrNoRows) {
-				// If there's no data for this group, do nothing.
-				return old, notify.ErrNoUpdate
-			} else {
-				return hlc.RangeEmpty(), errors.WithStack(err)
+			next, err := r.refreshQuery(ctx, old.Min())
+			if err != nil {
+				return hlc.RangeEmpty(), nil
 			}
 			if next == old {
 				log.Tracef("group %s: checkpoint range unchanged: %s", r.target, old)
 				return old, notify.ErrNoUpdate
 			}
-
 			log.Tracef("group %s: checkpoint range: %s -> %s", r.target, old, next)
 			r.metrics.refreshDuration.Observe(time.Since(start).Seconds())
 			return next, nil
 		})
 		return err
 	})
+}
+
+func (r *Group) refreshQuery(ctx context.Context, knownCommitted hlc.Time) (hlc.Range, error) {
+	var ret hlc.Range
+	err := retry.Retry(ctx, r.pool, func(ctx context.Context) error {
+		var nextMin, nextMax sql.Null[hlc.Time]
+		if err := r.pool.QueryRow(ctx, r.sql.refresh,
+			r.target.Name.Canonical().Raw(),
+			knownCommitted,
+		).Scan(&nextMin, &nextMax); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if !nextMin.Valid {
+			nextMin.V = knownCommitted
+		}
+
+		if nextMax.Valid {
+			ret = hlc.RangeIncluding(nextMin.V, nextMax.V)
+		} else {
+			ret = hlc.RangeIncluding(nextMin.V, nextMin.V)
+		}
+
+		return nil
+	})
+	return ret, err
 }
 
 // refreshJob starts a goroutine to periodically synchronize the

--- a/internal/staging/checkpoint/migrate.go
+++ b/internal/staging/checkpoint/migrate.go
@@ -1,0 +1,102 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/retry"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// migrate from the old resolved_timestamps table schema to the current
+// checkpoints table schema. This function will add a check constraint
+// to the resolved_timestamps table to prevent any future writes, rename
+// the table, and copy data into the new checkpoints table.
+func migrate(ctx context.Context, pool *types.StagingPool, old, new ident.Table) error {
+	return retry.Retry(ctx, pool, func(ctx context.Context) error {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		// Test for old table. This function accepts quoted idents.
+		var found *string
+		if err := tx.QueryRow(ctx, `select to_regclass($1)`, old.String()).Scan(&found); err != nil {
+			return errors.WithStack(err)
+		}
+
+		// No old table.
+		if found == nil {
+			return nil
+		}
+
+		constraint := ident.New(old.Table().Raw() + "_is_deprecated")
+
+		// Determine if we've already run the migration by looking for
+		// the check constraint. We need to fully-qualify the reference
+		// to pg_catalog, since the connection has no default database
+		// name.
+		var count int
+		if err := tx.QueryRow(ctx, fmt.Sprintf(`
+SELECT count(*)
+  FROM %s.pg_catalog.pg_constraint
+ WHERE conrelid=$1::REGCLASS AND conname=$2`, old.Schema().Idents(nil)[0]),
+			old.Raw(), constraint.Raw(),
+		).Scan(&count); err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Already migrated.
+		if count > 0 {
+			return nil
+		}
+
+		log.Infof("migrating %s to %s", old, new)
+
+		// Add a constraint that blocks all future writes.
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`
+ALTER TABLE %s ADD CONSTRAINT %s CHECK ('this_table_is_deprecated'='') NOT VALID`,
+			old, constraint),
+		); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`
+INSERT INTO %s (group_name, partition, source_hlc, first_seen, target_applied_at)
+SELECT target_schema, target_schema,
+       source_nanos::DECIMAL + (source_logical::DECIMAL/1e10)::DECIMAL(10,10),
+       first_seen, target_applied_at
+  FROM %s
+`, new, old),
+		); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			return errors.WithStack(err)
+		}
+
+		log.Infof("migrated %s to %s", old, new)
+		return nil
+	})
+}

--- a/internal/staging/checkpoint/migrate_test.go
+++ b/internal/staging/checkpoint/migrate_test.go
@@ -1,0 +1,102 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package checkpoint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cdc-sink/internal/sinktest/base"
+	"github.com/cockroachdb/cdc-sink/internal/types"
+	"github.com/cockroachdb/cdc-sink/internal/util/hlc"
+	"github.com/cockroachdb/cdc-sink/internal/util/ident"
+	"github.com/cockroachdb/cdc-sink/internal/util/notify"
+	"github.com/stretchr/testify/require"
+)
+
+const oldSchema = `
+CREATE TABLE %[1]s (
+  target_schema     STRING      NOT NULL,
+  source_nanos      INT         NOT NULL,
+  source_logical    INT         NOT NULL,
+  first_seen        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  target_applied_at TIMESTAMPTZ,
+  PRIMARY KEY (target_schema, source_nanos, source_logical)
+)
+`
+
+// This ensures that we can transition from the old resolved_timestamps
+// table schema to the new partitioned checkpoints schema.
+func TestMigration(t *testing.T) {
+	r := require.New(t)
+
+	fixture, err := base.NewFixture(t)
+	r.NoError(err)
+
+	ctx := fixture.Context
+
+	oldTable := ident.NewTable(fixture.StagingDB.Schema(),
+		ident.New("resolved_timestamps"))
+	_, err = fixture.StagingPool.Exec(ctx, fmt.Sprintf(oldSchema, oldTable))
+	r.NoError(err)
+
+	_, err = fixture.StagingPool.Exec(ctx, fmt.Sprintf(`
+INSERT INTO %s (target_schema, source_nanos, source_logical, target_applied_at) VALUES 
+ ('foo.public', 100, 1, '2024-04-22 15:01:06+00'),
+ ('foo.public', 200, 2, '2024-04-22 15:02:06+00'),
+ ('foo.public', 300, 3, NULL),
+ ('foo.public', 400, 4, NULL),
+ ('bar.baz', 700, 7, '2024-04-22 15:03:06+00'),
+ ('bar.baz', 800, 8, NULL),
+ ('quux.public', 900, 9, '2024-04-22 15:04:06+00')
+`, oldTable))
+	r.NoError(err)
+
+	chk, err := ProvideCheckpoints(ctx, fixture.StagingPool, fixture.StagingDB)
+	r.NoError(err)
+
+	schemas, err := chk.ScanForTargetSchemas(ctx)
+	r.NoError(err)
+	r.Len(schemas, 2) // Only returns unresolved schemas.
+
+	expected := map[string]hlc.Range{
+		"foo.public":  hlc.RangeIncluding(hlc.New(200, 2), hlc.New(400, 4)),
+		"bar.baz":     hlc.RangeIncluding(hlc.New(700, 7), hlc.New(800, 8)),
+		"quux.public": hlc.RangeIncluding(hlc.New(900, 9), hlc.New(900, 9)),
+	}
+	for id, expect := range expected {
+		rng, err := chk.newGroup(&types.TableGroup{
+			Name: ident.New(id),
+		}, notify.VarOf(hlc.RangeEmpty()),
+		).refreshQuery(ctx, hlc.Zero())
+		r.NoError(err)
+		r.Equal(expect, rng)
+	}
+
+	// Verify writes are blocked.
+	_, err = fixture.StagingPool.Exec(ctx, fmt.Sprintf(`
+INSERT INTO %s (target_schema, source_nanos, source_logical, target_applied_at) VALUES 
+ ('will.fail', 900, 9, '2024-04-22 15:04:06+00')
+`, oldTable))
+	code, ok := fixture.StagingPool.ErrCode(err)
+	r.True(ok)
+	r.Equal("23514", code) // check_violation
+
+	// Ensure that the next instance to be created will succeed.
+	_, err = ProvideCheckpoints(ctx, fixture.StagingPool, fixture.StagingDB)
+	r.NoError(err)
+}

--- a/internal/staging/version/versions.go
+++ b/internal/staging/version/versions.go
@@ -42,6 +42,7 @@ var Versions = []Version{
 	{"Add versions table", 400},
 	{"Support single-level schema namespaces", 389},
 	{"Track applied in staging table", 572},
+	{"Migrate resolved_timestamps to checkpoints", 828},
 }
 
 // A Version describes a breaking change in the cdc-sink metadata

--- a/internal/util/hlc/hlc_test.go
+++ b/internal/util/hlc/hlc_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBefore(t *testing.T) {
@@ -152,4 +153,18 @@ func TestParse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSQLHelpers(t *testing.T) {
+	r := require.New(t)
+
+	now := New(100, 200)
+
+	value, err := now.Value()
+	r.NoError(err)
+	r.Equal("100.0000000200", value)
+
+	var next Time
+	r.NoError(next.Scan(value))
+	r.Equal(now, next)
 }

--- a/migrations/pr_828.md
+++ b/migrations/pr_828.md
@@ -1,0 +1,33 @@
+# PR 828 Support partitioned checkpoints
+
+[PR 828](https://github.com/cockroachdb/cdc-sink/pull/828)
+
+Breaking schema change:
+
+The `resolved_timestamps` table is retired in favor of a `checkpoints`
+table which can support partitioned checkpoints (e.g. for partitioned
+Kafka topics or to allow multiple changefeeds to feed into the same
+target schema). The existing table will be blocked and renamed to
+support a rollback case. Manual intervention is required only to ensure
+a clean transition between use of the two tables.
+
+Migration:
+* Stop all instances of cdc-sink
+* Mark the migration as complete:
+```postgresql
+UPSERT INTO _cdc_sink.memo (key, value) VALUES ('version-828','{"state":"applied"}');
+```
+* Start a single instance of cdc-sink and wait for the automatic migration to occur.
+* Start any remaining instances as necessary.
+
+## Rollback
+
+* Stop all instances of cdc-sink.
+* Execute the following:
+```postgresql
+ALTER TABLE _cdc_sink.resolved_timestamps DROP CONSTRAINT resolved_timestamps_is_deprecated;
+DROP TABLE _cdc_sink.checkpoints CASCADE;
+```
+* Restart old instances of cdc-sink.
+* If the changefeed is still running, a newly-received resolved
+  timestamp message will resynchronize the system.


### PR DESCRIPTION
This change supports checkpoints that are aggregated across multiple
partitions. A checkpoint will advance only when all of its constituent
partitions have advanced to some common minimum value.

The hlc.Time type now implements the sql.Scanner and sql.driver.Valuer
interfaces to allow it be used directly with the sql API.

Breaking change: This commit includes an automated schema migration that
requires manual coordination if multiple instances of cdc-sink are used.

* Stop all instances of cdc-sink
* Mark the migration as complete:
```sql
UPSERT INTO _cdc_sink.memo (key, value) VALUES ('version-828','{"state":"applied"}');
```
* Start a single instance of cdc-sink and wait for the automatic migration to occur.
* Start any remaining instances as necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/828)
<!-- Reviewable:end -->
