### PR TITLE
apply: Add knob for per-statement row limit

### DIFF
--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -125,6 +125,9 @@ type targetJS struct {
 	// Two- or three-way merge operator. The bindMerge method will
 	// validate the type of value.
 	Merge goja.Value `goja:"merge"`
+	// For targets without a bulk-transfer mechanism, the maximum number
+	// of rows to send in a single statement.
+	RowLimit int `goja:"rowLimit"`
 }
 
 // Loader is responsible for the first-pass execution of the user

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -264,6 +264,7 @@ func (s *UserScript) bind(loader *Loader) error {
 				tgt.Ignore.Put(ident.New(k), true)
 			}
 		}
+		tgt.RowLimit = bag.RowLimit
 	}
 
 	return nil

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -176,6 +176,7 @@ CREATE TABLE %s.skewed_merge_times(
 			),
 			// SourceName not used; that can be handled by the function.
 			SourceNames: &ident.Map[applycfg.SourceColumn]{},
+			RowLimit:    99,
 		}
 		a.True(expectedApply.Equal(&cfg.Config))
 

--- a/internal/script/testdata/cdc-sink@v1.d.ts
+++ b/internal/script/testdata/cdc-sink@v1.d.ts
@@ -222,6 +222,14 @@ declare module "cdc-sink@v1" {
          * Enables a user-defined, two- or three-way merge function.
          */
         merge: MergeFunction | StandardMerge;
+        /**
+          * This is a tuning parameter which allows the maximum number
+          * of rows in a single UPSERT or DELETE statement to be
+          * limited. This is mainly needed for ultra-wide tables and
+          * databases with a relatively small number of available bind
+          * variables. If unset, a reasonable value will be chosen.
+         */
+        rowLimit: number;
     };
 
     /**

--- a/internal/script/testdata/main.ts
+++ b/internal/script/testdata/main.ts
@@ -102,6 +102,11 @@ api.configureTable("all_features", {
         })
         return {apply: op.target};
     }),
+    // This is a tuning parameter which allows the maximum number of
+    // rows in a single UPSERT or DELETE statement to be limited. This
+    // is mainly needed for ultra-wide tables and databases with a
+    // relatively small number of available bind variables.
+    rowLimit: 99,
 });
 
 // Elide all deletes for the table, e.g.: for archival use cases.

--- a/internal/target/apply/apply.go
+++ b/internal/target/apply/apply.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/cockroachdb/cdc-sink/internal/types"
 	"github.com/cockroachdb/cdc-sink/internal/util/applycfg"
-	"github.com/cockroachdb/cdc-sink/internal/util/batches"
 	"github.com/cockroachdb/cdc-sink/internal/util/ident"
 	"github.com/cockroachdb/cdc-sink/internal/util/merge"
 	"github.com/cockroachdb/cdc-sink/internal/util/metrics"
@@ -158,10 +157,6 @@ func (f *factory) newApply(
 // Apply applies the mutations to the target table.
 func (a *apply) Apply(ctx context.Context, tx types.TargetQuerier, muts []types.Mutation) error {
 	start := time.Now()
-	deletes, r := batches.Mutation()
-	defer r()
-	upserts, r := batches.Mutation()
-	defer r()
 
 	// We want to ensure that we achieve a last-one-wins behavior within
 	// an immediate-mode batch. This does perform unnecessary work
@@ -183,6 +178,22 @@ func (a *apply) Apply(ctx context.Context, tx types.TargetQuerier, muts []types.
 
 	if a.mu.templates.Positions.Len() == 0 {
 		return errors.Errorf("no ColumnData available for %s", a.target)
+	}
+
+	// If the generated SQL doesn't depend on the number of rows being
+	// inserted, we don't need to do any incremental batching.
+	var deletes []types.Mutation
+	if a.mu.templates.BulkDelete {
+		deletes = make([]types.Mutation, 0, len(muts))
+	} else {
+		deletes = make([]types.Mutation, 0, a.mu.templates.RowLimit)
+	}
+
+	var upserts []types.Mutation
+	if a.mu.templates.BulkUpsert {
+		upserts = make([]types.Mutation, 0, len(muts))
+	} else {
+		upserts = make([]types.Mutation, 0, a.mu.templates.RowLimit)
 	}
 
 	// Accumulate mutations and flush incrementally.

--- a/internal/target/apply/column_mapping.go
+++ b/internal/target/apply/column_mapping.go
@@ -49,6 +49,7 @@ type columnMapping struct {
 	PK                   []types.ColData              // The names of the PK columns.
 	PKDelete             []types.ColData              // The names of the PK columns to delete.
 	Renames              *ident.Map[ident.Ident]      // External (source) names to target names.
+	RowLimit             int                          // Limits number of generated bind variables.
 	TableName            *ident.Hinted[ident.Table]   // The target table.
 	UpsertParameterCount int                          // The number of SQL arguments.
 }
@@ -76,7 +77,12 @@ func newColumnMapping(
 		Positions:    &ident.Map[positionalColumn]{},
 		Product:      product,
 		Renames:      &ident.Map[ident.Ident]{},
+		RowLimit:     cfg.RowLimit,
 		TableName:    table,
+	}
+
+	if ret.RowLimit <= 0 {
+		ret.RowLimit = applycfg.DefaultRowLimit
 	}
 
 	// Ensure that merge behavior is enabled only if there's something

--- a/internal/util/applycfg/conf_test.go
+++ b/internal/util/applycfg/conf_test.go
@@ -34,6 +34,7 @@ func TestCopyEquals(t *testing.T) {
 		Deadlines:  ident.MapOf[time.Duration](ident.New("dl"), time.Hour),
 		Exprs:      ident.MapOf[string]("expr", "foo"),
 		Extras:     ident.New("extras"),
+		RowLimit:   42,
 		Ignore:     ident.MapOf[bool]("ign", true),
 		Merger: merge.Func(func(context.Context, *merge.Conflict) (*merge.Resolution, error) {
 			panic("unused")


### PR DESCRIPTION
The pgwire protocol has a limit of 2^15 bind variables per statement. The number of bind variables in our generated SQL is rows*colums, which means that extremely wide tables can run into a practical limit on the number of rows that can be sent in a single statement. Our current default number of rows is 100, which is somewhat conservative for normal-width schemas.

This change adds a new field to apply.Config that controls the number of rows to send for non-bulk targets. It is exposed via the userscript and adjusts the capacity of the buffers used when assembling database payloads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/831)
<!-- Reviewable:end -->
