### PR TITLE
sequencer: Adjust default flush period

### DIFF
--- a/internal/sequencer/config.go
+++ b/internal/sequencer/config.go
@@ -24,7 +24,7 @@ import (
 
 // Defaults for flag bindings.
 const (
-	DefaultFlushPeriod     = 1 * time.Millisecond
+	DefaultFlushPeriod     = 1 * time.Second
 	DefaultFlushSize       = 1_000
 	DefaultParallelism     = 16
 	DefaultQuiescentPeriod = 10 * time.Second


### PR DESCRIPTION
The default for the flush period is too aggressive, leading to excessively small target transaction sizes. In general, we expect that the flushSize flag should drive the size of the target transactions. Changing the flush period to one second ensures that target transactions should fill to the target size.

The flush period setting can't be eliminated entirely, however. In high-rate situations where the flush size is very large, the read cursor might take an arbitrarily long time to catch up to the write cursor which would prevent partial progress from being made.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cdc-sink/840)
<!-- Reviewable:end -->
