### PR TITLE
stdpool: Set Oracle connections to UTC timezone

### DIFF
--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -91,6 +91,10 @@ func OpenOracleAsTarget(
 	}
 	// Use go's pool, instead of the C library's pool.
 	params.StandaloneConnection = true
+	// If unset, the driver would otherwise use the local system timezone.
+	if params.Timezone == nil {
+		params.Timezone = time.UTC
+	}
 	connector := godror.NewConnector(params)
 
 	ret := &types.TargetPool{


### PR DESCRIPTION
This change ensures that the connections to Oracle Database are UTC-clean, unless otherwise configured by the end user. It prevents timestamp offsets from being applied if the local system timezone is not UTC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/835)
<!-- Reviewable:end -->
