### PR TITLE
workflow: Build Oracle Database target on old glibc

### DIFF
--- a/.github/workflows/go-binaries.yaml
+++ b/.github/workflows/go-binaries.yaml
@@ -38,7 +38,7 @@ on:
 jobs:
   binaries:
     name: Binaries
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:
       matrix:
         include:
@@ -47,6 +47,7 @@ jobs:
           - os: linux
             arch: amd64
             cgo: 1
+            runner: ubuntu-20.04 # Roll glibc dependency back
             target: oracle
           - os: linux
             arch: arm64


### PR DESCRIPTION
The glibc runtime dependency is set by the version of the toolchain used to compile the binary. This rolls the builder image back to Ubuntu 20.04 to use an older glibc version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/832)
<!-- Reviewable:end -->
